### PR TITLE
docs: polish documentation and diagrams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Working in Blueprint
+# Blueprint repository policy
 
 Blueprint is a small, principles-first process for AI coding. It separates thinking phases from the workflow that ships code.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
+# Claude Code
+
 @AGENTS.md
 
-## Claude Code adapter
+Blueprint keeps shared repository policy in `AGENTS.md` and only Claude-specific setup here.
 
 Install Blueprint skills with `npx skills add owainlewis/blueprint`. The public skills are `design`, `plan`, `test`, `review`, and `improve`.
 
@@ -8,7 +10,8 @@ The Skills CLI does not install commands. Install `/implement` separately for a 
 
 ```bash
 mkdir -p .claude/commands
-curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md -o .claude/commands/implement.md
+curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md \
+  -o .claude/commands/implement.md
 ```
 
 Use `~/.claude/commands/implement.md` instead for a user command. The downloaded file is the canonical workflow; `AGENTS.md` contains portable repository policy.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,36 +1,49 @@
-# Migration to the phase model
+# Migrate to the phase model
 
-This release is intentionally breaking. Blueprint now contains five phase skills and one `/implement` workflow.
+> **Breaking change:** Blueprint now ships five phase skills and one separate `/implement` workflow. Old skill directories must be removed manually.
 
-## New surface
+## What changed
 
-- Skills: `design`, `plan`, `test`, `review`, `improve`
-- Workflow command: `/implement`
+| Before | Now |
+| --- | --- |
+| `design-doc`, `spec` | `design` |
+| `browser-verify` | Browser proof inside `test` |
+| `refactor` | `improve` |
+| `branch`, `commit`, `implement`, `pr`, `pr-to-ready`, `task-to-pr` | `/implement` workflow |
+| `debug`, `tdd` | Techniques used while implementing |
+| `goal-design`, `milestone`, `multitask` | Ordinary instructions or project-specific workflows |
+| `code-reviewer` agent definition | A fresh generic subagent launched by `review` |
 
-## Removed skills
+The public skill surface is now:
 
-`branch`, `browser-verify`, `commit`, `debug`, `design-doc`, `goal-design`, `implement`, `milestone`, `multitask`, `pr`, `pr-to-ready`, `refactor`, `spec`, `task-to-pr`, and `tdd` are no longer shipped.
-
-The behavior is not all lost. Design docs and specs became `design`. Browser verification moved into `test`. Refactoring became `improve`. Ticket-to-PR delivery, commits, CI, feedback handling, and PR feedback moved into the `/implement` workflow. Debugging and TDD remain techniques an agent can use while implementing.
+```text
+design · plan · test · review · improve
+```
 
 ## Clean upgrade
 
-First remove only the old Blueprint skill directories from the skill location used by your agent. Then reinstall:
+1. **Find the skill directory used by your coding tool.** Remove only the old Blueprint skill folders listed above. Do not delete the whole directory; it may contain unrelated skills.
+2. **Reinstall the phase skills.**
 
-```bash
-npx skills add owainlewis/blueprint
-```
+   ```bash
+   npx skills add owainlewis/blueprint
+   ```
 
-Do not delete the whole skills directory because it may contain unrelated skills. Some noninteractive skill updaters do not remove directories that disappeared upstream, so `npx skills update` alone can leave both models installed.
+3. **Install `/implement` separately.** The Skills CLI does not install commands. For Claude Code at project scope:
 
-The Skills CLI does not install commands. Download the workflow separately to your tool's custom-command directory:
+   ```bash
+   mkdir -p .claude/commands
+   curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md \
+     -o .claude/commands/implement.md
+   ```
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md -o /path/to/custom/commands/implement.md
-```
+   For another tool, change the output path to its custom-command directory. Without custom commands, use the [raw workflow](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md) as an ordinary prompt.
 
-If the tool does not support slash commands, [open the raw command](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md) and invoke it as an ordinary prompt. Keep only a reference to the canonical command in your repository instructions.
+4. **Remove copied reviewer agents.** Delete any old Blueprint `code-reviewer` definition. The `review` skill now launches a fresh generic subagent.
+5. **Check the result.** Skill discovery should list exactly `design`, `plan`, `test`, `review`, and `improve` for Blueprint.
 
-Remove any copied `code-reviewer` agent definition. The `review` skill now asks the coding tool for a fresh generic subagent, which avoids a second source of review policy.
+## Why cleanup is manual
 
-There are no compatibility aliases. Keeping old and new entry points together makes routing ambiguous and defeats the purpose of the smaller model.
+Some noninteractive skill updaters add and replace skills but do not remove directories that disappeared upstream. Running `npx skills update` alone can therefore leave the old and new models installed together.
+
+Blueprint intentionally provides no compatibility aliases. Duplicate entry points make routing ambiguous and defeat the smaller phase model.

--- a/README.md
+++ b/README.md
@@ -1,71 +1,83 @@
+<div align="center">
+
 # Blueprint
 
-Blueprint is a small, principles-first workflow for AI coding.
+**A small, principles-first workflow for AI coding.**
 
-Agents are already good at writing code. They need clear decisions, bounded work, real proof, and independent review. Blueprint provides those boundaries without turning engineering into a catalogue of tiny skills.
+Clear decisions. Bounded work. Real proof. Independent review.
 
-## The model
+</div>
 
-There are three layers:
+Blueprint gives coding agents the engineering boundaries that matter without turning software delivery into a catalogue of tiny skills. It separates repository policy, reusable phases, and end-to-end workflows so each instruction has one clear job.
 
-1. **Repository instructions define policy.** `AGENTS.md` says what good work means in a codebase.
-2. **Skills define phases.** Each skill has one durable engineering outcome.
-3. **Commands compose workflows.** `/implement` takes one task through the phases to a pull request.
+## Start with the work, not the process
 
-```text
-idea -> design -> plan -> task
-                         |
-                         v
-                    /implement
-                         |
-                         v
-isolate -> code -> test -> review -> green PR -> human merge
-                  ^         |
-                  +-- fix ---+
+Use the smallest entry point that resolves the uncertainty in front of you.
 
