### PR TITLE
[codex] Clarify skill boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Working in Blueprint
 
-Blueprint encodes world-class software engineering and agentic engineering practice: design when architecture is ambiguous, spec when decisions matter, plan when work needs splitting, test before ship, refactor when code needs simplifying, review before merge, drive PR feedback to merge-ready with judgment.
+Blueprint encodes world-class software engineering and agentic engineering practice: design when architecture is ambiguous, spec when implementation contracts or invariants matter, plan when work needs splitting, test before ship, refactor when code needs simplifying, review before merge, drive PR feedback to merge-ready with judgment.
 
 If you are an AI agent working in this repo, follow this guidance.
 
@@ -10,7 +10,7 @@ Blueprint has three flows. The handoff between them is a project skeleton, spec,
 
 **Setup** (`bootstrap-project`): turn a new or empty repo into a clean starting point with README, license, `.gitignore`, `AGENTS.md`, docs, optional tracker setup, and an initial commit. Interview the repo creator when product, license, remote, or tracker decisions are unclear.
 
-**Decide** (`design-doc` -> `spec` -> `plan`): turn ambiguity into reviewed decisions and agent-sized tasks. Every stage pauses for human review. Start at `design-doc` when the architecture is ambiguous, at `spec` when decisions, contracts, or invariants need review, at `plan` when the work just needs splitting. Skip stages when the change is trivial and decision-complete.
+**Decide** (`design-doc` -> `spec` -> `plan`): turn ambiguity into reviewed decisions and agent-sized tasks. Every stage pauses for human review. Start at `design-doc` when architecture, alternatives, or tradeoffs are ambiguous. Use `spec` when implementation requirements, contracts, invariants, or error behavior need review. Use `plan` when the work just needs splitting. Skip stages when the change is trivial and decision-complete.
 
 **Deliver** (`task-to-pr`): turn one task into a draft PR with the ticket as the audit trail. `task-to-pr` runs workspace preparation -> `implement` -> review subagent -> acceptance-verification subagent -> `pr`, preferring worktrees when isolation reduces risk. Use `multitask` to run several independent tickets in parallel, one isolated worker per ticket. Use `pr-to-ready` once feedback exists to drive the PR to merge-ready; merging is always a human decision. Use `implement` alone when the workspace is prepared and no PR is expected, `tdd` when a failing test can describe the behavior first, `refactor` to tidy the changed code before review, and `debug` when something breaks.
 
@@ -21,8 +21,8 @@ Exploration is allowed without creating docs or issue tracker entries. Do not ma
 Decide:
 
 - `bootstrap-project`: bootstrap a new or empty repository with clean docs, license, agent guidance, optional tracker setup, and an initial commit.
-- `design-doc`: write a lightweight architecture design doc when the design is ambiguous.
-- `spec`: write the technical design before coding.
+- `design-doc`: write a lightweight architecture design doc when architecture or tradeoffs are ambiguous.
+- `spec`: write implementation requirements, contracts, invariants, and error behavior before coding.
 - `plan`: break a spec, brief, or request into agent-sized tasks.
 - `goal-skill`: turn rough long-running work into a paste-ready Codex `/goal` with verifier evidence and blocked conditions.
 
@@ -35,7 +35,7 @@ Deliver:
 - `tdd`: test-first variant of implement.
 - `debug`: find the root cause of a failure, then fix it with a regression test first when practical.
 - `refactor`: simplify changed code without changing behavior.
-- `review`: pre-merge review for correctness, security, simplicity, robustness, and tests.
+- `review`: pre-merge code review for correctness, security, simplicity, robustness, and tests.
 - `pr`: commit, push, and open a PR with a clear description.
 - `commit`: stage intended changes and write one clear Conventional Commit.
 - `pr-to-ready`: drive an open PR with feedback to merge-ready; never merges.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Coding agents don't fail for lack of intelligence. They fail for lack of process: no spec, no plan, no tests, no review, just a confident 2,000-line PR nobody asked for. Blueprint fixes the process and trusts the intelligence.
 
