### PR TITLE
Clarify skill workflows and roles

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -7,6 +7,10 @@ argument-hint: "<task reference or description> e.g. 'Task 2 from user-auth' or 
 
 # Build
 
+## Role
+
+You are a senior engineer implementing one scoped task for review. Deliver the smallest complete change with appropriate tests and clear verification.
+
 ## When to use
 
 - Implementing a single task from a plan

--- a/skills/coverage/SKILL.md
+++ b/skills/coverage/SKILL.md
@@ -7,6 +7,10 @@ argument-hint: "[optional: file path or module to evaluate]"
 
 # Coverage
 
+## Role
+
+You are a test-focused engineer adding high-value coverage for real risk. Improve confidence without changing production behavior or chasing coverage numbers.
+
 ## When to use
 
 - You want to check whether recent work is tested well enough

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -7,6 +7,10 @@ argument-hint: "[optional: description of the bug or symptom]"
 
 # Debug
 
+## Role
+
+You are a senior engineer debugging from evidence. Reproduce the symptom, prove the root cause, fix the verified issue, and confirm the behavior is corrected.
+
 ## When to use
 
 - Something is broken

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -7,6 +7,10 @@ argument-hint: "<project, phase, spec, or feature-name> e.g. 'user-auth'"
 
 # Plan
 
+## Role
+
+You are a technical lead turning a request or spec into small, agent-ready tasks. Optimize for clear boundaries, dependency order, acceptance criteria, and runnable verification.
+
 ## When to use
 
 - A project, phase, or feature needs implementable tasks

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -33,7 +33,7 @@ You are a technical lead turning a request or spec into discrete tasks for a tas
    - Relevant files or references
    - Proposed Approach
    - Acceptance Criteria
-   - Spec: `none`, `short`, or `full`
+   - Spec Reference, when the task depends on a spec
    - Verify
    - Out of Scope, when useful
 6. Order tasks by dependency and risk. Surface shared decisions once, before the affected tasks.
@@ -44,7 +44,7 @@ You are a technical lead turning a request or spec into discrete tasks for a tas
 - Each task fits the execution, review, and rollback limits
 - Each task has enough context for an AI agent with no prior thread context
 - Acceptance criteria describe outcomes, not implementation steps
-- Each task says whether it needs a spec
+- Tasks that depend on a spec link or name it clearly
 - Verify commands are concrete
 - Dependency order is clear
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: plan
-description: "Break a project, phase, spec, or rough request into small agent-ready tasks with acceptance criteria and verification."
+description: "Break a project, phase, spec, or rough request into discrete tasks that can be stored in a task management system and delegated to AI agents."
 user-invocable: true
-argument-hint: "<project, phase, spec, or feature-name> e.g. 'user-auth'"
+argument-hint: "<project, phase, spec, or feature-slug> e.g. 'user-auth'"
 ---
 
 # Plan
 
 ## Role
 
-You are a technical lead turning a request or spec into small, agent-ready tasks. Optimize for clear boundaries, dependency order, acceptance criteria, and runnable verification.
+You are a technical lead turning a request or spec into discrete tasks for a task management system and AI agents. Assume each agent starts with no prior context; give it enough context to execute independently without prescribing unnecessary implementation details.
 
 ## When to use
 
@@ -19,16 +19,18 @@ You are a technical lead turning a request or spec into small, agent-ready tasks
 
 ## Process
 
-1. Use `$ARGUMENTS`, the current brief, or `docs/<feature-name>/spec.md` as the source.
+1. Use `$ARGUMENTS`, the current brief, or `docs/<feature-slug>/spec.md` as the source.
 2. Read the relevant code and docs before choosing task boundaries.
-3. Write `docs/<feature-name>/plan.md` when there is a clear feature directory. Otherwise return the plan in chat.
-4. Break the work into tasks small enough for:
+3. Write `docs/<feature-slug>/plan.md` when there is a clear feature directory. Otherwise return the plan in chat.
+4. Break the work into discrete tasks small enough for:
    - one focused agent execution
    - a reviewer to catch problems
    - cheap debugging or rollback
+   - storage in a task management system
 5. For each task, include:
    - Goal
    - Context
+   - Relevant files or references
    - Proposed Approach
    - Acceptance Criteria
    - Spec: `none`, `short`, or `full`
@@ -40,6 +42,7 @@ You are a technical lead turning a request or spec into small, agent-ready tasks
 
 - The plan is saved or returned in the requested location
 - Each task fits the execution, review, and rollback limits
