### PR TITLE
docs: show skills as slash commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,11 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 
 ## Phases
 
-- `design`: decide what to build, why, and how. Stop for human review.
-- `plan`: split decided work into ordered, agent-ready tasks. Stop before implementation.
-- `test`: prove acceptance criteria and important failures, including browser checks when relevant.
-- `review`: use a fresh subagent for an independent, read-only review.
-- `improve`: inspect existing code and improve its clarity, simplicity, and structure without changing intended behavior.
+- `/design`: decide what to build, why, and how. Stop for human review.
+- `/plan`: split decided work into ordered, agent-ready tasks. Stop before implementation.
+- `/test`: prove acceptance criteria and important failures, including browser checks when relevant.
+- `/review`: use a fresh subagent for an independent, read-only review.
+- `/improve`: inspect existing code and improve its clarity, simplicity, and structure without changing intended behavior.
 
 Writing code is a base capability, not a separate phase skill. Debugging and test-driven development are implementation techniques, not product-level entry points.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Blueprint keeps shared repository policy in `AGENTS.md` and only Claude-specific setup here.
 
-Install Blueprint skills with `npx skills add owainlewis/blueprint`. The public skills are `design`, `plan`, `test`, `review`, and `improve`.
+Install Blueprint skills with `npx skills add owainlewis/blueprint`. Invoke the public skills as `/design`, `/plan`, `/test`, `/review`, and `/improve`.
 
 The Skills CLI does not install commands. Install `/implement` separately for a project:
 
@@ -16,4 +16,4 @@ curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/
 
 Use `~/.claude/commands/implement.md` instead for a user command. The downloaded file is the canonical workflow; `AGENTS.md` contains portable repository policy.
 
-The `review` phase uses a fresh generic subagent. Blueprint does not require a separate reviewer agent definition.
+The `/review` phase uses a fresh generic subagent. Blueprint does not require a separate reviewer agent definition.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,18 +6,18 @@
 
 | Before | Now |
 | --- | --- |
-| `design-doc`, `spec` | `design` |
-| `browser-verify` | Browser proof inside `test` |
-| `refactor` | `improve` |
+| `design-doc`, `spec` | `/design` |
+| `browser-verify` | Browser proof inside `/test` |
+| `refactor` | `/improve` |
 | `branch`, `commit`, `implement`, `pr`, `pr-to-ready`, `task-to-pr` | `/implement` workflow |
 | `debug`, `tdd` | Techniques used while implementing |
 | `goal-design`, `milestone`, `multitask` | Ordinary instructions or project-specific workflows |
-| `code-reviewer` agent definition | A fresh generic subagent launched by `review` |
+| `code-reviewer` agent definition | A fresh generic subagent launched by `/review` |
 
 The public skill surface is now:
 
 ```text
-design · plan · test · review · improve
+/design · /plan · /test · /review · /improve
 ```
 
 ## Clean upgrade
@@ -39,8 +39,8 @@ design · plan · test · review · improve
 
    For another tool, change the output path to its custom-command directory. Without custom commands, use the [raw workflow](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md) as an ordinary prompt.
 
-4. **Remove copied reviewer agents.** Delete any old Blueprint `code-reviewer` definition. The `review` skill now launches a fresh generic subagent.
-5. **Check the result.** Skill discovery should list exactly `design`, `plan`, `test`, `review`, and `improve` for Blueprint.
+4. **Remove copied reviewer agents.** Delete any old Blueprint `code-reviewer` definition. The `/review` skill now launches a fresh generic subagent.
+5. **Check the result.** The `/design`, `/plan`, `/test`, `/review`, and `/improve` skills should be available.
 
 ## Why cleanup is manual
 

--- a/README.md
+++ b/README.md
@@ -16,28 +16,28 @@ Use the smallest entry point that resolves the uncertainty in front of you.
 
 | If you need to… | Start with | Result |
 | --- | --- | --- |
-| Decide what to build or resolve important technical choices | `design` | A reviewed design with requirements and acceptance criteria |
-| Split a decided feature into work for several agent runs | `plan` | Ordered tasks in chat or tracker tickets |
+| Decide what to build or resolve important technical choices | `/design` | A reviewed design with requirements and acceptance criteria |
+| Split a decided feature into work for several agent runs | `/plan` | Ordered tasks in chat or tracker tickets |
 | Take one task through delivery | `/implement` | A tested, reviewed, green pull request |
-| Prove a change works | `test` | Acceptance criteria mapped to evidence |
-| Get an independent second opinion | `review` | Findings and a pre-merge verdict from a fresh subagent |
-| Simplify existing code without changing behavior | `improve` | Clearer, smaller, better-structured code |
+| Prove a change works | `/test` | Acceptance criteria mapped to evidence |
+| Get an independent second opinion | `/review` | Findings and a pre-merge verdict from a fresh subagent |
+| Simplify existing code without changing behavior | `/improve` | Clearer, smaller, better-structured code |
 
