### PR TITLE
docs: clarify blueprint skills

### DIFF
--- a/skills/branch/SKILL.md
+++ b/skills/branch/SKILL.md
@@ -7,13 +7,13 @@ argument-hint: <branch-name or task reference>
 
 # Branch
 
-1. Check the current branch, git status, and task details.
-2. Name it. A name from the user wins as given. Otherwise `<ticket-id>-<short-kebab-summary>`, or just the summary if there's no ticket. Follow the repo's existing naming style.
-3. Fetch, then branch from the latest default branch unless the user says otherwise.
-4. If the branch already exists, switch to it and note any commits it has beyond the base.
+1. Check the current branch, `git status --short`, remotes, and task details.
+2. Name it. A name from the user wins as given. Otherwise use `<ticket-id>-<short-kebab-summary>`, or just the summary if there is no ticket. Follow the repo's existing naming style.
+3. Fetch, then branch from the latest default branch when a remote exists, unless the user says otherwise.
+4. If the branch already exists, switch to it and report commits it has beyond the base.
 5. Report the branch name, its base, and any uncommitted work that was present.
 
 ## Rules
 
 - Never stash, discard, or force through uncommitted work. If switching is blocked, stop and ask.
-- Never invent ticket IDs. If a ticket exists but its ID isn't visible, ask; if no human is available, proceed without it and say so in the report.
+- Never invent ticket IDs. If a ticket exists but its ID is not visible, ask; if no human is available, proceed without it and say so in the report.

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -7,11 +7,12 @@ argument-hint: "[optional commit message]"
 
 # Commit
 
-1. Inspect the working tree and diffs. If there's nothing worth committing, or the diff isn't understood, stop.
+1. Inspect the working tree and diffs. If there are no intended changes, or you cannot explain the diff, stop.
 2. Stage only the intended files, not broad adds.
-3. Use the user's message if provided. Otherwise write a Conventional Commit matching the repo's existing style: imperative subject, add a body only when the reason or risk matters.
+3. Use the user's message if provided. Otherwise write a Conventional Commit matching the repo's existing style: imperative subject, add a body only when the reason, checks, or risk matter.
 4. Commit and report the hash and message.
 
 ## Rules
 
 - Never commit `.env`, credentials, or keys.
+- Never bypass hooks with `--no-verify`. If a hook fails, fix the cause or stop and report.

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -7,13 +7,14 @@ argument-hint: "<failure description, error output, or bug report>"
 
 # Debug
 
-1. Reproduce the failure. If you can't, keep gathering information and report what you observed.
+1. Reproduce the failure. If you cannot, keep gathering information and report what you observed.
 2. Trace it to the root cause and explain why it happens.
-3. Add a small failing test when practical, then make the smallest fix that passes it. If no test is practical, say why and verify another way.
+3. Add a small failing regression test when practical, then make the smallest fix that passes it. If no useful test is practical, say why and verify another way.
 4. Run relevant checks. Report the cause, the fix, how it was verified, and anything still unexplained.
 
 ## Rules
 
-- Fix the cause, not the symptom. One bug at a time.
-- Don't pull unrelated failures or flaky infrastructure into the task.
+- Fix the cause, not the symptom. Do not delete the failing check, swallow the error, or weaken the assertion unless that is the real fix.
+- One bug at a time.
+- Do not pull unrelated failures or flaky infrastructure into the task.
 - Stop when the fix needs a product or code-owner decision.

--- a/skills/design-doc/SKILL.md
+++ b/skills/design-doc/SKILL.md
@@ -7,14 +7,15 @@ argument-hint: "<system, feature, architecture question, repo path, or design br
 
 # Design Doc
 
-1. Read the brief and any linked docs, code, or plans. Ask a question, one at a time with a recommended answer, only when a missing fact would change the design.
-2. Write `docs/<design-slug>/design.md`, 1-3 pages, using the template below. Omit sections that don't apply.
-3. Stop after writing. Don't continue into spec, plan, or implementation until the human confirms.
+1. Read the brief and any linked docs, code, or plans. Ask one question at a time, with a recommended answer, only when a missing fact would change the design.
+2. Write `docs/<design-slug>/design.md`, 1-3 pages, using the template below. Omit sections that do not apply.
+3. Stop after writing. Do not continue into spec, plan, or implementation until the human confirms.
 
 ## Rules
 
-- Focus on decisions code won't explain later.
-- Don't copy full schemas, APIs, or code unless the exact shape is central.
+- Make the design choice and its tradeoffs easy to review.
+- Focus on decisions code will not explain later.
+- Do not copy full schemas, APIs, or code unless the exact shape is central.
 - Leave Status as Draft and Decision empty. Both are filled during review.
 
 ## Template
