### PR TITLE
feat: add milestone delivery skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Blueprint has two flows. The input to the next step is a spec, plan, or task wit
 
 **Decide** (`design-doc` -> `spec` -> `plan`): turn unclear work into reviewed decisions and tasks a new agent can do. Every stage pauses for human review. Start at `design-doc` when architecture, options, or tradeoffs are unclear. Use `spec` when requirements, function signatures, return values, data shapes, or error behavior need review. Use `plan` when the work just needs splitting. Skip stages when the change is small and already decided.
 
-**Deliver** (`task-to-pr`): turn one task into a PR that is ready for review, with the ticket as the record of the work. `task-to-pr` prepares the workspace, implements the change, tests it, gets another review, checks each acceptance criterion, commits, pushes, opens the PR, handles current feedback, and updates the ticket. Prefer worktrees when they reduce risk. Use `multitask` to run several independent tickets in parallel, one worker per ticket. Use `pr-to-ready` when later feedback exists; merging is always a human decision. Use `implement` alone for one code task, `tdd` when a failing test can describe the behavior first, `refactor` to simplify changed code before review, and `debug` when something breaks.
+**Deliver** (`task-to-pr`): turn one task into a PR that is ready for review, with the ticket as the record of the work. `task-to-pr` prepares the workspace, implements the change, tests it, gets another review, checks each acceptance criterion, commits, pushes, opens the PR, handles current feedback, and updates the ticket. Prefer worktrees when they reduce risk. Use `milestone` to complete a GitHub milestone through `task-to-pr`, one issue at a time. Use `multitask` to run several independent tickets in parallel, one worker per ticket. Use `pr-to-ready` when later feedback exists; merging is always a human decision. Use `implement` alone for one code task, `tdd` when a failing test can describe the behavior first, `refactor` to simplify changed code before review, and `debug` when something breaks.
 
 Exploration is allowed without creating docs or issue tracker entries. Do not manufacture fake specs, plans, or issues for spikes.
 
@@ -26,6 +26,7 @@ Decide:
 Deliver:
 
 - `task-to-pr`: turn one ticket into a PR ready for review, keeping the ticket updated with proof; uses separate branches or worktrees, tests, review, and acceptance checks.
+- `milestone`: complete all open issues in a GitHub milestone by running `task-to-pr` one issue at a time.
 - `multitask`: run several tickets to PRs in parallel, one worker per ticket.
 - `implement`: turn one task into a checked diff with tests.
 - `tdd`: test-first variant of implement.

--- a/README.md
+++ b/README.md
@@ -71,17 +71,20 @@ flowchart TD
 
 ## The Loops
 
-Most skills are steps: one phase, one human checkpoint. Three skills chain the steps into end-to-end loops:
+Most skills are steps: one phase, one human checkpoint. Four skills chain the steps into end-to-end loops:
 
 | Skill         | From                     | To                                                                         |
 | ------------- | ------------------------ | -------------------------------------------------------------------------- |
 | `task-to-pr`  | a ticket                 | a PR ready for review, with code, tests, another review, acceptance checks, and proof |
+| `milestone`   | a GitHub milestone       | every open issue completed through `task-to-pr`, one PR at a time |
 | `multitask`   | several tickets          | several PRs ready for review, one separate worker per ticket or dependent group |
 | `pr-to-ready` | an open PR with human, bot, or check feedback | a PR that is ready to merge, with checks passing |
 
 Loops keep the ticket updated as they work: status moves, comments with proof, and PR links. They stop at human checkpoints. Merging is always a human decision.
 
 `task-to-pr` is the single-ticket loop: it reads the ticket, creates a branch, implements the acceptance criteria, reviews the diff, checks acceptance, opens a PR ready for review, handles current feedback, and writes proof back to the ticket.
+
+`milestone` is the release-slice loop: it reads open issues in a GitHub milestone, orders them by dependency and risk, then runs `task-to-pr` for each issue. It stops for human merge unless merge permission was explicit. When merging is allowed, it merges only after checks and review are clean, syncs the default branch, then continues.
 
 `multitask` is the coordinator-worker loop for several tickets at once: it groups dependent work, starts one isolated worker per ticket, and reports each PR or blocker. The coordinator never edits code. See [guides/multitask.md](guides/multitask.md) for how it splits and coordinates work.
 