-existing code -> improve -> simpler code
+| If you need to… | Start with | Result |
+| --- | --- | --- |
+| Decide what to build or resolve important technical choices | `design` | A reviewed design with requirements and acceptance criteria |
+| Split a decided feature into work for several agent runs | `plan` | Ordered tasks in chat or tracker tickets |
+| Take one task through delivery | `/implement` | A tested, reviewed, green pull request |
+| Prove a change works | `test` | Acceptance criteria mapped to evidence |
+| Get an independent second opinion | `review` | Findings and a pre-merge verdict from a fresh subagent |
+| Simplify existing code without changing behavior | `improve` | Clearer, smaller, better-structured code |
+
+Small, decided work can go straight to `/implement`. Use `design` only when decisions need review, and `plan` only when the work needs splitting.
+
+## How Blueprint fits together
+
+```mermaid
+flowchart TB
+    subgraph Decide["Decide only as much as needed"]
+        Idea([Idea or problem]) --> Design["design"]
+        Idea -->|already decided| Task([One task])
+        Design -->|one task| Task
+        Design -->|needs splitting| Plan["plan"] --> Task
+    end
+
+    subgraph Deliver["Deliver with /implement"]
+        Task --> Isolate["isolate"] --> Code["code"] --> Test["test"] --> Review["review"]
+        Review -->|findings| Fix["fix"] --> Test
+        Review -->|clean| Publish["publish PR"] --> Validate["CI + current feedback"]
+        Validate -->|failure or finding| Fix
+        Validate -->|clean| PR["green PR"]
+    end
+
+    PR --> Merge([Human merge])
+    Existing([Existing code]) --> Improve["improve"] --> Simpler([Simpler code])
 ```
 
-Use only the phases the work needs. A small, decided task can start at `/implement`. A costly or unclear change should start at `design`. A large design can go through `plan` before implementation.
+The model has three layers:
 
-## Principles
+1. **Repository instructions define policy.** `AGENTS.md` says what good work means in a codebase.
+2. **Skills define phases.** Each skill has one durable engineering outcome and a clear stopping point.
+3. **Commands compose workflows.** `/implement` connects normal delivery steps without turning each one into a skill.
 
-- **Encode process, not knowledge.** Skills define outcomes and boundaries. Agents choose the local mechanics.
-- **One skill per phase.** A skill should represent a reusable mode of work, not one shell command or one job title.
-- **Workflows compose phases.** Ticket lookup, worktrees, commits, pull requests, CI, and feedback are one delivery workflow.
-- **Proof is part of the work.** Acceptance criteria map to tests or explicit manual evidence. Browser behavior is checked in a real browser.
-- **Review must be independent.** A fresh subagent reviews the diff and its proof. A named reviewer persona adds little value.
-- **The source of truth can change.** When implementation exposes a bad requirement, update the ticket or design before continuing.
-- **Prefer less.** Keep the smallest complete change, the shortest useful instruction, and no duplicate entry points.
-- **Humans own irreversible judgment.** Agents prepare a green PR. A human merges unless they explicitly delegate it.
+## The five phases
 
-## Skills
-
-| Skill | Outcome | Stops when |
+| Skill | Owns | Stops when |
 | --- | --- | --- |
-| `design` | A reviewed description of what, why, requirements, acceptance criteria, technical design, constraints, risks, and scope | The design is written for human review |
-| `plan` | Ordered, agent-ready tasks and optional milestones | The tasks are ready to hand off |
-| `test` | Acceptance criteria and important failures have evidence | Each criterion is pass, fail, or explicitly unverified |
-| `review` | A fresh subagent has independently reviewed the change | Findings and a verdict are reported |
-| `improve` | Existing code is clearer, simpler, and better structured without changing intended behavior | Relevant tests prove behavior was preserved |
+| `design` | What, why, requirements, acceptance criteria, technical design, constraints, risks, and scope | The design is ready for human review |
+| `plan` | Vertical, ordered tasks and optional milestones | The work is ready to hand off |
+| `test` | Automated checks, failure paths, and real-browser proof when relevant | Every criterion is pass, fail, or explicitly unverified |
+| `review` | Independent review of correctness, security, regressions, complexity, and proof | Findings and a verdict are reported |
+| `improve` | Behavior-preserving simplification of existing code | Relevant checks prove behavior was preserved |
 
-There is no `build` skill. Writing code is a base agent capability. There are no separate skills for branching, committing, opening a PR, debugging, TDD, browser checking, or addressing feedback. Those are techniques or steps inside a phase or workflow.
+Writing code is a base capability, not a phase skill. Branching, committing, opening a PR, debugging, TDD, browser checking, and addressing feedback are techniques or workflow steps, not separate product concepts.
 
-## `/implement`
+## One task to one pull request
 
-`commands/implement.md` is the canonical end-to-end workflow. Give it one ticket, task, or existing PR. It:
+[`commands/implement.md`](commands/implement.md) is the single authority for delivery. Given a ticket, task, or existing PR, it:
 
-1. resolves the task or PR, creating a ticket only when requested or useful for durable tracking;
-2. isolates work before editing by resuming the PR worktree or branching from the latest remote default branch;
-3. inspects the code, outlines the change without invoking `plan`, and writes the smallest complete implementation;
-4. runs `test`, including real-browser verification when relevant;
-5. runs `review` with a fresh subagent;
-6. addresses valid findings, then repeats tests and review until clean;
-7. creates Conventional Commits, pushes, and opens a ready PR;
-8. waits for CI to finish, then handles feedback that currently exists without waiting indefinitely for future review;
-9. stops at a green, mergeable PR for a human to merge.
+1. resolves the source and isolates work before editing;
+2. implements the smallest complete change;
+3. runs `test` and independent `review` loops;
+4. creates Conventional Commits and opens or updates the PR;
+5. waits for CI, handles feedback that exists, and records evidence;
+6. stops at a green, mergeable PR for a human to merge.
 
-This command is the single workflow authority. `AGENTS.md` points to it instead of carrying a second copy. Agents without slash commands can read it as an ordinary prompt. Tool-specific command locations are adapters, not new product concepts.
+It does not wait forever for future human feedback, manufacture tracker artifacts for trivial work, or merge without explicit permission.
 
 ## Install
 
@@ -75,27 +87,48 @@ Install the five skills:
 npx skills add owainlewis/blueprint
 ```
 
-The Skills CLI installs skills, not `commands/implement.md`. Download the command separately. For a project-level Claude Code command:
+The Skills CLI does not install commands. For a project-level Claude Code command:
 
 ```bash
 mkdir -p .claude/commands
-curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md -o .claude/commands/implement.md
+curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md \
+  -o .claude/commands/implement.md
 ```
 
-For another coding tool, change the output path to its custom-command directory. You can also [open the raw command](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md) and invoke it as an ordinary prompt. Repository policy stays in `AGENTS.md`; the delivery workflow stays in the command.
+For another coding tool, download the [raw command](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md) to its custom-command directory or use it as an ordinary prompt.
 
-If you installed an older Blueprint release, read [MIGRATION.md](MIGRATION.md). Skill updaters may leave removed directories behind, so updating alone may not give you the new five-skill surface.
+Upgrading from the older skill catalogue? Follow the [migration guide](MIGRATION.md). Removed skills can remain installed after a normal update, so the cleanup step matters.
+
+## Repository map
+
+```text
+skills/                 five reusable engineering phases
+commands/implement.md   canonical task-to-PR workflow
+AGENTS.md                portable repository policy
+CLAUDE.md                Claude Code adapter
+REVIEW.md                review standard for Blueprint itself
+MIGRATION.md             clean upgrade from the old catalogue
+examples/                reviewed design and planning examples
+```
 
 ## Examples
 
-The RAG chatbot example shows the full decision flow:
+The RAG chatbot example follows one idea through the decision flow:
 
-1. [rough input](examples/input.md)
+1. [rough project notes](examples/input.md)
 2. [reviewed design](examples/rag-chatbot/design.md)
 3. [captured chat plan](examples/rag-chatbot/plan.md)
 
-The [Dispatch control-plane design](examples/dispatch-control-plane/design.md) is a larger architecture example.
+For a larger architecture example, read the [Dispatch local control-plane design](examples/dispatch-control-plane/design.md).
 
-## What Blueprint is not
+## Principles
 
-Blueprint is not an issue tracker, agent framework, release system, reviewer persona library, or unattended state machine. It is a compact set of phase instructions plus one normal code-delivery workflow.
+- **Encode process, not knowledge.** Give agents outcomes, constraints, and proof; trust them with local mechanics.
+- **One skill per phase.** A skill represents a durable mode of work, not a command or job title.
+- **Proof is part of the work.** Tests establish behavior. Review checks that the implementation and proof are sound.
+- **Use the real surface.** Browser behavior is checked in a browser. Live PR feedback is read from the PR.
+- **Fix the source of truth.** If implementation exposes a bad requirement, update the task or design before continuing.
+- **Prefer less.** Keep the smallest complete change, shortest useful instruction, and no duplicate entry points.
+- **Keep irreversible judgment human.** Agents prepare the decision. Humans review designs and merge pull requests unless they explicitly delegate it.
+
+Blueprint is not an issue tracker, agent framework, release system, or reviewer-persona library. It is a compact engineering process for capable coding agents.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ flowchart TB
     end
 
     PR --> Merge([Human merge])
+    Merge ~~~ Existing
     Existing([Existing code]) --> Improve["improve"] --> Simpler([Simpler code])
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ flowchart TB
     end
 
     PR --> Merge([Human merge])
-    Merge ~~~ Existing
-    Existing([Existing code]) --> Improve["improve"] --> Simpler([Simpler code])
 ```
+
+`improve` is a separate maintenance path for existing code, not a step every change must pass through.
 
 The model has three layers:
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,6 +1,6 @@
-# Review Blueprint changes
+# Review Blueprint
 
-Review this repository as a small process product, not a prompt catalogue.
+Review Blueprint as a small process product, not a prompt catalogue. Read the issue, complete diff, rendered public docs, and relevant surrounding files.
 
 - Does each skill represent one meaningful engineering phase?
 - Is policy in `AGENTS.md`, phase behavior in a skill, and orchestration in a command?

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -7,17 +7,17 @@ argument-hint: "<ticket, task, or PR>"
 
 Follow this workflow for `$ARGUMENTS`:
 
-1. Resolve `$ARGUMENTS`. Resume an existing PR and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or PRs.
-2. Set up isolated work before editing. Resume the branch and worktree for an existing PR. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its PR is merged or closed.
-3. Read the repository instructions and inspect the relevant code.
-4. Outline the smallest complete change and check it against the ticket, task, or PR. This is a local execution outline, not the `plan` phase. Do not create tickets or a plan document.
-5. Implement the changes and add tests where necessary.
-6. Run the `test` phase, including real-browser checks for browser-rendered behavior.
-7. Run the `review` phase with a fresh subagent to review the diff independently.
-8. Address valid review findings, then rerun affected tests and fresh review.
-9. Create a Conventional Commit, push the branch, and open or update a ready pull request. Link the ticket when one exists and include test and review evidence.
-10. Wait for CI checks to finish. Fix relevant failures and rerun affected tests and review until required checks pass. If no checks are configured, continue.
-11. Inspect the human and bot feedback available at that point. Fix important findings, reply to addressed comments with evidence, and rerun affected tests and fresh review. Do not wait indefinitely for future human feedback.
+1. **Resolve the source.** Resume an existing PR and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or PRs.
+2. **Isolate the work before editing.** Resume the branch and worktree for an existing PR. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its PR is merged or closed.
+3. **Read the context.** Read the repository instructions and inspect the relevant code.
+4. **Outline the change.** Define the smallest complete change and check it against the ticket, task, or PR. This is a local execution outline, not the `plan` phase. Do not create tickets or a plan document.
+5. **Implement.** Make the change and add tests where necessary.
+6. **Test.** Run the `test` phase, including real-browser checks for browser-rendered behavior.
+7. **Review.** Run the `review` phase with a fresh subagent.
+8. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
+9. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request. Link the ticket when one exists and include test and review evidence.
+10. **Finish CI.** Wait for checks to finish. Fix relevant failures and rerun affected tests and review until required checks pass. If no checks are configured, continue.
+11. **Handle current feedback.** Inspect the human and bot feedback available at that point. Fix important findings, reply to addressed comments with evidence, and rerun affected tests and fresh review. Do not wait indefinitely for future human feedback.
 
 Commit and push every post-PR fix before reassessing checks or feedback.
 

--- a/examples/dispatch-control-plane/design.md
+++ b/examples/dispatch-control-plane/design.md
@@ -1,298 +1,199 @@
-# Design: Dispatch Local Agent Control Plane
+# Dispatch local agent control plane
 
-## Status
+> **Status:** Proposed for review
+>
+> **Scope:** Local-first v1 architecture
 
-Draft
+## What and why
 
-## Summary
+Dispatch lets a developer delegate agent work from a web control plane instead of managing every run in an interactive terminal. A local worker claims tasks, runs explicit shell and agent steps, streams evidence back, and preserves enough run history for review and follow-up.
 
-Dispatch is a local-first control plane for delegated agent work. A Next.js app owns the UI, API routes, and JSON-backed state. A Go worker process registers itself, long-polls for pending tasks, runs shell and agent steps, streams events back, and reports completion. This design documents the current minimal architecture and the tradeoffs behind keeping orchestration explicit rather than hiding it inside a workflow engine.
+The first version should prove this delegation loop without committing to production infrastructure. It favors inspectable local state and explicit execution over hidden automation.
 
-## Background
+## Requirements
 