-It encodes how the best engineering teams have always shipped: bootstrap cleanly, design when architecture is ambiguous, spec when decisions matter, plan when work needs splitting, test before ship, review before merge. Sixteen dense skills you can run as single steps you drive yourself, or as loops that take whole tickets to draft PRs while you sleep.
+It encodes how the best engineering teams have always shipped: bootstrap cleanly, design when architecture is ambiguous, spec when implementation contracts or invariants matter, plan when work needs splitting, test before ship, review before merge. Sixteen dense skills you can run as single steps you drive yourself, or as loops that take whole tickets to draft PRs while you sleep.
 
 Blueprint is the deliberate opposite of bloated, over-engineered skill libraries like Superpowers and GSD. No ceremony, no guardrail mazes, no thousand-line process files burning your context window before any work starts. Simplicity is clarity: a skill short enough to hold in your head is a skill an agent actually follows. And Blueprint bets on the model. Heavy frameworks assume the model is weak and wrap it in rules; Blueprint assumes the model is strong and hands it the judgment of a great senior engineer, written down. Every model release makes that bet pay off more, and the guardrails more wrong.
 
@@ -22,13 +22,13 @@ Blueprint is the deliberate opposite of bloated, over-engineered skill libraries
 | ------------ | -------------------------- | ----------------------------------------------------------------------------- |
 | **Setup**    | `bootstrap-project`        | Start a repo with clean docs, agent guidance, tracker setup, and first commit |
 | **Design**   | `design-doc`               | Explore architecture, alternatives, and tradeoffs                             |
-| **Define**   | `spec`                     | One document with requirements and design                                     |
+| **Define**   | `spec`                     | Requirements, contracts, invariants, and implementation design                |
 | **Plan**     | `plan`                     | Break work into agent-sized tasks                                             |
 | **Goal**     | `goal-skill`               | Turn long-running work into a paste-ready Codex `/goal`                       |
 | **Build**    | `implement` / `tdd`        | Execute one task; tests prove acceptance                                      |
 | **Debug**    | `debug`                    | Reproduce a failure, fix it test-first when practical, and keep the guard     |
 | **Improve**  | `refactor`                 | Simplify changed code without changing behavior                               |
-| **Review**   | `review`                   | Correctness, security, simplicity before merge                                |
+| **Review**   | `review`                   | Code-change correctness, security, simplicity before merge                    |
 | **Deliver**  | `task-to-pr` / `multitask` | Turn one ticket, or several tickets in parallel, into draft PRs               |
 | **Feedback** | `pr-to-ready`              | Drive an open PR with feedback to merge-ready                                 |
 | **Browser**  | `browser-verify`           | Check rendered UI, HTML, and visual docs in a real browser                    |
@@ -42,8 +42,8 @@ flowchart TD
 
     Ambiguous{Architecture<br/>ambiguous?}
     Design["design-doc<br/>options + tradeoffs<br/>chosen direction"]
-    SpecGate{Decisions,<br/>contracts,<br/>or invariants?}
-    Spec["spec<br/>requirements + design<br/>human review"]
+    SpecGate{Contracts,<br/>invariants,<br/>or error behavior?}
+    Spec["spec<br/>requirements + implementation design<br/>human review"]
     Split{Needs<br/>splitting?}
     Plan["plan<br/>agent-sized tasks<br/>acceptance criteria"]
     Direct["one scoped task<br/>acceptance criteria"]
@@ -193,8 +193,8 @@ The supported install path is `npx skills add owainlewis/blueprint`. That instal
 | Skill               | Purpose                                                                                           |
 | ------------------- | ------------------------------------------------------------------------------------------------- |
 | `bootstrap-project` | Bootstrap a new repo with docs, license, agent guidance, tracker setup, and optional first commit |
-| `design-doc`        | Write a lightweight architecture design doc                                                       |
-| `spec`              | Write a spec                                                                                      |
+| `design-doc`        | Decide architecture, alternatives, and tradeoffs                                                   |
+| `spec`              | Specify implementation requirements, contracts, and invariants                                     |
 | `plan`              | Break input into reviewable tasks                                                                 |
 | `goal-skill`        | Create a paste-ready Codex `/goal` with verifier evidence and blocked stop conditions             |
 | `implement`         | Execute a single task                                                                             |