@@ -33,6 +34,9 @@ argument-hint: "<system, feature, architecture question, repo path, or design br
     ## Non-goals
     What it deliberately does not solve.
 
+    ## Constraints
+    Technical, product, migration, compatibility, operational, cost, or time limits.
+
     ## Proposed design
     How it works. Structure, data flow, key interfaces. Diagram only if it clarifies.
 
@@ -40,7 +44,7 @@ argument-hint: "<system, feature, architecture question, repo path, or design br
     Each option considered, why it lost. This is the section reviewers judge.
 
     ## Risks
-    What could go wrong and how it's mitigated.
+    What could go wrong and how it is mitigated.
 
     ## Rollout
     How it ships: migration, flags, backout.

--- a/skills/goal-design/SKILL.md
+++ b/skills/goal-design/SKILL.md
@@ -7,13 +7,13 @@ argument-hint: "<rough goal, task, ticket, issue set, or prompt>"
 
 # Goal Design
 
-1. Read the brief and anything it references. Ask only when the goal can't be checked from the input.
-2. Write one plain paragraph starting with `/goal`, 5-8 sentences: what to read first, what to change, what checks must pass, what proof to report, an effort budget, when to stop as blocked.
+1. Read the brief and anything it references. Ask only when the goal cannot be checked from the input.
+2. Write one plain prompt starting with `/goal`, 5-8 sentences: what to read first, what to change, what checks must pass, what proof to report, an effort budget, and when to stop as blocked.
 3. Return the prompt first. Add a note after only when useful.
 
 ## Rules
 
-- The completion condition must be provable from the agent's own output. Name the exact command and expected result; goal evaluation reads the session, it doesn't run checks itself.
+- The completion condition must be provable from the agent's own output. Name the exact command and expected result; goal evaluation reads the session, it does not run checks itself.
 - Checks are a gate, not a suggestion. Concrete proof: command results, links, files, screenshots.
 - Always include a budget: a turn, iteration, or time limit.
 - Require reviewer sign-off before PR, and a check of each acceptance criterion when criteria exist.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -9,15 +9,15 @@ argument-hint: "<task reference or description> e.g. 'LIN-123' or 'Task 2 from u
 
 1. Read the request, its sources, and the relevant code. Capture the goal, acceptance criteria, checks, and what not to change.
 2. Ask only when requirements, safety, ownership, or product behavior are unclear. State low-risk assumptions and continue.
-3. Make the smallest complete change in the right module. Don't change public interfaces or data shapes unless the task requires it.
-4. Add or update tests for changed behavior. If a useful test isn't practical, say why and verify manually.
+3. Make the smallest complete change in the right module. Do not change public interfaces or data shapes unless the task requires it.
+4. Add or update tests for changed behavior. If a useful test is not practical, say why and verify manually.
 5. Run the most relevant checks first, wider checks when shared or user-facing behavior changed. Fix relevant failures without expanding the task.
-6. Use a subagent to review the work. Fix any issues found. 
-7. Open a pull request for human to review
+6. Use a subagent or reviewer for non-trivial diffs. Fix real issues about the task and rerun checks. If no reviewer is available, self-review and say so.
+7. If the task expects a PR, open one for human review. Otherwise report changed files, checks, acceptance status, review status, and anything not checked.
 
 ## Rules
 
-- One task at a time. Don't touch unrelated code.
-- Don't hide unchecked work.
-- Don't overwrite or discard user changes.
+- One task at a time. Do not touch unrelated code.
+- Do not hide unchecked work.
+- Do not overwrite or discard user changes.
 - If the task, spec, or plan is wrong, stop and update the source of truth before continuing.

--- a/skills/multitask/SKILL.md
+++ b/skills/multitask/SKILL.md
@@ -7,11 +7,11 @@ argument-hint: "<ticket list> e.g. LIN-101, LIN-102, LIN-103"
 
 # Multitask
 
-1. Read each ticket and the code it likely touches. Tickets that overlap in files or behavior go in one ordered group; the rest get separate workers.
-2. Give each worker its own worktree, branch, and full session. If parallel workers aren't available, run groups sequentially and say so.
+1. Read each ticket and the code it likely touches. Tickets that overlap in files, data shapes, or behavior go in one ordered group; the rest get separate workers.
+2. Give each worker its own worktree, branch, and full session. If parallel workers are not available, run groups sequentially and say so.
 3. Start each worker with a complete prompt: ticket, repo path, branch rule, acceptance criteria, checks, review rule, PR rules, report format. The worker owns the full loop from implement through PR, ticket update, and proof.
 4. Watch the workers. If one fails or invalidates an assumption another needs, stop the affected workers and report why. Report failures, never silently retry.