-The `dispatch` repo contains a prototype for running AI agents as delegated workers instead of interactive terminal sessions.
+- Developers can create tasks from a web UI or API.
+- One or more local workers can register, heartbeat, claim tasks, and report completion.
+- Tasks contain ordered shell and agent steps.
+- Runs retain comments, status, and ordered event streams for review.
+- Follow-up replies can continue a completed Claude Code session.
+- The control plane starts with `just dev`; workers run as separate processes.
+- Checkout, setup, test, and push behavior remains explicit in task steps.
 
-Current repo layout:
+## Acceptance criteria
 
-```text
-control-plane/   Next.js UI, API routes, local store, shared types
-worker/          Go worker CLI
-docs/            specs, architecture notes, mockups
-scripts/         local helper commands, including fake Claude
-```
+- A developer can create a task and see it move from `pending` to `running` to `succeeded` or `failed`.
+- A worker claims at most one task at a time and executes its steps in order.
+- Shell and agent output appears in the task event stream with stable sequence numbers.
+- A failed step stops the remaining steps and records the failure.
+- A follow-up comment creates a new run and can reuse the prior Claude session ID.
+- The full local flow works with `scripts/fake-claude` before a real agent runtime is required.
 
-The control plane stores data in `.agentctrl-data/store.json` by default. The worker registers a host and worker, polls the control plane, claims one task at a time, executes task steps, streams task events, and completes the task. Claude Code is the intended real runtime; `scripts/fake-claude` supports local smoke testing.
+## Design
 
-This design covers the local v1 architecture, not the eventual production design with Postgres, auth, multi-tenant projects, budgets, or agent-created task trees.
-
-## Goals
-
-- Let a developer create tasks from a web UI or API.
-- Let one or more local workers claim and run tasks.
-- Support ordered task steps: shell steps and agent steps.
-- Capture task runs, comments, and event streams for review.
-- Support Claude Code sessions so replies to a completed task can continue the same task context.
-- Keep the prototype easy to run with `just dev` plus a separate worker command.
-
-## What Not to Solve
-
-- Production durability, horizontal control-plane scaling, or multi-user auth.
-- Managing worker machines or provisioning workspaces.
-- Hiding checkout, setup, branch, or push behavior behind special workflow types.
-- Supporting every agent runtime equally in v1.
-- Building a full distributed scheduler.
-
-## Limits
-
-- The control plane is a Next.js app with API routes under `control-plane/app/api`.
-- The worker is a Go CLI under `worker/cmd/agentctrl-worker`.
-- Storage is local JSON, so concurrent writes and long-term durability are intentionally limited.
-- One worker runs one task at a time.
-- Task lifecycle is currently `pending -> running -> succeeded | failed`.
-- Task steps must be explicit so users can compose checkout, setup, agent, test, and push behavior themselves.
-
-## Proposed Design
-
-Dispatch uses a control-plane / worker split.
+Dispatch uses a control-plane and worker split. The Next.js application owns the UI, API, shared TypeScript model, and JSON-backed state. A separate Go process owns local execution.
 
 ```mermaid
 flowchart TB
-    User["Developer"] --> UI["Next.js UI"]
-    UI --> API["Next.js API routes"]
-    API --> Store["Local JSON store<br/>.agentctrl-data/store.json"]
-
-    Worker["Go worker CLI"] -->|register host / worker| API
-    Worker -->|heartbeat| API
-    Worker -->|claim pending task| API
-    Worker -->|stream events| API
-    Worker -->|complete run| API
-
-    Worker --> Shell["Shell step"]
-    Worker --> Agent["Agent step<br/>Claude Code or fallback command"]
+    Developer([Developer]) --> UI["Next.js UI"]
+    UI --> API["Control-plane API"]
+    API <--> Store[("Local JSON store")]
+    API <-->|tasks · status · events| Worker["Go worker"]
+    Worker -->|execute| Shell["Local shell"]
+    Worker -->|delegate| Agent["Claude Code"]
 ```
 
-### Control Plane
+### Control plane
 
-The control plane owns durable state for the prototype:
+The control plane stores hosts, workers, tasks, runs, steps, comments, and events in `.agentctrl-data/store.json`. API routes create tasks, serve UI state, register workers, assign pending work, append events, and complete runs.
 
-- hosts
-- workers
-- tasks
-- task runs
-- task steps
-- comments
-- events
-
-The API creates tasks, returns current state to UI pages, accepts host and worker registration, lets workers claim tasks, records step status, appends events, and marks runs complete.
-
-The store is implemented in `control-plane/lib/store.ts`. All mutations happen through `withStore`, which reads the JSON file, mutates an in-memory object, and writes it back.
+All mutations pass through `withStore` in `control-plane/lib/store.ts`, which reads the file, changes an in-memory object, and writes the result. This is sufficient for a local prototype but is not a production concurrency model.
 
 ### Worker
 
-The worker CLI:
+The worker:
 
-1. Registers a host with labels such as `local` or `macos`.
-2. Registers a worker attached to that host.
-3. Heartbeats on each polling loop.
-4. Claims a pending task when available.
-5. Runs the task's steps sequentially.
-6. Streams system/stdout/stderr/agent events back to the control plane.
-7. Completes the run and task with `succeeded` or `failed`.
+1. registers its host and worker identity;
+2. heartbeats while polling;
+3. claims one pending task;
+4. executes its steps sequentially;
+5. streams system, stdout, stderr, and agent events;
+6. completes the run and task as `succeeded` or `failed`.
 
-For agent steps, the worker uses a structured Claude Code adapter when the command basename is `claude`. Other commands use the generic fallback contract:
+Claude Code has a structured adapter. Other agent commands use the fallback contract:
 
 ```text
 <command> -p "<task prompt>"
 ```
 
-### Tasks and Runs
+### Tasks, runs, and events
 
-A task is the user-facing work item. A run is an execution attempt for that task. A task can have multiple runs, which enables follow-up replies after an initial task completes.
+A task is the user-facing unit of work. A run is one execution attempt. A task can have several runs so a follow-up can continue the same work without rewriting history.
 
 ```mermaid
 classDiagram
+    Task "1" --> "*" TaskRun : attempts
+    Task "1" --> "*" TaskStep : defines
+    TaskRun "1" --> "*" TaskEvent : records
+    TaskRun "0..1" --> "0..1" TaskComment : triggered by
+
     class Task {
-      id
-      title
-      prompt
-      workDir
-      status
-      currentRunId
-      latestRunId
+        id
+        title
+        prompt
+        workDir
+        status
     }
     class TaskRun {
-      id
-      taskId
-      status
-      prompt
-      triggerCommentId
-      sessionId
-      workDir
+        id
+        taskId
+        status
+        sessionId
     }
     class TaskStep {
-      id
-      taskId
-      index
-      type
-      command
-      prompt
-      status
+        index
+        type
+        command
+        status
     }
     class TaskEvent {
-      id
-      taskId
-      runId
-      seq
-      stream
-      message
+        seq
+        stream
+        message
     }
-
-    Task "1" --> "*" TaskRun
-    Task "1" --> "*" TaskStep
-    TaskRun "1" --> "*" TaskEvent
+    class TaskComment {
+        id
+        author
+        body
+    }
 ```
 