@@ -244,14 +244,14 @@ Run this to update Blueprint and your installed skills to the latest version.
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `bootstrap-project` | Starts a new or empty repo with README, license, `.gitignore`, `AGENTS.md`, docs, optional tracker setup, and an initial commit                         | `Bootstrap this repo for a new macOS editor project` |
 | `design-doc`        | Writes `docs/<design-slug>/design.md`: architecture, alternatives, tradeoffs, and cross-cutting concerns                                                | `Write a design doc for multi-tenant auth`           |
-| `spec`              | Writes `docs/<feature-slug>/spec.md`: requirements and design in one document                                                                           | `Write a spec for user-auth`                         |
+| `spec`              | Writes `docs/<feature-slug>/spec.md`: requirements, contracts, invariants, and implementation design                                                     | `Write a spec for user-auth`                         |
 | `plan`              | Breaks a spec, brief, or request into tasks sized for agents, review, and rollback                                                                      | `Create a plan for user-auth`                        |
 | `goal-skill`        | Creates paste-ready Codex `/goal` prompts with verifier evidence, constraints, boundaries, iteration policy, and blocked conditions                     | `Create a Codex goal for this deployment plan`       |
 | `implement`         | Executes one scoped change with tests and verification                                                                                                  | `Implement LIN-123 from user-auth`                   |
 | `tdd`               | Implements behavior test-first                                                                                                                          | `Use TDD for retry logic in the API client`          |
 | `debug`             | Finds the root cause of a failure, fixes it test-first when practical, and leaves a regression test                                                     | `Debug the failing retry test`                       |
 | `refactor`          | Improves code shape without changing behavior                                                                                                           | `Refactor the current diff`                          |
-| `review`            | Reviews specs or code for correctness, security, simplicity, robustness, and tests                                                                      | `Review the current diff`                            |
+| `review`            | Reviews code changes for correctness, security, simplicity, robustness, and tests                                                                       | `Review the current diff`                            |
 | `task-to-pr`        | Runs the loop from ticket to draft PR: fetch the ticket, implement, test, fresh-subagent review, verify acceptance, open the PR, and keep the ticket updated with evidence | `task-to-pr LIN-123` |
 | `multitask`         | Coordinates several tickets to draft PRs at once: classify dependencies, isolate worker lanes, run `task-to-pr` per ticket, and report the fleet        | `multitask LIN-101 LIN-102 LIN-103`                  |
 | `pr`                | Commits intended changes, pushes the branch, and opens a clear draft PR                                                                                 | `Open a draft PR for this change`                    |

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: spec
-description: "Write an implementation spec to docs/<feature-slug>/spec.md and pause for human review. Use when the user says \"write a spec\", \"spec this out\", \"technical design\", \"design doc\", or when a task has decisions, invariants, or contracts that should be reviewed before code is written."
+description: "Write an implementation spec to docs/<feature-slug>/spec.md and pause for human review. Use when the user says \"write a spec\" or \"spec this out\", or when implementation requirements, contracts, invariants, interfaces, or error behavior need review before coding. Use design-doc instead for architecture ambiguity, alternatives, or tradeoffs."
 user-invocable: true
 argument-hint: "<feature description, context, or constraints>"
 ---
 
 # Spec
 
-You are a principal engineer writing a technical spec for an AI agent to execute. Cover what we are building, why it matters, and how to build it safely. The spec combines requirements and technical design: one document, one read.
+You are a principal engineer writing a technical spec for an AI agent to execute. Cover what we are building, why it matters, and how to build it safely. The spec combines requirements and implementation design: one document, one read. If the main work is choosing architecture, alternatives, or tradeoffs, use `design-doc` first.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Clarifies that `task-to-pr` includes fresh acceptance verification before opening a draft PR.
- Describes `review` as code-change review, matching the review skill contract.
- Tightens the `design-doc` / `spec` / `plan` boundary in README, AGENTS, and the spec skill frontmatter.

## Verification

- Read the touched files after editing: `README.md`, `AGENTS.md`, `skills/spec/SKILL.md`.
- Ran `rg` for the old conflicting phrases and got no matches.
- Ran `rg` for the new boundary phrases to confirm the expected wording is present.
- Ran `git diff --check`.
- Looked for existing lightweight project checks with `rg --files -g 'package.json' -g 'Makefile' -g 'justfile' -g 'pyproject.toml' -g 'Cargo.toml' -g '.github/workflows/*'`; none were present.

## Context

This task came from the complete skill review.