### PR TITLE
[codex] Trim bootstrap project skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ If you are an AI agent working in this repo, follow this guidance.
 
 Blueprint has three flows. The handoff between them is a project skeleton, spec, or task with acceptance criteria.
 
-**Setup** (`bootstrap-project`): turn a new or empty repo into a clean starting point with README, license, `.gitignore`, `AGENTS.md`, docs, optional tracker setup, and an initial commit. Interview the repo creator when product, license, remote, or tracker decisions are unclear.
+**Setup** (`bootstrap-project`): turn a new or empty repo into a clean local starting point with README, license, `.gitignore`, `AGENTS.md`, and docs. Interview the repo creator only when file-changing decisions are unclear; commit or push only when explicitly asked.
 
 **Decide** (`design-doc` -> `spec` -> `plan`): turn ambiguity into reviewed decisions and agent-sized tasks. Every stage pauses for human review. Start at `design-doc` when architecture, alternatives, or tradeoffs are ambiguous. Use `spec` when implementation requirements, contracts, invariants, or error behavior need review. Use `plan` when the work just needs splitting. Skip stages when the change is trivial and decision-complete.
 
@@ -20,7 +20,7 @@ Exploration is allowed without creating docs or issue tracker entries. Do not ma
 
 Decide:
 
-- `bootstrap-project`: bootstrap a new or empty repository with clean docs, license, agent guidance, optional tracker setup, and an initial commit.
+- `bootstrap-project`: bootstrap a new or empty repository with clean docs, license, and agent guidance.
 - `design-doc`: write a lightweight architecture design doc when architecture or tradeoffs are ambiguous.
 - `spec`: write implementation requirements, contracts, invariants, and error behavior before coding.
 - `plan`: break a spec, brief, or request into agent-sized tasks.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Blueprint is the deliberate opposite of bloated, over-engineered skill libraries
 
 | Phase        | Skill                      | What it does                                                                  |
 | ------------ | -------------------------- | ----------------------------------------------------------------------------- |
-| **Setup**    | `bootstrap-project`        | Start a repo with clean docs, agent guidance, tracker setup, and first commit |
+| **Setup**    | `bootstrap-project`        | Start a repo with clean local docs and agent guidance                         |
 | **Design**   | `design-doc`               | Explore architecture, alternatives, and tradeoffs                             |
 | **Define**   | `spec`                     | Requirements, contracts, invariants, and implementation design                |
 | **Plan**     | `plan`                     | Break work into agent-sized tasks                                             |
@@ -192,7 +192,7 @@ The supported install path is `npx skills add owainlewis/blueprint`. That instal
 
 | Skill               | Purpose                                                                                           |
 | ------------------- | ------------------------------------------------------------------------------------------------- |
-| `bootstrap-project` | Bootstrap a new repo with docs, license, agent guidance, tracker setup, and optional first commit |
+| `bootstrap-project` | Bootstrap a new repo with docs, license, and agent guidance                                      |
 | `design-doc`        | Decide architecture, alternatives, and tradeoffs                                                   |
 | `spec`              | Specify implementation requirements, contracts, and invariants                                     |
 | `plan`              | Break input into reviewable tasks                                                                 |
@@ -242,7 +242,7 @@ Run this to update Blueprint and your installed skills to the latest version.
 
 | Skill               | What it does                                                                                                                                            | Example                                              |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `bootstrap-project` | Starts a new or empty repo with README, license, `.gitignore`, `AGENTS.md`, docs, optional tracker setup, and an initial commit                         | `Bootstrap this repo for a new macOS editor project` |
+| `bootstrap-project` | Starts a new or empty repo with README, license, `.gitignore`, `AGENTS.md`, and docs                                                                          | `Bootstrap this repo for a new macOS editor project` |
 | `design-doc`        | Writes `docs/<design-slug>/design.md`: architecture, alternatives, tradeoffs, and cross-cutting concerns                                                | `Write a design doc for multi-tenant auth`           |
 | `spec`              | Writes `docs/<feature-slug>/spec.md`: requirements, contracts, invariants, and implementation design                                                     | `Write a spec for user-auth`                         |
 | `plan`              | Breaks a spec, brief, or request into tasks sized for agents, review, and rollback                                                                      | `Create a plan for user-auth`                        |