-### Step Execution
-
-Steps execute in order. A shell step runs with `sh -lc`. An agent step runs Claude Code or the fallback command. A failed step stops the task and reports failure.
+### Execution
 
 ```mermaid
 sequenceDiagram
     participant W as Worker
-    participant API as Control Plane API
-    participant S as Shell
-    participant A as Agent CLI
+    participant API as Control-plane API
+    participant R as Step runtime
 
-    W->>API: claim(workerId, hostId)
-    API-->>W: task with run and steps
-    loop each step
-        W->>API: step running
-        alt shell step
-            W->>S: run command
-            S-->>W: output + exit code
-        else agent step
-            W->>A: run prompt
-            A-->>W: events + exit code
-        end
-        W->>API: append events
-        W->>API: step succeeded or failed
+    W->>API: Claim next task
+    API-->>W: Task, run, and ordered steps
+    loop Each step
+        W->>API: Mark step running
+        W->>R: Execute shell command or agent prompt
+        R-->>W: Output, events, and exit code
+        W->>API: Append events and step result
     end
-    W->>API: complete run
+    alt Every step succeeds
+        W->>API: Complete run as succeeded
+    else A step fails
+        W->>API: Complete run as failed
+    end
 ```
 
-## Architecture Views
+## Interfaces and data
 
-### System Context
+The shared TypeScript model is the contract between the UI, API, store, and worker responses.
 
-```mermaid
-flowchart LR
-    Developer["Developer"] --> Dispatch["Dispatch Control Plane"]
-    Dispatch --> Worker["Local Worker"]
-    Worker --> Claude["Claude Code"]
-    Worker --> Shell["Local Shell"]
-    Dispatch --> Store["Local JSON Store"]
-```
+| Type | Purpose |
+| --- | --- |
+| `Host` | Machine identity and labels |
+| `Worker` | Runtime process attached to a host |
+| `Task` | User-facing work item and current state |
+| `TaskStep` | Ordered shell or agent operation |
+| `TaskRun` | Execution attempt and optional Claude session ID |
+| `TaskComment` | User, agent, or system comment |
+| `TaskEvent` | Ordered output or lifecycle event |
 
-### Runtime View
+Task creation accepts a title, prompt, optional working directory, and optional step definitions. When no usable steps are supplied, the control plane creates one default agent step from the task prompt.
 
-```mermaid
-flowchart TD
-    Create["Create task"] --> Pending["Task pending"]
-    Pending --> Claim["Worker claims task"]
-    Claim --> Running["Task running"]
-    Running --> Steps{"More steps?"}
-    Steps -->|Yes| Execute["Run next shell or agent step"]
-    Execute --> Event["Record events and output"]
-    Event --> Failed{"Step failed?"}
-    Failed -->|No| Steps
-    Failed -->|Yes| TaskFailed["Task failed"]
-    Steps -->|No| Succeeded["Task succeeded"]
-```
+## Failure behavior
 
-## Interfaces and Data
+- A failed step stops the task and records its output and exit status.
+- A worker claims only one task, preventing parallel execution inside one process.
+- Heartbeats expose disconnected workers, but v1 does not reclaim abandoned tasks automatically.
+- Corrupt or concurrent JSON writes are local-prototype risks; production use requires transactional storage.
+- Shell commands and agent runtimes execute with the local user's permissions. There is no sandbox or secret boundary in v1.
 
-The current TypeScript model is the contract between UI, API routes, local store, and worker responses.
+## Test approach
 
-Important types:
+- Start the control plane and a worker using `scripts/fake-claude`.
+- Create a task containing both shell and agent steps.
+- Verify ordered execution, event sequence numbers, and terminal status in the UI.
+- Force a step failure and verify later steps do not run.
+- Add a follow-up comment and verify a new run preserves the previous history and session ID.
+- Repeat the happy path with a real Claude Code worker before declaring the adapter complete.
 
-- `Host`: machine identity and labels
-- `Worker`: runtime process attached to a host
-- `Task`: user-facing unit of work
-- `TaskStep`: ordered shell or agent operation
-- `TaskRun`: execution attempt with optional Claude session ID
-- `TaskComment`: user, agent, or system comment
-- `TaskEvent`: ordered event stream for audit and UI display
+## Risks
 
-Task creation accepts a title, prompt, optional working directory, and optional step definitions. If no usable steps are provided, the control plane creates a default agent step using the task prompt.
+| Risk | Consequence | Mitigation for v1 |
+| --- | --- | --- |
+| JSON storage | Lost updates under concurrent writes | Keep v1 local and serialize mutations through `withStore` |
+| Long polling | Extra latency and repeated requests | Accept the tradeoff until the delegation loop is proven |
+| TypeScript and Go models drift | Runtime contract failures | Keep the model small; consider generated clients before production |
+| Local command execution | Host access and secret exposure | Limit v1 to developer-controlled machines and document the trust boundary |
+| Explicit task steps | More setup for users | Provide useful defaults without hiding the execution model |
 
-## Other Options
+## Alternatives considered
 