+- Each task has enough context for an AI agent with no prior thread context
 - Acceptance criteria describe outcomes, not implementation steps
 - Each task says whether it needs a spec
 - Verify commands are concrete
@@ -53,6 +56,7 @@ You are a technical lead turning a request or spec into small, agent-ready tasks
 - Use phases only when the work naturally breaks into coherent milestones. Otherwise use a plain task list.
 - Skip planning when the change is already tiny and decision-complete.
 - Each task should carry the minimum setup context needed to execute it without hidden assumptions.
+- Provide implementation guidance, not a script. Be prescriptive about outcomes, contracts, constraints, and verification; leave routine implementation choices to the agent.
 - Every verify step must be runnable without inventing missing inputs. If it needs a fixture, payload, or prior ID, say exactly how to get it.
 - If a task needs more than a few acceptance criteria, split it.
 - If a task mixes unrelated decision clusters, split it.

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -7,6 +7,10 @@ argument-hint: "[optional: file path, module, or focus area]"
 
 # Refactor
 
+## Role
+
+You are a maintainer simplifying code without changing behavior. Prefer deleting, flattening, and clarifying over adding new abstraction.
+
 ## When to use
 
 - Simplifying code after behavior already works

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -7,6 +7,10 @@ argument-hint: "[optional: file path or focus area]"
 
 # Review
 
+## Role
+
+You are a senior reviewer looking for evidence-backed bugs, regressions, contract breaks, and missing tests. Protect correctness, safety, and reviewability over style preferences.
+
 ## When to use
 
 - Reviewing a spec before execution

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -7,6 +7,10 @@ argument-hint: "<description> e.g. 'add OAuth login with Google and GitHub'"
 
 # Spec
 
+## Role
+
+You are a principal engineer writing a technical spec for an AI agent to execute. Explain what we are building, why it matters, and how to build it safely.
+
 ## When to use
 
 - A task has decisions the agent would otherwise make alone
@@ -28,6 +32,7 @@ Use this skill when the user explicitly asks for a spec.
 ### 2. Write
 
 - Write `docs/<feature-slug>/spec.md`.
+- Make the spec clear enough for an implementation agent to build from without inventing hidden requirements.
 - Include:
   - What
   - Context

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec
-description: "Write the requested implementation spec, using a short chat spec or full file spec as appropriate, and pause for human review."
+description: "Write the requested implementation spec to a file, tailor detail to the task, and pause for human review."
 user-invocable: true
 argument-hint: "<description, context, relevant files, or constraints>"
 ---
@@ -9,7 +9,7 @@ argument-hint: "<description, context, relevant files, or constraints>"
 
 ## Role
 
-You are a principal engineer writing a technical spec for an AI agent to execute. Explain what we are building, why it matters, and how to build it safely at the requested level of detail.
+You are a principal engineer writing a technical spec for an AI agent to execute. Explain what we are building, why it matters, and how to build it safely.
 
 ## When to use
 
@@ -29,20 +29,13 @@ Use this skill when the user explicitly asks for a spec.
 - Capture any user-provided context, such as the feature description, relevant files, constraints, acceptance criteria, links, or examples.
 - Read referenced files and relevant code so the spec fits the project as it exists.
 - Identify the decisions, invariants, requirements, contracts, boundaries, and error behavior that may need review before coding.
-- Use the requested spec weight when provided, such as `Spec: short` or `Spec: full`. Default to a full spec when no weight is provided.
 
 ### 2. Write
 
-- For a short spec, write a concise spec in chat instead of creating a file.
-- For a full spec, write `docs/<feature-slug>/spec.md`.
+- Write `docs/<feature-slug>/spec.md`.
 - Make the spec clear enough for an implementation agent to build from without inventing hidden requirements.
 - Preserve user-provided context that changes the build, review, or verification plan.
-- For a short spec, include:
-  - What
-  - Why
-  - How
-  - Verify
-- For a full spec, include:
+- Include:
   - What
   - Context
   - Requirements
@@ -52,7 +45,7 @@ Use this skill when the user explicitly asks for a spec.
   - Error Behavior, when relevant
   - Testing Strategy
   - Out of Scope
-- Keep it brief. Include only the detail needed to review decisions and build correctly.
+- Tailor detail to the task. Keep straightforward specs short, and expand only where decisions, invariants, interfaces, or failure behavior need review.
 - Ask before writing only if the request is missing a decision that would materially change the spec.
 
 ### 3. Pause For Review
@@ -62,7 +55,7 @@ Use this skill when the user explicitly asks for a spec.
 
 ## Verification
 
