### PR TITLE
docs: make task-to-pr worktree first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Blueprint has two flows. The input to the next step is a spec, plan, or task wit
 
 **Decide** (`design-doc` -> `spec` -> `plan`): turn unclear work into reviewed decisions and tasks a new agent can do. Every stage pauses for human review. Start at `design-doc` when architecture, options, or tradeoffs are unclear. Use `spec` when requirements, function signatures, return values, data shapes, or error behavior need review. Use `plan` when the work just needs splitting. Skip stages when the change is small and already decided.
 
-**Deliver** (`task-to-pr`): turn one task into a PR that is ready for review, with the ticket as the record of the work. `task-to-pr` prepares the workspace, implements the change, tests it, gets another review, checks each acceptance criterion, commits, pushes, opens the PR, handles current feedback, and updates the ticket. Prefer worktrees when they reduce risk. Use `milestone` to complete a GitHub milestone through `task-to-pr`, one issue at a time. Use `multitask` to run several independent tickets in parallel, one worker per ticket. Use `pr-to-ready` when later feedback exists; merging is always a human decision. Use `implement` alone for one code task, `tdd` when a failing test can describe the behavior first, `refactor` to simplify changed code before review, and `debug` when something breaks.
+**Deliver** (`task-to-pr`): turn one task into a PR that is ready for review, with the ticket as the record of the work. `task-to-pr` creates a dedicated branch and worktree from the latest remote default branch, implements the change, tests it, gets another review, checks each acceptance criterion, commits, pushes, opens the PR, handles current feedback, and updates the ticket. Use `milestone` to complete a GitHub milestone through `task-to-pr`, one issue at a time. Use `multitask` to run several independent tickets in parallel, one worker per ticket. Use `pr-to-ready` when later feedback exists; merging is always a human decision. Use `implement` alone for one code task, `tdd` when a failing test can describe the behavior first, `refactor` to simplify changed code before review, and `debug` when something breaks.
 
 Exploration is allowed without creating docs or issue tracker entries. Do not manufacture fake specs, plans, or issues for spikes.
 
@@ -25,7 +25,7 @@ Decide:
 
 Deliver:
 
-- `task-to-pr`: turn one ticket into a PR ready for review, keeping the ticket updated with proof; uses separate branches or worktrees, tests, review, and acceptance checks.
+- `task-to-pr`: turn one ticket into a PR ready for review, keeping the ticket updated with proof; uses a dedicated branch and worktree, tests, review, and acceptance checks.
 - `milestone`: complete all open issues in a GitHub milestone by running `task-to-pr` one issue at a time.
 - `multitask`: run several tickets to PRs in parallel, one worker per ticket.
 - `implement`: turn one task into a checked diff with tests.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ flowchart TD
     Handoff["tasks / tickets<br/>ready to build"]
 
     Count{How many<br/>tickets?}
-    Single["task-to-pr<br/>branch -> code<br/>review + verify -> PR"]
+    Single["task-to-pr<br/>branch + worktree -> code<br/>review + verify -> PR"]
     Multi["multitask<br/>classify, isolate<br/>coordinate workers"]
     PRs["PRs ready for review<br/>tests, review<br/>acceptance proof"]
     Ready["pr-to-ready<br/>feedback to ready<br/>never merge"]
@@ -82,7 +82,7 @@ Most skills are steps: one phase, one human checkpoint. Four skills chain the st
 
 Loops keep the ticket updated as they work: status moves, comments with proof, and PR links. They stop at human checkpoints. Merging is always a human decision.
 
-`task-to-pr` is the single-ticket loop: it reads the ticket, creates a branch, implements the acceptance criteria, reviews the diff, checks acceptance, opens a PR ready for review, handles current feedback, and writes proof back to the ticket.
+`task-to-pr` is the single-ticket loop: it reads the ticket, creates a dedicated branch and worktree from the latest remote default branch, implements the acceptance criteria, reviews the diff, checks acceptance, opens a PR ready for review, handles current feedback, and writes proof back to the ticket.
 
 `milestone` is the release-slice loop: it reads open issues in a GitHub milestone, orders them by dependency and risk, then runs `task-to-pr` for each issue. It stops for human merge unless merge permission was explicit. When merging is allowed, it merges only after checks and review are clean, syncs the default branch, then continues.
 

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -1,29 +1,32 @@
 ---
 name: task-to-pr
-description: "Turn one ticket into a PR that is ready for review, with code, tests, review, acceptance checks, and proof."
+description: "Turn one ticket into a PR ready for review in its own branch and worktree, with code, tests, review, acceptance checks, and proof."
 user-invocable: true
 argument-hint: "<ticket reference> e.g. JIRA-123, LIN-123, github#456, https://github.com/owner/repo/issues/456"
 ---
 
 # Task To PR
 