-### Put the worker inside the Next.js app
-
-This would make local startup simpler, but it couples task execution to the web server process. A separate worker better matches the long-term architecture where workers run on different machines and the control plane only coordinates.
-
-### Use Postgres immediately
-
-Postgres would improve durability, concurrency, and queryability, but it adds setup friction. Local JSON is enough for the v1 prototype and keeps the core loop easy to inspect.
-
-### Make tasks a single prompt only
-
-A single prompt is simpler, but real delegated work often needs checkout, setup, agent execution, tests, and push steps. Explicit shell and agent steps keep those operations visible and composable.
-
-### Hide git and workspace behavior inside Dispatch
-
-Hardcoding worktrees, clones, branches, and pushes would make the product opinionated too early. Keeping them as shell steps lets each project encode its own workflow.
-
-## Tradeoffs
-
-- Local JSON keeps the prototype simple but is not safe for high-concurrency writes.
-- Long-polling is easy to implement and debug but less efficient than a push-based worker protocol.
-- Explicit steps make workflows transparent but require users to compose more up front.
-- A Go worker adds a second language to the repo but gives a small, portable process for task execution.
-- Claude Code receives first-class adapter behavior, while other runtimes only get the generic command contract.
-
-## Cross-Cutting Concerns
-
-### Reliability
-
-Workers heartbeat and claim one task at a time. The prototype has basic failure reporting, but lease expiry, reclaiming abandoned tasks, and durable concurrency should be revisited before production.
-
-### Observability
-
-Task events are first-class records with sequence numbers, stream names, messages, and timestamps. This gives the UI enough data to show what happened during a run.
-
-### Security
-
-The prototype runs shell commands and agent CLIs on machines the developer controls. There is no sandbox, auth boundary, or secret isolation in the local v1. Production use would need authentication, scoped worker tokens, secret handling, and workspace isolation.
-
-### Maintainability
-
-The shared TypeScript types keep the control-plane model explicit. The risk is drift between the TypeScript API contract and the Go worker structs, since there is no generated client.
-
-### Operations
-
-Developers start the control plane with `just dev` and start workers separately. This makes the control plane and worker lifecycle visible during development.
+- **Run workers inside Next.js.** Simpler startup, but task execution would share the web server lifecycle and make remote workers harder later.
+- **Start with Postgres.** Better durability and concurrency, but unnecessary setup before the local loop is validated.
+- **Represent every task as one prompt.** Smaller model, but no explicit checkout, setup, test, or push steps.
+- **Hide Git and workspace operations.** Easier demos, but forces project-specific policy into Dispatch too early.
 
 ## Rollout
 
-The current architecture is already suitable for a local prototype:
+1. Prove the complete flow with the fake agent runtime.
+2. Run real local Claude Code tasks and follow-ups.
+3. Validate failure reporting and abandoned-worker behavior.
+4. Replace JSON with Postgres while preserving task, run, step, comment, and event concepts.
+5. Add authentication, worker tokens, secret handling, and workspace isolation before networked or multi-user use.
 
-1. Run the Next.js control plane.
-2. Start a fake worker with `scripts/fake-claude`.
-3. Create a task with shell and/or agent steps.
-4. Verify task events, runs, and completion in the UI.
-5. Start a Claude Code worker for real agent runs.
+## Out of scope
 
-The likely next migration is replacing the JSON store with Postgres while preserving the same task, run, step, comment, and event concepts.
-
-## Open Questions
-
-- Should task status include a human review state between `running` and terminal states?
-- How should failed tasks be retried while preserving run history?
-- Should the Go worker consume an OpenAPI-generated client to prevent API contract drift?
-- What is the minimum auth model for local network use?
-- When should agent-created child tasks enter the model?
-
-## Decision
-
-Keep Dispatch v1 as a local-first control plane with a Next.js API/UI, JSON-backed state, and a separate Go worker. Preserve explicit shell and agent steps as the core composition primitive. Defer production durability, auth, and agent-created task trees until the local delegation loop is proven.
+- Production durability or horizontally scaled control planes
+- Multi-user authentication and tenant isolation
+- Worker-machine provisioning
+- A distributed scheduler or lease-recovery system
+- Budgets and agent-created task trees
+- Equal first-class support for every agent runtime

--- a/examples/input.md
+++ b/examples/input.md
@@ -5,6 +5,7 @@ Build a Python RAG chatbot API. Users upload PDF documents, the system chunks an
 Stack: FastAPI, PostgreSQL with pgvector for embeddings, OpenAI API for embeddings and chat completion. Use UV for package management.
 
 Endpoints:
+
 - POST /api/v1/documents - upload a PDF, chunk it, embed it, store it
 - POST /api/v1/chat - send a message, retrieve relevant chunks, return an AI-generated answer with source references
 - GET /api/v1/documents - list uploaded documents
@@ -15,12 +16,14 @@ Keep it simple. Single user, no auth for now. The chunking strategy does not nee
 Should be deployable with Docker Compose (API + Postgres).
 
 Expected behavior:
+
 - Non-PDF uploads fail clearly.
 - Missing document deletion returns a not-found error.
 - Upstream OpenAI failures return an upstream error.
 - When no document chunk is relevant, the chat endpoint returns a fixed "no relevant information" answer instead of making something up.
 
 Testing:
+
 - Use pytest.
 - Mock OpenAI calls in tests.
 - Use a small PDF fixture with known text so chat and source references can be verified.

--- a/examples/rag-chatbot/design.md
+++ b/examples/rag-chatbot/design.md
@@ -1,5 +1,9 @@
 # RAG Chatbot API
 
+> **Status:** Reviewed example
+>
+> **Source:** [`examples/input.md`](../input.md)
+
 ## What and why
 
 Build a Python API that lets one user upload PDFs and ask questions answered from their contents. Answers must be grounded in retrieved chunks so the service does not invent information outside the uploaded documents.
@@ -27,6 +31,21 @@ Build a Python API that lets one user upload PDFs and ask questions answered fro
 ## Design
 
 Use FastAPI for HTTP, PostgreSQL with pgvector for metadata and vector search, and the OpenAI API for embeddings and answer generation. Keep OpenAI behind a small adapter so tests can replace embedding and chat calls with deterministic fakes.
+
+```mermaid
+flowchart TB
+    subgraph Ingest["Document ingestion"]
+        direction LR
+        Upload([Upload PDF]) --> Extract["extract"] --> Chunk["chunk"] --> Embed["embed"] --> Store[("PostgreSQL<br/>+ pgvector")]
+    end
+
+    subgraph Answer["Grounded answer"]
+        direction LR
+        Question([Ask question]) --> Query["embed query"] --> Retrieve["retrieve chunks"] --> Generate["generate from context"] --> Response([Answer + sources])
+    end
+
+    Store --> Retrieve
+```
 
 Store one row per document and many related chunk rows. Each chunk holds text, position, embedding, and document ID. Database cascading removes chunks when a document is deleted.
 

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -6,9 +6,9 @@
 
 A FastAPI service for uploading PDFs and answering questions from their contents using PostgreSQL with pgvector and OpenAI.
 
-Source design: `docs/rag-chatbot/design.md`
+Source design: [RAG chatbot design](design.md)
 
-## Shared Decisions
+## Shared decisions
 
 - Use FastAPI, PostgreSQL with pgvector, Docker Compose, and OpenAI.
 - Use fixed-size chunks with overlap for V1.
@@ -19,38 +19,38 @@ Source design: `docs/rag-chatbot/design.md`
 
 ---
 
-## Phase 1: Foundation
+## Milestone 1: Foundation
 
 Goal: the app starts, connects to the database, and exposes a healthy API shell.
 
 ### Task 1: Local API foundation
 
-**Outcome**
+#### Outcome
 
 The API and database can be started locally, configured from the environment, and checked with a health endpoint.
 