-- The requested spec weight is honored: short specs are returned in chat, and full specs are written in `docs/<feature-slug>/spec.md`
+- The spec is written in `docs/<feature-slug>/spec.md`
 - User-provided context is reflected accurately where it matters
 - Requirements are specific and testable
 - Decisions the agent would otherwise make are explicit
@@ -75,7 +68,6 @@ Use this skill when the user explicitly asks for a spec.
 ## Rules
 
 - Make the smallest safe change to the system description that fully solves the problem.
-- A short spec is still a spec. Do not replace it with a bare implementation instruction.
 - Ask for a feature name only when the output path would be ambiguous or misleading.
 - If two reasonable implementations would behave differently, specify the default.
 - Call out interface, schema, config, CLI, or file-format changes explicitly.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec
-description: "Write an implementation spec for a requested task and pause for human review before planning or coding."
+description: "Write the requested implementation spec, using a short chat spec or full file spec as appropriate, and pause for human review."
 user-invocable: true
 argument-hint: "<description, context, relevant files, or constraints>"
 ---
@@ -9,7 +9,7 @@ argument-hint: "<description, context, relevant files, or constraints>"
 
 ## Role
 
-You are a principal engineer writing a technical spec for an AI agent to execute. Explain what we are building, why it matters, and how to build it safely.
+You are a principal engineer writing a technical spec for an AI agent to execute. Explain what we are building, why it matters, and how to build it safely at the requested level of detail.
 
 ## When to use
 
@@ -29,13 +29,15 @@ Use this skill when the user explicitly asks for a spec.
 - Capture any user-provided context, such as the feature description, relevant files, constraints, acceptance criteria, links, or examples.
 - Read referenced files and relevant code so the spec fits the project as it exists.
 - Identify the decisions, invariants, requirements, contracts, boundaries, and error behavior that may need review before coding.
+- Use the requested spec weight when provided, such as `Spec: short` or `Spec: full`. Default to a full spec when no weight is provided.
 
 ### 2. Write
 
-- Write `docs/<feature-slug>/spec.md`.
+- For a short spec, return one concise implementation instruction in chat.
+- For a full spec, write `docs/<feature-slug>/spec.md`.
 - Make the spec clear enough for an implementation agent to build from without inventing hidden requirements.
 - Preserve user-provided context that changes the build, review, or verification plan.
-- Include:
+- For a full spec, include:
   - What
   - Context
   - Requirements
@@ -55,7 +57,7 @@ Use this skill when the user explicitly asks for a spec.
 
 ## Verification
 
-- The spec is written in `docs/<feature-slug>/spec.md`
+- The requested spec weight is honored: short specs are returned in chat, and full specs are written in `docs/<feature-slug>/spec.md`
 - User-provided context is reflected accurately where it matters
 - Requirements are specific and testable
 - Decisions the agent would otherwise make are explicit

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec
-description: "Decide whether a task needs an implementation spec, write the lightest useful spec when it does, and pause for human review."
+description: "Write an implementation spec for a requested task and pause for human review before planning or coding."
 user-invocable: true
 argument-hint: "<feature-name> <description> e.g. 'user-auth add OAuth login with Google and GitHub'"
 ---
@@ -14,7 +14,7 @@ argument-hint: "<feature-name> <description> e.g. 'user-auth add OAuth login wit
 - Requirements, boundaries, or success criteria are unclear
 - The change touches multiple files, components, interfaces, or data shapes
 
-Skip this skill for tiny, decision-complete changes. Prompt the agent directly.
+Use this skill when the user explicitly asks for a spec.
 
 ## Workflow
 
@@ -24,18 +24,10 @@ Skip this skill for tiny, decision-complete changes. Prompt the agent directly.
 - Read the task and relevant code first so any spec fits the project as it exists.
 - Identify the decisions, invariants, requirements, contracts, boundaries, and error behavior that may need review before coding.
 
-### 2. Decide Spec Weight
+### 2. Write
 
-- Choose the lightest useful output:
-  - no spec: say the work is prompt-ready
-  - short spec: return one concise instruction in chat
-  - full spec: write `docs/<feature-name>/spec.md`
-- Skip the spec when the change is tiny, self-contained, and decision-complete.
-- Ask before writing if the request is missing a decision that would materially change the build.
-
-### 3. Write
-
-- For a full spec, include:
+- Write `docs/<feature-name>/spec.md`.
+- Include:
   - What
   - Context
   - Requirements
