### PR TITLE
docs: clarify git helper skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,16 +30,19 @@ Deliver:
 
 - `task-to-pr`: orchestrate one ticket to a draft PR, keeping the ticket updated with evidence; uses isolated branches/worktrees, tests, review, and acceptance verification.
 - `multitask`: run several tickets to draft PRs in parallel, one isolated worker per ticket; composes task-to-pr.
-- `branch`: create a traceable Git branch with the ticket ID when available.
 - `implement`: turn one scoped task into a verified diff with tests.
 - `tdd`: test-first variant of implement.
 - `debug`: find the root cause of a failure, then fix it with a regression test first when practical.
 - `refactor`: simplify changed code without changing behavior.
 - `review`: pre-merge code review for correctness, security, simplicity, robustness, and tests.
 - `pr`: commit, push, and open a PR with a clear description.
-- `commit`: stage intended changes and write one clear Conventional Commit.
 - `pr-to-ready`: drive an open PR with feedback to merge-ready; never merges.
 - `browser-verify`: verify browser-rendered work in a real browser.
+
+Helper entry points:
+
+- `branch`: create a traceable Git branch with the ticket ID when available.
+- `commit`: stage intended changes and write one clear Conventional Commit.
 
 ## Agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@
 
 Blueprint installs as standalone skills via `npx skills add owainlewis/blueprint`. The active workflows live in `skills/<name>/SKILL.md`.
 
-- Invoke skills by name: `bootstrap-project`, `design-doc`, `spec`, `plan`, `implement`, `tdd`, `debug`, `refactor`, `review`, `task-to-pr`, `multitask`, `pr`, `pr-to-ready`, `browser-verify`, `branch`, `commit`.
+- Invoke core workflows by name: `bootstrap-project`, `design-doc`, `spec`, `plan`, `implement`, `tdd`, `debug`, `refactor`, `review`, `task-to-pr`, `multitask`, `pr`, `pr-to-ready`, `browser-verify`.
+- Helper entry points remain available for mechanical delivery steps: `branch`, `commit`.
 - Agent definitions live in `agents/`. Copy them to `.claude/agents/` (project) or `~/.claude/agents/` (user) to make them spawnable; `npx skills add` installs skills only.
 - `browser-verify` requires an available real-browser automation and inspection path, such as Chrome DevTools MCP.
 - Keep shared repo guidance in `AGENTS.md`; keep Claude-specific adapter notes here.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Coding agents don't fail for lack of intelligence. They fail for lack of process: no spec, no plan, no tests, no review, just a confident 2,000-line PR nobody asked for. Blueprint fixes the process and trusts the intelligence.
 
-It encodes how the best engineering teams have always shipped: bootstrap cleanly, design when architecture is ambiguous, spec when implementation contracts or invariants matter, plan when work needs splitting, test before ship, review before merge. Sixteen dense skills you can run as single steps you drive yourself, or as loops that take whole tickets to draft PRs while you sleep.
+It encodes how the best engineering teams have always shipped: bootstrap cleanly, design when architecture is ambiguous, spec when implementation contracts or invariants matter, plan when work needs splitting, test before ship, review before merge. Fourteen core workflow skills, plus two mechanical helpers, let you run single steps yourself or loops that take whole tickets to draft PRs while you sleep.
 
 Blueprint is the deliberate opposite of bloated, over-engineered skill libraries like Superpowers and GSD. No ceremony, no guardrail mazes, no thousand-line process files burning your context window before any work starts. Simplicity is clarity: a skill short enough to hold in your head is a skill an agent actually follows. And Blueprint bets on the model. Heavy frameworks assume the model is weak and wrap it in rules; Blueprint assumes the model is strong and hands it the judgment of a great senior engineer, written down. Every model release makes that bet pay off more, and the guardrails more wrong.
 
@@ -190,6 +190,8 @@ For an attended Codex coordinator that works through a small issue set, keeps a 
 
 The supported install path is `npx skills add owainlewis/blueprint`. That installs standalone skills; invoke them by skill name (`spec`, `plan`, `implement`, etc.) or by the skill picker/natural-language flow your agent supports.
 