-**Context**
+#### Context
 
 This task creates the base service shape for every later endpoint. It should establish local startup, settings, database connectivity, and the test runner without adding document or chat behavior.
 
-**Constraints**
+#### Constraints
 
 - Use `uv` for Python package management.
 - Use Docker Compose for the API and PostgreSQL with pgvector.
 - Keep configuration in environment variables.
 
-**Acceptance Criteria**
+#### Acceptance criteria
 
 - The API and database start with Docker Compose.
 - `GET /health` returns `{"status":"ok"}` when the API can reach the database.
 - The app fails clearly when required database configuration is missing.
 - A baseline `pytest` run is available for later tasks.
 
-**Design Reference**
+#### Design reference
 
-`docs/rag-chatbot/design.md` covers the stack, Docker Compose surface, environment configuration, and JSON response expectations.
+The [RAG chatbot design](design.md) covers the stack, Docker Compose surface, environment configuration, and JSON response expectations.
 
-**Checks**
+#### Checks
 
 ```bash
 docker compose up -d
@@ -58,33 +58,33 @@ curl http://localhost:8000/health
 pytest
 ```
 
-**Out of Scope**
+#### Out of scope
 
 Document upload, embeddings, retrieval, chat, auth, and deployment beyond local Docker Compose.
 
 ---
 
-## Phase 2: Document Ingestion
+## Milestone 2: Document ingestion
 
 Goal: PDFs can be uploaded, processed, and stored for later retrieval.
 
 ### Task 2: PDF upload and ingestion
 
-**Outcome**
+#### Outcome
 
 Users can upload a PDF and receive a stored document record with chunk count.
 
-**Context**
+#### Context
 
 This task proves the ingestion path: validation, text extraction, chunking, embeddings, and persistence. Later document and chat tasks depend on the stored document and chunk data.
 
-**Constraints**
+#### Constraints
 
 - Accept PDFs only.
 - Use fixed-size chunks of about 500 tokens with about 50 tokens of overlap.
 - Mock OpenAI calls in tests.
 
-**Acceptance Criteria**
+#### Acceptance criteria
 
 - `POST /api/v1/documents` accepts a PDF and returns `{id, filename, uploaded_at, chunk_count}`.
 - Uploaded PDFs are stored with chunks and embeddings that can be queried later.
@@ -92,48 +92,48 @@ This task proves the ingestion path: validation, text extraction, chunking, embe
 - OpenAI embedding failures return `502` with `{error: {code, message}}`.
 - A PDF fixture exists with known text for later retrieval tests.
 
-**Design Reference**
+#### Design reference
 
-`docs/rag-chatbot/design.md` covers document storage, chunking defaults, embedding behavior, upload validation, and upstream OpenAI error behavior.
+The [RAG chatbot design](design.md) covers document storage, chunking defaults, embedding behavior, upload validation, and upstream OpenAI error behavior.
 
-**Checks**
+#### Checks
 
 ```bash
 pytest
 curl -F "file=@tests/fixtures/test.pdf" http://localhost:8000/api/v1/documents
 ```
 
-**Out of Scope**
+#### Out of scope
 
 Document listing, deletion, retrieval, chat, auth, and non-PDF formats.
 
 ### Task 3: Document listing and deletion
 
-**Outcome**
+#### Outcome
 
 Users can list uploaded documents and delete a document with all of its chunks and embeddings.
 
-**Context**
+#### Context
 
 Documents and chunks exist after Task 2. This task adds the document management behavior needed before chat can rely on the stored corpus.
 
-**Constraints**
+#### Constraints
 
 - Do not change upload behavior from Task 2.
 - Deleted chunks must not remain retrievable.
 
-**Acceptance Criteria**
+#### Acceptance criteria
 
 - `GET /api/v1/documents` returns documents with `id`, `filename`, `uploaded_at`, and `chunk_count`.
 - `DELETE /api/v1/documents/{id}` removes the document and its related chunks.
 - Deleting a missing document returns `404` with `{error: {code, message}}`.
 - After deletion, the document no longer appears in the list and its chunks are gone.
 
-**Design Reference**
+#### Design reference
 
-`docs/rag-chatbot/design.md` defines the document listing/deletion API shapes and the invariant that deleting a document also removes its chunks and embeddings.
+The [RAG chatbot design](design.md) defines the document listing/deletion API shapes and the invariant that deleting a document also removes its chunks and embeddings.
 
-**Checks**
+#### Checks
 
 ```bash
 pytest
@@ -141,33 +141,33 @@ pytest
 
 Manual smoke check: upload `tests/fixtures/test.pdf`, list documents, delete the returned ID, then confirm the ID no longer appears in `GET /api/v1/documents`.
 
-**Out of Scope**
+#### Out of scope
 
 Search, chat, cross-user permissions, and soft delete.
 
 ---
 
-## Phase 3: Chat
+## Milestone 3: Grounded chat
 
 Goal: users can ask questions and get grounded answers from uploaded documents.
 
 ### Task 4: Retrieval-backed chat endpoint
 
-**Outcome**
+#### Outcome
 
 Users can ask a question and receive a grounded answer with source references from uploaded PDFs.
 
-**Context**
+#### Context
 
 This task combines vector retrieval, prompt construction, OpenAI chat completion, source formatting, and no-result behavior.
 
-**Constraints**
+#### Constraints
 
 - Retrieve at most 5 chunks for each question.
 - Return sources ordered by relevance.
 - Do not add conversation history or streaming.
 
-**Acceptance Criteria**
+#### Acceptance criteria
 
 - `POST /api/v1/chat` accepts a message and returns `{answer, sources}`.
 - Sources include `document_id`, `filename`, `chunk_index`, and `content`.
@@ -175,11 +175,11 @@ This task combines vector retrieval, prompt construction, OpenAI chat completion
 - If no relevant chunks are found, the endpoint returns `{"answer":"No relevant information found in uploaded documents.","sources":[]}`.
 - OpenAI embedding or chat failures return `502` with `{error: {code, message}}`.
 
-**Design Reference**
+#### Design reference
 
-`docs/rag-chatbot/design.md` covers retrieval defaults, chat response shape, source references, no-information behavior, and upstream OpenAI failure handling.
+The [RAG chatbot design](design.md) covers retrieval defaults, chat response shape, source references, no-information behavior, and upstream OpenAI failure handling.
 
-**Checks**
+#### Checks
 
 ```bash
 pytest
@@ -187,6 +187,6 @@ pytest
 
 Manual smoke check: upload `tests/fixtures/test.pdf`, ask `What database is used for embeddings?`, and confirm the response mentions PostgreSQL with pgvector and includes at least one source.
 