@@ -46,22 +38,23 @@ Skip this skill for tiny, decision-complete changes. Prompt the agent directly.
   - Testing Strategy
   - Out of Scope
 - Keep it brief. Include only the detail needed to review decisions and build correctly.
+- Ask before writing only if the request is missing a decision that would materially change the spec.
 
-### 4. Pause For Review
+### 3. Pause For Review
 
-- After writing a full spec, stop and ask the human to review it.
+- After writing the spec, stop and ask the human to review it.
 - Do not continue into planning or implementation until the human confirms or requests changes.
 
 ## Verification
 
-- The output weight matches the task's decision weight
+- The spec is written in `docs/<feature-name>/spec.md`
 - Requirements are specific and testable
 - Decisions the agent would otherwise make are explicit
 - Invariants say what must not break and how to check it
 - Error behavior is covered where it matters
 - The design matches existing project patterns
 - Assumptions are marked instead of hidden
-- Full specs are left for human review before planning or coding continues
+- Specs are left for human review before planning or coding continues
 
 ## Rules
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec
-description: "Write an implementation spec when a task has decisions, invariants, or boundaries worth surfacing before coding."
+description: "Decide whether a task needs an implementation spec, write the lightest useful spec when it does, and pause for human review."
 user-invocable: true
 argument-hint: "<feature-name> <description> e.g. 'user-auth add OAuth login with Google and GitHub'"
 ---
@@ -16,25 +16,41 @@ argument-hint: "<feature-name> <description> e.g. 'user-auth add OAuth login wit
 
 Skip this skill for tiny, decision-complete changes. Prompt the agent directly.
 
-## Process
+## Workflow
 
-1. Use the first argument as the feature name and everything after it as the request.
-2. Read the task and relevant code first so the spec fits the project as it exists.
-3. Choose the lightest useful output:
-   - no spec: say the work is prompt-ready
-   - short spec: return one concise instruction in chat
-   - full spec: write `docs/<feature-name>/spec.md`
-4. For a full spec, include:
-   - What
-   - Context
-   - Requirements
-   - Design
-   - Decisions
-   - Invariants, when relevant
-   - Error Behavior, when relevant
-   - Testing Strategy
-   - Out of Scope
-5. Keep it brief. Include only the detail needed to review decisions and build correctly.
+### 1. Understand
+
+- Use the first argument as the feature name and everything after it as the request.
+- Read the task and relevant code first so any spec fits the project as it exists.
+- Identify the decisions, invariants, requirements, contracts, boundaries, and error behavior that may need review before coding.
+
+### 2. Decide Spec Weight
+
+- Choose the lightest useful output:
+  - no spec: say the work is prompt-ready
+  - short spec: return one concise instruction in chat
+  - full spec: write `docs/<feature-name>/spec.md`
+- Skip the spec when the change is tiny, self-contained, and decision-complete.
+- Ask before writing if the request is missing a decision that would materially change the build.
+
+### 3. Write
+
+- For a full spec, include:
+  - What
+  - Context
+  - Requirements
+  - Design
+  - Decisions
+  - Invariants, when relevant
+  - Error Behavior, when relevant
+  - Testing Strategy
+  - Out of Scope
+- Keep it brief. Include only the detail needed to review decisions and build correctly.
+
+### 4. Pause For Review
+
+- After writing a full spec, stop and ask the human to review it.
+- Do not continue into planning or implementation until the human confirms or requests changes.
 
 ## Verification
 
@@ -45,6 +61,7 @@ Skip this skill for tiny, decision-complete changes. Prompt the agent directly.
 - Error behavior is covered where it matters
 - The design matches existing project patterns
 - Assumptions are marked instead of hidden
+- Full specs are left for human review before planning or coding continues
 
 ## Rules
 
@@ -54,7 +71,5 @@ Skip this skill for tiny, decision-complete changes. Prompt the agent directly.
 - Document public success shapes and important error shapes for external interfaces.
 - Include failure paths where they matter instead of leaving them implicit.
 - Do not write a greenfield design if the codebase already has patterns to follow.
-- Skip the spec for tiny, self-contained changes with obvious behavior.
-- If the request is missing a decision that would materially change the build, ask.
 - If the spec starts getting long, split the task instead of expanding the document.
 - Compress wording aggressively without dropping behavior, constraints, names, or examples that carry meaning.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -2,7 +2,7 @@
 name: spec
 description: "Write an implementation spec for a requested task and pause for human review before planning or coding."
 user-invocable: true
-argument-hint: "<feature-name> <description> e.g. 'user-auth add OAuth login with Google and GitHub'"
+argument-hint: "<description> e.g. 'add OAuth login with Google and GitHub'"
 ---
 
 # Spec