-Small, decided work can go straight to `/implement`. Use `design` only when decisions need review, and `plan` only when the work needs splitting.
+Small, decided work can go straight to `/implement`. Use `/design` only when decisions need review, and `/plan` only when the work needs splitting.
 
 ## How Blueprint fits together
 
 ```mermaid
 flowchart TB
     subgraph Decide["Decide only as much as needed"]
-        Idea([Idea or problem]) --> Design["design"]
+        Idea([Idea or problem]) --> Design["/design"]
         Idea -->|already decided| Task([One task])
         Design -->|one task| Task
-        Design -->|needs splitting| Plan["plan"] --> Task
+        Design -->|needs splitting| Plan["/plan"] --> Task
     end
 
     subgraph Deliver["Deliver with /implement"]
-        Task --> Isolate["isolate"] --> Code["code"] --> Test["test"] --> Review["review"]
+        Task --> Isolate["isolate"] --> Code["code"] --> Test["/test"] --> Review["/review"]
         Review -->|findings| Fix["fix"] --> Test
         Review -->|clean| Publish["publish PR"] --> Validate["CI + current feedback"]
         Validate -->|failure or finding| Fix
@@ -47,7 +47,7 @@ flowchart TB
     PR --> Merge([Human merge])
 ```
 
-`improve` is a separate maintenance path for existing code, not a step every change must pass through.
+`/improve` is a separate maintenance path for existing code, not a step every change must pass through.
 
 The model has three layers:
 
@@ -59,11 +59,11 @@ The model has three layers:
 
 | Skill | Owns | Stops when |
 | --- | --- | --- |
-| `design` | What, why, requirements, acceptance criteria, technical design, constraints, risks, and scope | The design is ready for human review |
-| `plan` | Vertical, ordered tasks and optional milestones | The work is ready to hand off |
-| `test` | Automated checks, failure paths, and real-browser proof when relevant | Every criterion is pass, fail, or explicitly unverified |
-| `review` | Independent review of correctness, security, regressions, complexity, and proof | Findings and a verdict are reported |
-| `improve` | Behavior-preserving simplification of existing code | Relevant checks prove behavior was preserved |
+| `/design` | What, why, requirements, acceptance criteria, technical design, constraints, risks, and scope | The design is ready for human review |
+| `/plan` | Vertical, ordered tasks and optional milestones | The work is ready to hand off |
+| `/test` | Automated checks, failure paths, and real-browser proof when relevant | Every criterion is pass, fail, or explicitly unverified |
+| `/review` | Independent review of correctness, security, regressions, complexity, and proof | Findings and a verdict are reported |
+| `/improve` | Behavior-preserving simplification of existing code | Relevant checks prove behavior was preserved |
 
 Writing code is a base capability, not a phase skill. Branching, committing, opening a PR, debugging, TDD, browser checking, and addressing feedback are techniques or workflow steps, not separate product concepts.
 
@@ -73,7 +73,7 @@ Writing code is a base capability, not a phase skill. Branching, committing, ope
 
 1. resolves the source and isolates work before editing;
 2. implements the smallest complete change;
-3. runs `test` and independent `review` loops;
+3. runs `/test` and independent `/review` loops;
 4. creates Conventional Commits and opens or updates the PR;
 5. waits for CI, handles feedback that exists, and records evidence;
 6. stops at a green, mergeable PR for a human to merge.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -10,10 +10,10 @@ Follow this workflow for `$ARGUMENTS`:
 1. **Resolve the source.** Resume an existing PR and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or PRs.
 2. **Isolate the work before editing.** Resume the branch and worktree for an existing PR. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its PR is merged or closed.
 3. **Read the context.** Read the repository instructions and inspect the relevant code.
-4. **Outline the change.** Define the smallest complete change and check it against the ticket, task, or PR. This is a local execution outline, not the `plan` phase. Do not create tickets or a plan document.
+4. **Outline the change.** Define the smallest complete change and check it against the ticket, task, or PR. This is a local execution outline, not the `/plan` phase. Do not create tickets or a plan document.
 5. **Implement.** Make the change and add tests where necessary.
-6. **Test.** Run the `test` phase, including real-browser checks for browser-rendered behavior.
-7. **Review.** Run the `review` phase with a fresh subagent.
+6. **Test.** Run the `/test` phase, including real-browser checks for browser-rendered behavior.
+7. **Review.** Run the `/review` phase with a fresh subagent.
 8. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
 9. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request. Link the ticket when one exists and include test and review evidence.
 10. **Finish CI.** Wait for checks to finish. Fix relevant failures and rerun affected tests and review until required checks pass. If no checks are configured, continue.

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -1,6 +1,6 @@
 # Plan: RAG Chatbot API
 
-> Captured chat output from the `plan` skill. A real run stays in chat or is published as tracker tickets when requested.
+> Captured chat output from the `/plan` skill. A real run stays in chat or is published as tracker tickets when requested.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- show every public skill in slash-command invocation form
- use `/design`, `/plan`, `/test`, `/review`, `/improve`, and `/implement` consistently
- update the workflow diagram and migration language to match

## Why

Modern coding agents expose installed skills as slash commands. Mixing bare skill names with `/implement` made one coherent command surface look inconsistent.

## Test plan

- `npx --yes skills add . --list` finds exactly five skills
- README Mermaid diagram compiles successfully
- YAML metadata parses
- local Markdown links resolve
- `bash -n examples/regenerate.sh` passes
- `git diff --check` passes
- fresh independent review: Approve, no blocker or important findings
- live GitHub mobile render checked at 390x844 with no overflow or console warnings

## Risks

Documentation-only terminology change. Raw skill names and filesystem paths remain unchanged where invocation syntax does not apply.

## Related issue

Follow-up to #38.