-1. Resolve the ticket: problem, acceptance criteria, PR rules. Stop if it is unclear, already has a PR, spans unrelated work, or needs missing secrets or decisions.
-2. Work in an isolated branch or worktree named with the ticket ID. Protect unrelated local changes.
-3. Implement the smallest complete change. Add or update tests, and docs when user-facing behavior changed.
-4. Run focused checks first, wider ones when shared behavior changed.
-5. Get non-trivial diffs reviewed by another agent or reviewer. If none is available, self-review and say so in the PR body.
-6. Check each acceptance criterion against the ticket. Unmet required criteria block the PR.
-7. Commit with a Conventional Commit subject and ticket ID, push, open a PR ready for review. Body: ticket link, summary, acceptance status, check results, review status.
-8. Handle checks and feedback that arrive during this run: fix actionable items, re-check, push. Stop when clean, when nothing arrives after a reasonable wait, or when a human decision is needed.
-9. Update the ticket with the PR link and proof, move it to the closest review state.
-10. Report ticket, branch, PR URL, checks, feedback handled, and anything blocked or unchecked.
+1. Resolve the ticket and linked context. Capture the goal, acceptance criteria, verification, constraints, and PR rules. Stop if the ticket is unclear, spans unrelated work, duplicates existing work, or needs a missing decision, secret, or permission.
+2. Inspect the repository, remotes, default branch, current worktrees, and open branches or PRs for the ticket. If work already exists, reuse its branch and worktree, or create a worktree for that branch. Never create a duplicate delivery path.
+3. Fetch the remote. For new work, create a ticket-named branch and dedicated worktree from the latest remote default branch. Use another base only when the repo or ticket explicitly requires it. Do all implementation in the dedicated worktree, never the caller's checkout.
+4. Mark the ticket in progress when the tracker supports it. Implement the smallest complete change in the worktree. Add or update tests, and update docs when user-facing behavior changes.
+5. Run focused checks first, then wider checks when shared or user-facing behavior changed. Fix relevant failures without growing the ticket.
+6. Get non-trivial diffs reviewed by a fresh agent or reviewer. Judge each finding, fix valid in-scope issues, and rerun affected checks. If no reviewer is available, self-review and disclose that in the PR.
+7. Check every acceptance criterion against the ticket and record its proof. Unmet required criteria block the PR.
+8. Commit only intended changes with a Conventional Commit subject and ticket ID. Push and open one PR ready for review. Include the ticket link, summary, acceptance proof, checks, review status, and anything not verified.
+9. Handle checks and feedback that arrive during this run. Fix actionable items, re-check, and push. Stop when clean, when nothing arrives after a reasonable wait, or when a human decision is needed.
+10. Update the ticket with the PR link and proof, move it to the closest review state, and report the ticket, base, branch, worktree, PR, checks, review, and blockers.
 
 ## Rules
 
 - One ticket, one branch, one PR. A list of tickets means one worker per ticket.
+- Every ticket runs in a dedicated branch and worktree. New work starts from the latest remote default branch. Keep the original checkout untouched.
+- Reuse an existing branch, worktree, or PR for the ticket instead of creating a duplicate.
+- Branch from unmerged work only when the ticket explicitly depends on it.
 - Never merge. Long-running review watching is a separate run unless asked.
 - Do not open a PR with failing relevant checks or unmet required criteria unless the user asks for an early draft, and disclose it.
 - Do not expand the task for nice-to-have suggestions from review, checks, or bots.
-- Prefer a worktree when the checkout has local changes, is in use, or runs unattended.
-- On failure, keep work local, keep branches and worktrees intact, report exactly what failed.
+- Keep the worktree after opening the PR. Remove it only after merge or when the user asks.
+- On failure, keep the branch and worktree intact and report exactly what failed.
 - Unattended runs report through the ticket, not chat. When blocked: comment proof, apply the needs-human label, release any claim label, exit cleanly.


### PR DESCRIPTION
## Summary

- Make every task-to-pr run use a dedicated branch and worktree.
- Start new work from the latest remote default branch.
- Resume existing ticket branches and PRs without creating duplicate work.
- Keep the worktree until merge or an explicit cleanup request.

## Why

A fixed workspace lifecycle keeps ticket work isolated, protects the caller checkout, and makes concurrent agent work predictable.

## Test plan

- Skill front matter and Markdown fence validation passed.
- git diff --check passed.
- Repository Markdown link check still reports the two pre-existing missing targets: guides/multitask.md and CHANGELOG.md.
- Self-reviewed the final documentation diff; no separate reviewer was available.

## Risks

The stricter workflow requires Git worktree support and a remote default branch. Existing ticket work is reused rather than recreated.

## Related issue

None.