-5. Report every ticket: branch, PR URL, status, blockers, proof. Clean up worktrees whose PRs are open.
+5. Report every ticket: branch, PR URL, status, blockers, proof, and any worktree path. Clean up worktrees only when the repo convention says to or the user asks.
 
 ## Rules
 

--- a/skills/pr-to-ready/SKILL.md
+++ b/skills/pr-to-ready/SKILL.md
@@ -8,9 +8,9 @@ argument-hint: "<PR URL, number, branch, or current repository PR>"
 # PR To Ready
 
 1. Identify the PR from `$ARGUMENTS`, the current branch, or open repo PRs.
-2. Inspect the live PR: diff, commits, checks, reviews, unresolved threads, mergeability, local git status.
+2. Inspect the live PR: diff, commits, checks, reviews, unresolved threads, comments, mergeability, and local git status.
 3. Classify feedback: actionable, disputed, resolved, outdated, informational, needs-human.
-4. Fix actionable items, keeping changes small. Push back on disputed items with a comment on the thread explaining why, and don't change the code. Stop for product, security, code-owner, or risk decisions.
+4. Fix actionable items, keeping changes small. Push back on disputed items with a comment on the thread explaining why, and do not change the code. Stop for product, security, code-owner, or risk decisions.
 5. Run the smallest checks that prove the fix, wider checks when shared or user-facing behavior changed.
 6. Re-check the PR after pushing. Reply on each addressed thread with what changed. Update the linked ticket with proof when accessible.
 7. Report Ready, Not ready, or Blocked, with changes, checks run, pushed-back items, and remaining items.
@@ -20,7 +20,7 @@ argument-hint: "<PR URL, number, branch, or current repository PR>"
 
 - Never merge.
 - Push back only with a concrete reason: correctness, scope, or a documented convention. Preference disagreements from a human reviewer go to needs-human, not a rebuttal.
-- Don't expand the task for nice-to-have feedback.
-- Don't mark ready while required checks fail or actionable feedback remains.
+- Do not expand the task for nice-to-have feedback.
+- Do not mark ready while required checks fail or actionable feedback remains.
 - Trust the live PR state, not stale summaries.
-- Don't hide skipped tests, placeholders, partial fixes, or assumptions.
+- Do not hide skipped tests, placeholders, partial fixes, or assumptions.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -9,13 +9,14 @@ argument-hint: "[optional: PR title, base branch, or draft|ready]"
 
 1. If still on the default branch, create or switch to a task branch first.
 2. Commit intended changes with a Conventional Commit subject. Stage only intended files.
-3. Push and open the PR, ready for review by default, draft only when asked or the work is known incomplete. Title reads like a commit subject: in squash-merge repos it becomes the commit on the default branch.
-4. Write the body from the diff: what changed and why, ticket link when one exists, checks run with results, anything not checked.
-5. Report the PR URL.
+3. Before writing the PR body, read the repo's PR template if one exists. Check `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `pull_request_template.md`, `docs/pull_request_template.md`, and `.txt` variants. If a `PULL_REQUEST_TEMPLATE/` directory exists under `.github/`, the repo root, or `docs/`, pick the template named by the repo or user; otherwise use the default template if present.
+4. Push and open the PR, ready for review by default, draft only when asked or the work is known incomplete. Title reads like a commit subject: in squash-merge repos it becomes the commit on the default branch.
+5. Write the body from the template when one exists. Preserve headings and fill relevant sections from the diff and work done: what changed and why, ticket link when one exists, checks run with results, review issues fixed, and anything not checked. If no template exists, write a concise body with those same details.
+6. Report the PR URL.
 
 ## Rules
 
 - One PR per branch. If one is open, push and update it. Preserve human edits to the body: update only what the new commits change.
 - Follow the repo's PR template when one exists.
-- Never claim checks that didn't run.
+- Never claim checks that did not run.
 - If push or PR creation fails, keep the work local and report the exact failure.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -11,7 +11,7 @@ Do not edit files. Find the change from `$ARGUMENTS` or the conversation; ask if
 
 Try to prove the change wrong, not right. Trust code and tests, not confident explanations.
 
-## Quality
+## Check
 
 Check behavior, edge cases, failure paths, security, interfaces and data shapes, and fit with existing patterns. Check whether tests prove the changed behavior. Flag dead code left by the change.
 
@@ -27,4 +27,4 @@ List blockers, then important, then nits, each with location, severity, impact, 
 - **important**: should fix.
 - **nit**: author can ignore.
 
-End with one sentence on whether the tests actually run the changed code. Tests that don't run the changed branch, mock the function under test, or assert what the code did instead of what it should do are blockers.
+End with one sentence on whether the tests actually run the changed code, and what is missing if they do not. Tests that do not run the changed branch, mock the function under test, or only assert what the code did instead of what it should do are blockers.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -8,8 +8,8 @@ argument-hint: "<feature description, context, or constraints>"
 # Spec
 
 1. Read the request, referenced files, and relevant code.