--- a/skills/bootstrap-project/SKILL.md
+++ b/skills/bootstrap-project/SKILL.md
@@ -1,95 +1,70 @@
 ---
 name: bootstrap-project
-description: "Bootstrap a new or empty project repository with clean defaults: README, license, .gitignore, AGENTS.md, docs, optional PRD/roadmap, tracker issues or board, initial commit, and optional remote setup. Interview the repo creator when product, license, tracker, or GitHub/Linear setup decisions are unclear."
+description: "Bootstrap a new or empty project repository with a local skeleton: README, license, .gitignore, AGENTS.md, docs, and optional commit or push only when explicit. Interview the repo creator when file-changing decisions are unclear."
 user-invocable: true
-argument-hint: "<project idea, repo path, tracker preference, or bootstrap scope>"
+argument-hint: "<project idea, repo path, or bootstrap scope>"
 ---
 
 # Bootstrap Project
 
 Turn a new or empty repository into a ready-to-build project skeleton.
-Do not invent product direction or external setup decisions.
-Inspect first, ask only for decisions that change what gets created, then write the smallest useful baseline.
+Keep the work local unless the user explicitly asks for commit, push, or remote setup.
+Inspect first, ask only for decisions that change files, then write the smallest useful baseline.
+Do not invent product direction, ownership, or external workflow.
 
 ## Workflow
 
-### 1. Inspect
+### 1. Inspect First
 
-- Confirm the project root, git state, current branch, remotes, and existing files.
+- Confirm the project root, git state, current branch, remotes, and meaningful existing files.
 - Detect language/framework hints from files already present.
-- Check for existing `README.md`, `LICENSE`, `.gitignore`, `AGENTS.md`, `docs/`, issue templates, and tracker references.
-- If a remote or tracker is mentioned, inspect what exists before creating anything.
-- Stop before overwriting meaningful existing project identity, docs, license, or tracker setup.
+- Check for existing `README.md`, `LICENSE`, `.gitignore`, `AGENTS.md`, and `docs/`.
+- Stop before overwriting project identity, docs, license, or agent guidance.
+- Ignore unrelated files and never touch secrets, vendored files, generated files, dependency directories, lockfiles, or changelogs unless the user explicitly asks and the bootstrap requires it.
 
-### 2. Interview The Creator
+### 2. Ask Only Necessary Questions
 
-Ask one question at a time, with a recommended answer, only when the answer changes the baseline.
+Ask one question at a time, with a recommended answer, only when the answer changes the baseline:
 
-Ask when unclear:
-
-- project name and one-sentence purpose;
-- whether to initialize git;
-- whether to create or attach a GitHub repo;
-- whether to push the initial baseline;
-- license choice;
-- tracker choice: GitHub Issues, GitHub Project, Linear, none, or later;
-- whether a product PRD is known enough to write now;
-- whether roadmap tasks should be created now or left as docs;
-- repo-specific agent guidance or constraints.
+- project name and one-sentence purpose, if `README.md` needs project identity;
+- license choice, if `LICENSE` should be created;
+- whether to initialize git, if the directory is not already a repo;
+- repo-specific agent guidance or constraints, if `AGENTS.md` is missing or too generic;
+- remote URL, commit, or push intent, only when the user explicitly requested that work.
 
 Do not ask what the repo already answers.
-If the user says to use defaults, use conservative defaults: git initialized, MIT license for open-source personal projects, minimal README, `AGENTS.md`, `docs/`, no remote creation unless a repo name or URL is explicit, no tracker items unless the work is already split.
+If the user says to use defaults, create a minimal local baseline only: `README.md`, appropriate `.gitignore`, lightweight `AGENTS.md`, `docs/` when useful, no public claims, no remote setup, no commit, and no push.
 
