### PR TITLE
[codex] Make browser verification tooling portable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,5 +6,5 @@ Blueprint installs as standalone skills via `npx skills add owainlewis/blueprint
 
 - Invoke skills by name: `bootstrap-project`, `design-doc`, `spec`, `plan`, `implement`, `tdd`, `debug`, `refactor`, `review`, `task-to-pr`, `multitask`, `pr`, `pr-to-ready`, `browser-verify`, `branch`, `commit`.
 - Agent definitions live in `agents/`. Copy them to `.claude/agents/` (project) or `~/.claude/agents/` (user) to make them spawnable; `npx skills add` installs skills only.
-- `browser-verify` requires Chrome DevTools MCP.
+- `browser-verify` requires an available real-browser automation and inspection path, such as Chrome DevTools MCP.
 - Keep shared repo guidance in `AGENTS.md`; keep Claude-specific adapter notes here.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ npx skills add owainlewis/blueprint
 
 Install Blueprint with the `skills` CLI. This is the supported setup path; Blueprint does not maintain per-tool skill installation guides.
 
-`browser-verify` requires Chrome DevTools MCP:
+`browser-verify` requires an available real-browser automation and inspection path.
+Chrome DevTools MCP is one supported setup:
 
 ```bash
 claude mcp add chrome-devtools --scope user npx chrome-devtools-mcp@latest

--- a/skills/browser-verify/SKILL.md
+++ b/skills/browser-verify/SKILL.md
@@ -13,9 +13,10 @@ You verify what the browser actually renders. Static code review is not enough f
 
 ### 1. Open
 
-Open the target in a real browser using Chrome DevTools MCP.
+Open the target with an available real-browser verification path.
+Use Chrome DevTools MCP, Playwright, in-app browser tooling, or another browser automation and inspection capability.
 
-If Chrome DevTools MCP is unavailable, stop and tell the user browser verification cannot run until it is installed.
+If no real-browser verification path is available, stop and tell the user browser verification cannot run until one is available.
 
 ### 2. Inspect
 


### PR DESCRIPTION
## Summary

- Updates `browser-verify` to use any available real-browser automation and inspection path, including Chrome DevTools MCP, Playwright, in-app browser tooling, or equivalent browser automation.
- Changes the stop condition so the skill blocks only when no real-browser verification path is available.
- Softens README and CLAUDE references so Chrome DevTools MCP is documented as one supported setup, not the only route.

## Verification

- Read back `skills/browser-verify/SKILL.md`, `README.md`, and `CLAUDE.md` after editing.
- Ran `rg` to confirm hard-coded Chrome DevTools MCP blocking language was removed or softened.
- Ran `git diff --check`.
- No existing lightweight project test runner was present for this docs-only change.

## Notes

This came from the skill review feedback that `browser-verify` was too tool-specific for a portable skill library.