-2. Ask one question at a time, with a recommended answer, only when a missing decision would change behavior, interfaces, dependencies, or checks.
-3. Write `docs/<feature-slug>/spec.md`, short unless the decisions need detail, using the template below. Omit sections that don't apply.
+2. Ask one question at a time, with a recommended answer, only when a missing decision would change behavior, interfaces, dependencies, error behavior, or checks.
+3. Write `docs/<feature-slug>/spec.md`, short unless the decisions need detail, using the template below. Omit sections that do not apply.
 4. Check current versions when the spec pins runtimes, frameworks, or dependencies.
 5. Stop and ask for review. Do not plan or implement.
 
@@ -36,7 +36,7 @@ argument-hint: "<feature description, context, or constraints>"
     ## Decisions
     Choices made where implementations could differ, each with the chosen default and why.
 
-    ## Must not change
+    ## Invariants
     Existing behavior, interfaces, and data shapes this work must preserve.
 
     ## Error behavior
@@ -44,3 +44,6 @@ argument-hint: "<feature description, context, or constraints>"
 
     ## Test plan
     How each requirement gets verified: specific tests or runnable checks.
+
+    ## Out of scope
+    What this spec deliberately does not cover.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -7,11 +7,11 @@ argument-hint: "<ticket reference> e.g. JIRA-123, LIN-123, github#456, https://g
 
 # Task To PR
 
-1. Resolve the ticket: problem, acceptance criteria, PR rules. Stop if it's unclear, already has a PR, spans unrelated work, or needs missing secrets or decisions.
+1. Resolve the ticket: problem, acceptance criteria, PR rules. Stop if it is unclear, already has a PR, spans unrelated work, or needs missing secrets or decisions.
 2. Work in an isolated branch or worktree named with the ticket ID. Protect unrelated local changes.
 3. Implement the smallest complete change. Add or update tests, and docs when user-facing behavior changed.
 4. Run focused checks first, wider ones when shared behavior changed.
-5. Get the diff reviewed by another agent or reviewer. If none is available, self-review, and don't push unless the user accepts that limitation.
+5. Get non-trivial diffs reviewed by another agent or reviewer. If none is available, self-review and say so in the PR body.
 6. Check each acceptance criterion against the ticket. Unmet required criteria block the PR.
 7. Commit with a Conventional Commit subject and ticket ID, push, open a PR ready for review. Body: ticket link, summary, acceptance status, check results, review status.
 8. Handle checks and feedback that arrive during this run: fix actionable items, re-check, push. Stop when clean, when nothing arrives after a reasonable wait, or when a human decision is needed.
@@ -22,8 +22,8 @@ argument-hint: "<ticket reference> e.g. JIRA-123, LIN-123, github#456, https://g
 
 - One ticket, one branch, one PR. A list of tickets means one worker per ticket.
 - Never merge. Long-running review watching is a separate run unless asked.
-- Don't open a PR with failing relevant checks or unmet required criteria unless the user asks for an early draft, and disclose it.
-- Don't expand the task for nice-to-have suggestions from review, checks, or bots.
+- Do not open a PR with failing relevant checks or unmet required criteria unless the user asks for an early draft, and disclose it.
+- Do not expand the task for nice-to-have suggestions from review, checks, or bots.
 - Prefer a worktree when the checkout has local changes, is in use, or runs unattended.
 - On failure, keep work local, keep branches and worktrees intact, report exactly what failed.
 - Unattended runs report through the ticket, not chat. When blocked: comment proof, apply the needs-human label, release any claim label, exit cleanly.


### PR DESCRIPTION
## Summary

- Clarify 12 Blueprint skill files with smaller, more direct workflow language.
- Keep the newer compact skill style from `main` while folding in stronger proof, review, PR template, and acceptance-check guidance.
- Tighten spec and design-doc terminology around constraints, non-goals, invariants, and out of scope.

## Why

The repo skills are the operating surface for Blueprint. These edits make the instructions easier to scan, reduce ambiguity, and keep delivery flows focused on concrete checks and proof before reporting done.

## Test plan

- `python3` validation script for all `skills/*/SKILL.md` front matter and Markdown fence balance: passed.
- `rg -n "<<<<<<<|=======|>>>>>>>|quality bar|Quality Bar|robust|comprehensive|thorough|polished|—|–" skills/*/SKILL.md || true`: no matches.
- `git diff --check`: passed.

## Risks

Low. This changes skill documentation only. Review should check whether the shorter wording still preserves the intended behavior for delivery, review, and PR workflows.

## Related issue

None.