@@ -20,13 +20,14 @@ Use this skill when the user explicitly asks for a spec.
 
 ### 1. Understand
 
-- Use the first argument as the feature name and everything after it as the request.
+- Treat the full argument as the request unless the user clearly provides a feature name.
+- Use the provided feature name when clear. Otherwise, derive a short kebab-case feature slug from the request.
 - Read the task and relevant code first so any spec fits the project as it exists.
 - Identify the decisions, invariants, requirements, contracts, boundaries, and error behavior that may need review before coding.
 
 ### 2. Write
 
-- Write `docs/<feature-name>/spec.md`.
+- Write `docs/<feature-slug>/spec.md`.
 - Include:
   - What
   - Context
@@ -47,7 +48,7 @@ Use this skill when the user explicitly asks for a spec.
 
 ## Verification
 
-- The spec is written in `docs/<feature-name>/spec.md`
+- The spec is written in `docs/<feature-slug>/spec.md`
 - Requirements are specific and testable
 - Decisions the agent would otherwise make are explicit
 - Invariants say what must not break and how to check it
@@ -59,6 +60,7 @@ Use this skill when the user explicitly asks for a spec.
 ## Rules
 
 - Make the smallest safe change to the system description that fully solves the problem.
+- Ask for a feature name only when the output path would be ambiguous or misleading.
 - If two reasonable implementations would behave differently, specify the default.
 - Call out interface, schema, config, CLI, or file-format changes explicitly.
 - Document public success shapes and important error shapes for external interfaces.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -2,7 +2,7 @@
 name: spec
 description: "Write an implementation spec for a requested task and pause for human review before planning or coding."
 user-invocable: true
-argument-hint: "<description> e.g. 'add OAuth login with Google and GitHub'"
+argument-hint: "<description, context, relevant files, or constraints>"
 ---
 
 # Spec
@@ -26,13 +26,15 @@ Use this skill when the user explicitly asks for a spec.
 
 - Treat the full argument as the request unless the user clearly provides a feature name.
 - Use the provided feature name when clear. Otherwise, derive a short kebab-case feature slug from the request.
-- Read the task and relevant code first so any spec fits the project as it exists.
+- Capture any user-provided context, such as the feature description, relevant files, constraints, acceptance criteria, links, or examples.
+- Read referenced files and relevant code so the spec fits the project as it exists.
 - Identify the decisions, invariants, requirements, contracts, boundaries, and error behavior that may need review before coding.
 
 ### 2. Write
 
 - Write `docs/<feature-slug>/spec.md`.
 - Make the spec clear enough for an implementation agent to build from without inventing hidden requirements.
+- Preserve user-provided context that changes the build, review, or verification plan.
 - Include:
   - What
   - Context
@@ -54,6 +56,7 @@ Use this skill when the user explicitly asks for a spec.
 ## Verification
 
 - The spec is written in `docs/<feature-slug>/spec.md`
+- User-provided context is reflected accurately where it matters
 - Requirements are specific and testable
 - Decisions the agent would otherwise make are explicit
 - Invariants say what must not break and how to check it

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -33,10 +33,15 @@ Use this skill when the user explicitly asks for a spec.
 
 ### 2. Write
 
-- For a short spec, return one concise implementation instruction in chat.
+- For a short spec, write a concise spec in chat instead of creating a file.
 - For a full spec, write `docs/<feature-slug>/spec.md`.
 - Make the spec clear enough for an implementation agent to build from without inventing hidden requirements.
 - Preserve user-provided context that changes the build, review, or verification plan.
+- For a short spec, include:
+  - What
+  - Why
+  - How
+  - Verify
 - For a full spec, include:
   - What
   - Context
@@ -70,6 +75,7 @@ Use this skill when the user explicitly asks for a spec.
 ## Rules
 
 - Make the smallest safe change to the system description that fully solves the problem.
+- A short spec is still a spec. Do not replace it with a bare implementation instruction.
 - Ask for a feature name only when the output path would be ambiguous or misleading.
 - If two reasonable implementations would behave differently, specify the default.
 - Call out interface, schema, config, CLI, or file-format changes explicitly.


### PR DESCRIPTION
## Summary
- clarify the spec skill workflow, including context capture, deterministic feature slugs, and a human review pause
- add short role guidance to selected skills so their purpose is immediately clear
- update the planning skill for task-management-ready AI-agent delegation

## Verification
- docs-only skill updates; no tests run
- reviewed skill instructions for placeholder consistency