@@ -154,12 +157,13 @@ npx skills update
 | **Improve**  | `refactor`          | Improves code shape without changing behavior                                                                     | `Refactor the current diff`                  |
 | **Review**   | `review`            | Reviews code changes for correctness, security, simplicity, robustness, and tests                                | `Review the current diff`                    |
 | **Deliver**  | `task-to-pr`        | Runs the loop from ticket to PR: implement, test, review, check acceptance, open the PR, update the ticket with proof | `task-to-pr LIN-123`                    |
+| **Deliver**  | `milestone`         | Completes a GitHub milestone through `task-to-pr`, one issue and PR at a time                                    | `milestone https://github.com/org/repo/milestone/1` |
 | **Deliver**  | `multitask`         | Coordinates several tickets to PRs at once, one isolated worker per ticket                                        | `multitask LIN-101 LIN-102 LIN-103`          |
 | **Deliver**  | `pr`                | Commits intended changes, pushes the branch, and opens a clear PR                                                 | `Open a PR for this change`                  |
 | **Feedback** | `pr-to-ready`       | Inspects live PR state, fixes actionable feedback, verifies checks, and reports merge readiness; never merges     | `Is PR #42 ready to merge?`                  |
 | **Browser**  | `browser-verify`    | Verifies rendered UI, HTML, visual docs, and browser-facing behavior in a real browser                            | `Browser-verify the local HTML report`       |
 
-Helper entry points, not core workflows; they stay installable so `task-to-pr`, `multitask`, and `pr` can expose the full delivery path consistently:
+Helper entry points, not core workflows; they stay installable so `task-to-pr`, `milestone`, `multitask`, and `pr` can expose the full delivery path consistently:
 
 | Skill    | What it does                                                      | Example                                 |
 | -------- | ------------------------------------------------------------------ | ---------------------------------------- |

--- a/skills/milestone/SKILL.md
+++ b/skills/milestone/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: milestone
+description: "Complete all open GitHub issues in a milestone by running task-to-pr one issue at a time."
+user-invocable: true
+argument-hint: "<GitHub milestone URL>"
+---
+
+# Milestone
+
+Goal: finish every open issue in a GitHub milestone.
+
+## Workflow
+
+1. Inspect the milestone, repo, open issues, open PRs, and project state when accessible.
+2. Order issues by dependency, risk, and reviewability. Put blockers, bugs, and shared seams before dependent feature work.
+3. Work one issue at a time by running `task-to-pr`. Do not reimplement its inner loop.
+4. After each PR is ready, stop for human merge unless the user explicitly allowed merging for this run.
+5. If merging is allowed, merge only after local checks, CI, and review are clean. Then sync the default branch before starting the next issue.
+6. Keep the issue and project state updated with PR links, proof, blockers, and final status.
+7. Report the milestone result: completed issues, merged PRs, open PRs, blockers, checks, and anything not verified.
+
+## Rules
+
+- One issue, one branch, one PR unless combining is clearly required. Explain any combination before doing it.
+- Do not start issues outside the milestone.
+- Do not batch unrelated issues.
+- Do not merge without explicit permission from the user.
+- Do not merge with failing checks, unresolved required review, missing acceptance criteria, or unexplained test gaps.
+- Stop if an issue is unclear, already has a matching PR, needs missing secrets or permissions, repeats the same blocker, or grows beyond its acceptance criteria.


### PR DESCRIPTION
## Summary

Adds a new `milestone` skill for completing all open GitHub issues in a milestone by coordinating `task-to-pr` one issue at a time.

## Why

This captures the milestone-sized agent workflow as a reusable Blueprint skill without bloating `goal-design` or reimplementing `task-to-pr`.

## Test plan

- `git diff --check`
- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`
- `npx skills --help`
- `npx skills add . --list --full-depth`
- `npx skills use . --skill milestone --full-depth`

## Risks

Low. This is docs and skill metadata only. The main risk is wording that over-authorizes merging, so the skill explicitly requires user permission and clean checks/review before merge.

## Related issue

None.