-**Out of Scope**
+#### Out of scope
 
 Conversation history, streaming responses, reranking, and retrieval tuning beyond the V1 defaults.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "<feature, problem, or brief>"
 
 # Design
 
+## Workflow
+
 1. Read the request, repository instructions, relevant code, and linked material.
 2. Resolve choices that would change behavior, interfaces, data, errors, security, operations, or tests. Ask only questions whose answers materially change the design. Recommend an answer when asking.
 3. Write `docs/<feature-slug>/design.md` using the shape below. Keep it short and omit sections that do not apply.
@@ -43,4 +45,7 @@ How each important requirement will be proved.
 - Related work this design does not include.
 ```
 
-Prefer one clear recommendation over a catalogue of options. Record rejected options only when the tradeoff matters later.
+## Boundaries
+
+- Prefer one clear recommendation over a catalogue of options.
+- Record rejected options only when the tradeoff matters later.

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[code, files, diff, branch, or improvement focus]"
 
 # Improve
 
+## Workflow
+
 1. Identify the target from the request, current diff, or recently changed code.
 2. Read the target, its tests, and relevant surrounding code. Establish the behavior that must not change.
 3. Look for unnecessary complexity, duplication, dead code, weak names, awkward boundaries, and abstractions that cost more than they help.
@@ -14,4 +16,8 @@ argument-hint: "[code, files, diff, branch, or improvement focus]"
 5. Preserve public interfaces, data shapes, errors, and user-visible behavior unless the user explicitly asks to change them.
 6. Run the relevant tests and checks. Report what improved, what behavior was preserved, and the evidence.
 
-Do not add product scope or absorb unrelated cleanup. Prefer a few clear edits over a broad rewrite.
+## Boundaries
+
+- Do not add product scope or absorb unrelated cleanup.
+- Prefer a few clear edits over a broad rewrite.
+- Preserve behavior even when a redesign would be easier.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "<design, brief, issue, or request>"
 
 # Plan
 
+## Workflow
+
 1. Read the source, repository instructions, and relevant code.
 2. Stop and return to design if product or technical choices remain open.
 3. Break the work into vertical, outcome-based tasks small enough for one agent run. Order them by dependency. Add milestones only when they create a useful delivery or review boundary.
@@ -18,23 +20,27 @@ Each task must stand alone:
 ```markdown
 ## <Task title>
 
-**Outcome**
+### Outcome
 The working result.
 
-**Context**
+### Context
 What a new agent needs with no session history.
 
-**Constraints**
+### Constraints
 Decisions and behavior that must not change.
 
-**Acceptance criteria**
+### Acceptance criteria
 - Testable condition.
 
-**Checks**
+### Checks
 Exact commands and any required manual verification.
 
-**Out of scope**
+### Out of scope
 Related work this task must not absorb.
 ```
 
-Do not split by file or technical layer when one vertical slice can deliver working behavior. Do not create scaffolding or cleanup tasks without a checked outcome.
+## Boundaries
+
+- Do not split by file or technical layer when one vertical slice can deliver working behavior.
+- Do not create scaffolding or cleanup tasks without a checked outcome.
+- Do not hide unresolved decisions inside implementation tickets.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -9,6 +9,8 @@ argument-hint: "[ticket, design, diff, branch, commit, PR, or file path]"
 
 The reviewer must be a fresh subagent that did not implement the change. Do not edit files.
 
+## Workflow
+
 1. Give the reviewer the task, acceptance criteria, repository guidance, diff or PR, and test evidence.
 2. Have it read the relevant surrounding code and try to prove the change wrong. Check behavior, edge cases, failures, security boundaries, interfaces, compatibility, regressions, scope, complexity, and whether tests exercise the changed behavior.
 3. Have it run focused checks when practical.
@@ -18,8 +20,14 @@ The reviewer must be a fresh subagent that did not implement the change. Do not 
 - **important:** should fix before merge.
 - **nit:** optional; omit unless asked.
 
+## Verdict
+
 If fresh subagents are unavailable, stop and report that independent review is blocked unless the user explicitly accepts a documented self-review.
 
 If there are no findings, say so. End with `Approve`, `Request changes`, or `Blocked`, then state what remains unverified.
 
-Review only the change. Do not turn preferences into findings or approve solely because checks pass.
+## Boundaries
+
+- Review only the change.
+- Do not turn preferences into findings.
+- Do not approve solely because checks pass.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -7,10 +7,16 @@ argument-hint: "<task, acceptance criteria, diff, branch, PR, URL, or flow>"
 
 # Test
 
+## Workflow
+
 1. Read the task, acceptance criteria, changed code, existing tests, and repository instructions.
 2. Map every acceptance criterion and important failure path to proof. Add or update focused tests when proof is missing.
 3. Run the narrowest relevant checks, then wider checks when shared behavior or interfaces changed.
 4. For browser-rendered behavior, start the documented app and verify the main flow and important failure states in a real browser. Check desktop and mobile layout when relevant, keyboard use, console errors, and failed requests. Capture evidence. Source inspection is not browser proof.
 5. Report each criterion as pass, fail, or unverified with the command, browser flow, or evidence that supports it.
 
-Do not weaken assertions to make a change pass. Do not fix unrelated failures. If browser verification is required but no browser tool is available, report the check as blocked unless the user explicitly accepts a manual exception.
+## Boundaries
+
+- Do not weaken assertions to make a change pass.
+- Do not fix unrelated failures.
+- If required browser tooling is unavailable, report the check as blocked unless the user explicitly accepts a manual exception.


### PR DESCRIPTION
## Summary

- redesign the README around a clear reader journey and accurate delivery diagram
- tighten installation, migration, repository policy, command, and skill documentation
- rebuild the examples with consistent structure and five validated Mermaid diagrams

## Why

Blueprint should feel like one coherent documentation product. The previous material was correct but uneven in hierarchy, examples, diagrams, and cross-file presentation.

## Test plan

- `npx --yes skills add . --list` finds exactly five skills
- remote `npx --yes skills add owainlewis/blueprint --list` finds exactly five skills
- YAML frontmatter parses and all descriptions meet metadata limits
- local Markdown links resolve
- `markdown-link-check` passes for README, migration, and Claude adapter links
- all five Mermaid blocks compile with Mermaid CLI
- `bash -n examples/regenerate.sh` passes
- example regeneration passes
- `git diff --check` passes
- fresh independent review: Approve, no blocker or important findings
- live GitHub rendering passes at 1440x1000 and 390x844 for README, tables, code blocks, and all five diagrams
- browser console: no warnings or errors
- GitHub Actions: no checks configured

## Risks

Documentation-only change. Main risk is misleading workflow semantics or poor responsive rendering; both were checked through independent review and the live GitHub surface.

## Related issue

Closes #37