-### 3. Create The Skeleton
+### 3. Create Or Update The Skeleton
 
-Create or update only the files needed for the chosen baseline:
+Create or update only files needed for the chosen baseline:
 
-- `README.md`: minimalist project identity, status, and links to docs.
+- `README.md`: project identity, status, and links to useful docs.
 - `LICENSE`: chosen license.
 - `.gitignore`: language and platform defaults.
 - `AGENTS.md`: repo-specific agent instructions and project constraints.
-- `docs/prd.md`: only when product direction is known enough.
-- `docs/roadmap.md`: only when the work can be split into agent-sized tasks.
-- `docs/prompt.md` or loop prompts: only when the user wants a coordinator/work loop.
+- `docs/`: short durable notes only when the user supplied enough context to make them real.
 
 Keep docs plain and practical.
 For long Markdown files, put each full sentence on its own physical line.
+Prefer editing existing files over replacing them wholesale, and preserve existing identity.
 
-### 4. Set Up Tracker
-
-If requested, create tracker artifacts from the roadmap:
-
-- GitHub Issues: one issue per task, with goal, context, acceptance criteria, verify, and out of scope.
-- GitHub Project: create or reuse a board, link it to the repo, add issues, and set initial status.
-- Linear: create issues in the selected team/project when access and conventions are clear.
-
-Do not create duplicate issues or boards.
-Do not invent tracker states, labels, teams, or milestones.
-If setup requires permissions or missing identifiers, ask or report the exact blocker.
-
-### 5. Commit And Push
+### 4. Commit And Push Only When Explicit
 
 - Stage only intended bootstrap files.
-- Do not stage secrets, `.env`, keys, generated dependency directories, or unrelated local changes.
-- Create one Conventional Commit, usually `docs: bootstrap project` or `chore: bootstrap project`.
-- Push only when the user asked for it or the bootstrap request explicitly included remote setup.
+- If asked to commit, create one Conventional Commit.
+- If asked to push, confirm the branch and remote first.
+- Never stage secrets, `.env`, keys, generated or vendored files, dependency directories, or unrelated changes.
 
-### 6. Report
+### 5. Report
 
-Report:
-
-- files created or changed;
-- repo and remote state;
-- tracker or board links;
-- commit hash, if committed;
-- push status, if pushed;
-- the next recommended action.
+Report files changed, repo and remote state, commit hash if committed, push status if pushed, and the next recommended action.
 
 ## Rules
 
-- Prefer defaults, but never guess external ownership decisions.
-- Do not create a GitHub repo, Linear project, license, or public-facing product claim without enough user intent.
-- Do not turn a vague idea into a fake PRD.
+- Prefer defaults, but never guess external ownership.
+- Do not create external services, tracker artifacts, licenses, or public-facing claims without enough user intent.
+- Do not turn a vague idea into fake product docs.
 - Do not overwrite existing docs or project identity without explicit permission.
 - Keep the skeleton small.
 - Leave the repo ready for `spec`, `plan`, or `task-to-pr`.


### PR DESCRIPTION
## Summary

- Trimmed `bootstrap-project` from broad repo/tracker setup into a focused local skeleton workflow.
- Removed the detailed tracker, board, Linear, GitHub Project, PRD, and roadmap setup steps from the skill.
- Updated README and AGENTS bootstrap descriptions so they match the narrower scope.

## Verification

- Read back touched files after editing: `skills/bootstrap-project/SKILL.md`, `README.md`, `AGENTS.md`.
- Compared bootstrap skill line count: 95 lines before, 70 lines after.
- Ran `rg -n "Linear|GitHub Project|board" skills/bootstrap-project/SKILL.md` and confirmed no matches.
- Ran `rg -n "tracker setup|optional tracker|initial commit" README.md AGENTS.md skills/bootstrap-project/SKILL.md` and confirmed no matches.
- Ran `bash -n examples/regenerate.sh`.
- Ran `git diff --check`.

## Context

This task came from the skill review, which identified `bootstrap-project` as the largest and least dense skill and recommended keeping it to local project bootstrap boundaries.