+Core workflows:
+
 | Skill               | Purpose                                                                                           |
 | ------------------- | ------------------------------------------------------------------------------------------------- |
 | `bootstrap-project` | Bootstrap a new repo with docs, license, and agent guidance                                      |
@@ -207,10 +209,15 @@ The supported install path is `npx skills add owainlewis/blueprint`. That instal
 | `pr`                | Commit, push, and open a PR                                                                       |
 | `pr-to-ready`       | Drive an open PR to merge-ready                                                                   |
 | `browser-verify`    | Verify browser-rendered work                                                                      |
-| `branch`            | Create a traceable Git branch                                                                     |
-| `commit`            | Conventional commit                                                                               |
 
-Branching and committing are mechanical, but they are still skills so the installer can expose the full workflow consistently.
+Helper entry points:
+
+| Skill    | Purpose                       |
+| -------- | ----------------------------- |
+| `branch` | Create a traceable Git branch |
+| `commit` | Conventional commit           |
+
+`branch` and `commit` are helper entry points, not core workflows. They stay installable so `task-to-pr`, `multitask`, and `pr` can expose the full delivery path consistently.
 
 Removed entry points are not maintained as aliases: `requirements` is now `spec`; `architecture` is now `design-doc` for architecture docs or `spec` for implementation instructions; `task` and `build` are now `implement`; `coverage` is handled through `implement` when adding tests or `review` when evaluating them; `address-pr-feedback` is now `pr-to-ready`; `codex-run-loop` is now `task-to-pr` for one ticket or `multitask` for several tickets.
 
@@ -240,6 +247,8 @@ Run this to update Blueprint and your installed skills to the latest version.
 
 ## Skills
 
+Core workflows:
+
 | Skill               | What it does                                                                                                                                            | Example                                              |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `bootstrap-project` | Starts a new or empty repo with README, license, `.gitignore`, `AGENTS.md`, and docs                                                                          | `Bootstrap this repo for a new macOS editor project` |
@@ -257,8 +266,13 @@ Run this to update Blueprint and your installed skills to the latest version.
 | `pr`                | Commits intended changes, pushes the branch, and opens a clear draft PR                                                                                 | `Open a draft PR for this change`                    |
 | `pr-to-ready`       | Inspects live PR state, fixes still-actionable feedback, verifies checks, and reports merge readiness; never merges                                     | `Is PR #42 ready to merge?`                          |
 | `browser-verify`    | Verifies rendered UI, HTML, visual docs, and browser-facing behavior in a real browser                                                                  | `Browser-verify the local HTML report`               |
-| `branch`            | Creates a traceable Git branch with the ticket ID when available                                                                                        | `Create a branch for LIN-123 user-auth`              |
-| `commit`            | Stages intended changes and writes one clear Conventional Commit                                                                                        | `Commit the current changes`                         |
+
+Helper entry points:
+
+| Skill    | What it does                                                 | Example                                 |
+| -------- | ------------------------------------------------------------ | --------------------------------------- |
+| `branch` | Creates a traceable Git branch with the ticket ID when available | `Create a branch for LIN-123 user-auth` |
+| `commit` | Stages intended changes and writes one clear Conventional Commit | `Commit the current changes`            |
 
 ## Agent Instructions
 


### PR DESCRIPTION
## Summary
- Clarifies the public skill surface as 14 core workflow skills plus 2 mechanical helper entry points.
- Moves `branch` and `commit` into helper sections in README and AGENTS guidance while keeping them installable and invocable.
- Aligns CLAUDE adapter notes with the same core-vs-helper framing.

## Verification
- Read back `README.md`, `AGENTS.md`, and `CLAUDE.md` after editing.
- Ran `rg -n "\b(branch|commit)\b|branching|committing" .` and confirmed remaining references are intentional delivery mechanics, helper entries, or skill files.
- Ran `rg -n "Sixteen|Branching and committing|Invoke skills by name" README.md AGENTS.md CLAUDE.md` to confirm old wording was removed.
- Ran `git diff --check`.

## Notes
- This task came from the skill review concern that 16 public skills is probably the upper limit.
- No skills were deleted or renamed, so existing invocations of `branch` and `commit` remain compatible.
- No project test harness was present; this is a docs-only change.