### PR TITLE
feat: restore milestone delivery workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,15 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 - `/review`: use a fresh subagent for an independent, read-only review.
 - `/improve`: inspect existing code and improve its clarity, simplicity, and structure without changing intended behavior.
 
+## Workflow: Milestones
+
+For a GitHub milestone, use `/milestone`. It orders open issues and runs `/task-to-pr` one issue at a time. Stop for human merge after each green pull request unless the user explicitly delegates merging for that run.
+
 Writing code is a base capability, not a separate phase skill. Debugging and test-driven development are implementation techniques, not product-level entry points.
 
 ## Workflow: Code changes
 
-For one end-to-end code change, follow the canonical [`/implement` workflow](commands/implement.md). It owns ticket handling, worktree isolation, coding, tests, independent review, commits, pull requests, CI, and current feedback. Never merge unless the user explicitly asks.
+For one end-to-end code change, follow the canonical [`/implement` workflow](commands/implement.md). `/task-to-pr` is the named ticket-to-PR entry point and delegates to that workflow. It owns ticket handling, worktree isolation, coding, tests, independent review, commits, pull requests, CI, and current feedback. Never merge unless the user explicitly asks.
 
 ## Outputs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,18 @@
 
 Blueprint keeps shared repository policy in `AGENTS.md` and only Claude-specific setup here.
 
-Install Blueprint skills with `npx skills add owainlewis/blueprint`. Invoke the public skills as `/design`, `/plan`, `/test`, `/review`, and `/improve`.
+Install Blueprint skills with `npx skills add owainlewis/blueprint`. Invoke the phase skills as `/design`, `/plan`, `/test`, `/review`, and `/improve`. Use `/milestone` to deliver every issue in a GitHub milestone through `/task-to-pr`.
 
-The Skills CLI does not install commands. Install `/implement` separately for a project:
+The Skills CLI does not install commands. Install `/implement` and `/task-to-pr` separately for a project:
 
 ```bash
 mkdir -p .claude/commands
 curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md \
   -o .claude/commands/implement.md
+curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/task-to-pr.md \
+  -o .claude/commands/task-to-pr.md
 ```
 
-Use `~/.claude/commands/implement.md` instead for a user command. The downloaded file is the canonical workflow; `AGENTS.md` contains portable repository policy.
+Use `~/.claude/commands/` instead for user commands. `/implement` remains the canonical workflow; `/task-to-pr` is its named ticket-to-PR entry point. `AGENTS.md` contains portable repository policy.
 
 The `/review` phase uses a fresh generic subagent. Blueprint does not require a separate reviewer agent definition.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migrate to the phase model
 
-> **Breaking change:** Blueprint now ships five phase skills and one separate `/implement` workflow. Old skill directories must be removed manually.
+> **Breaking change:** Blueprint now ships five phase skills, the `/milestone` coordination skill, and separate `/implement` and `/task-to-pr` workflow commands. Old skill directories must be removed manually.
 
 ## What changed
 
@@ -9,15 +9,17 @@
 | `design-doc`, `spec` | `/design` |
 | `browser-verify` | Browser proof inside `/test` |
 | `refactor` | `/improve` |
-| `branch`, `commit`, `implement`, `pr`, `pr-to-ready`, `task-to-pr` | `/implement` workflow |
+| `branch`, `commit`, `implement`, `pr`, `pr-to-ready` | `/implement` workflow |
+| `task-to-pr` | `/task-to-pr` workflow command, backed by `/implement` |
 | `debug`, `tdd` | Techniques used while implementing |
-| `goal-design`, `milestone`, `multitask` | Ordinary instructions or project-specific workflows |
+| `goal-design`, `multitask` | Ordinary instructions or project-specific workflows |
+| `milestone` | `/milestone`, updated to use `/task-to-pr` |
 | `code-reviewer` agent definition | A fresh generic subagent launched by `/review` |
 
 The public skill surface is now:
 
 ```text
-/design · /plan · /test · /review · /improve
+/design · /plan · /test · /review · /improve · /milestone
 ```
 
 ## Clean upgrade
@@ -29,21 +31,23 @@ The public skill surface is now:
    npx skills add owainlewis/blueprint
    ```
 
-3. **Install `/implement` separately.** The Skills CLI does not install commands. For Claude Code at project scope:
+3. **Install `/implement` and `/task-to-pr` separately.** The Skills CLI does not install commands. For Claude Code at project scope:
 
    ```bash
    mkdir -p .claude/commands
    curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md \
      -o .claude/commands/implement.md
+   curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/task-to-pr.md \
+     -o .claude/commands/task-to-pr.md
    ```
 
    For another tool, change the output path to its custom-command directory. Without custom commands, use the [raw workflow](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md) as an ordinary prompt.
 
 4. **Remove copied reviewer agents.** Delete any old Blueprint `code-reviewer` definition. The `/review` skill now launches a fresh generic subagent.
-5. **Check the result.** The `/design`, `/plan`, `/test`, `/review`, and `/improve` skills should be available.
+5. **Check the result.** The `/design`, `/plan`, `/test`, `/review`, `/improve`, and `/milestone` skills should be available.
 
 ## Why cleanup is manual
 
 Some noninteractive skill updaters add and replace skills but do not remove directories that disappeared upstream. Running `npx skills update` alone can therefore leave the old and new models installed together.
 
-Blueprint intentionally provides no compatibility aliases. Duplicate entry points make routing ambiguous and defeat the smaller phase model.
+Blueprint keeps `/task-to-pr` as the one compatibility workflow entry point because it names a common outcome and delegates to `/implement`. Other duplicate entry points remain removed so routing stays clear.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Use the smallest entry point that resolves the uncertainty in front of you.
 | --- | --- | --- |
 | Decide what to build or resolve important technical choices | `/design` | A reviewed design with requirements and acceptance criteria |
 | Split a decided feature into work for several agent runs | `/plan` | Ordered tasks in chat or tracker tickets |
-| Take one task through delivery | `/implement` | A tested, reviewed, green pull request |
+| Take one task through delivery | `/implement` or `/task-to-pr` | A tested, reviewed, green pull request |
+| Complete every issue in a GitHub milestone | `/milestone` | One green pull request at a time, with human merge checkpoints |
 | Prove a change works | `/test` | Acceptance criteria mapped to evidence |
 | Get an independent second opinion | `/review` | Findings and a pre-merge verdict from a fresh subagent |
 | Simplify existing code without changing behavior | `/improve` | Clearer, smaller, better-structured code |
@@ -52,7 +53,7 @@ flowchart TB
 The model has three layers:
 
 1. **Repository instructions define policy.** `AGENTS.md` says what good work means in a codebase.
-2. **Skills define phases.** Each skill has one durable engineering outcome and a clear stopping point.
+2. **Skills define phases and reusable coordination.** Each skill has one durable engineering outcome and a clear stopping point.
 3. **Commands compose workflows.** `/implement` connects normal delivery steps without turning each one into a skill.
 
 ## The five phases
@@ -80,31 +81,40 @@ Writing code is a base capability, not a phase skill. Branching, committing, ope
 
 It does not wait forever for future human feedback, manufacture tracker artifacts for trivial work, or merge without explicit permission.
 
+[`commands/task-to-pr.md`](commands/task-to-pr.md) restores the explicit `/task-to-pr` workflow name. It delegates to `/implement` rather than duplicating the delivery loop.
+
+## One milestone to completed issues
+
+`/milestone` is the release-slice workflow. It reads a GitHub milestone, orders open issues by dependency and risk, then runs `/task-to-pr` for one issue at a time. It stops for human merge after each green pull request unless the user explicitly delegates merging for that run.
+
 ## Install
 
-Install the five skills:
+Install the five phase skills and the milestone workflow:
 
 ```bash
 npx skills add owainlewis/blueprint
 ```
 
-The Skills CLI does not install commands. For a project-level Claude Code command:
+The Skills CLI does not install commands. For the project-level Claude Code workflows:
 
 ```bash
 mkdir -p .claude/commands
 curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md \
   -o .claude/commands/implement.md
+curl -fsSL https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/task-to-pr.md \
+  -o .claude/commands/task-to-pr.md
 ```
 
-For another coding tool, download the [raw command](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md) to its custom-command directory or use it as an ordinary prompt.
+For another coding tool, download the [raw implementation workflow](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/implement.md) and [raw task-to-PR workflow](https://raw.githubusercontent.com/owainlewis/blueprint/main/commands/task-to-pr.md) to its custom-command directory or use them as ordinary prompts.
 
 Upgrading from the older skill catalogue? Follow the [migration guide](MIGRATION.md). Removed skills can remain installed after a normal update, so the cleanup step matters.
 
 ## Repository map
 
 ```text
-skills/                 five reusable engineering phases
-commands/implement.md   canonical task-to-PR workflow
+skills/                 five reusable phases and the milestone workflow
+commands/implement.md   canonical implementation workflow
+commands/task-to-pr.md  named task-to-PR workflow entry point
 AGENTS.md                portable repository policy
 CLAUDE.md                Claude Code adapter
 REVIEW.md                review standard for Blueprint itself

--- a/commands/task-to-pr.md
+++ b/commands/task-to-pr.md
@@ -1,0 +1,10 @@
+---
+description: "Takes one task or ticket through the canonical implementation workflow to a green pull request ready for human merge."
+argument-hint: "<ticket or task>"
+---
+
+# Workflow: Task to PR
+
+Run `/implement` for `$ARGUMENTS`.
+
+This is a named workflow entry point, not a separate implementation path. Follow every step and stopping condition in `/implement`. Never merge unless the user explicitly asks.

--- a/skills/milestone/SKILL.md
+++ b/skills/milestone/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: milestone
+description: "Completes all open GitHub issues in a milestone by running the task-to-pr workflow one issue at a time. Use when the user asks to complete, deliver, work through, or finish a GitHub milestone."
+user-invocable: true
+argument-hint: "<GitHub milestone URL or name>"
+---
+
+# Milestone
+
+Finish every open issue in a GitHub milestone.
+
+## Workflow
+
+1. Resolve the milestone and repository. Inspect its open issues, dependencies, linked pull requests, checks, and current project state.
+2. Order the remaining issues by dependency, risk, and reviewability. Put blockers, bugs, and shared seams before dependent feature work.
+3. Take one issue at a time through `/task-to-pr`, which delegates to the canonical `/implement` workflow. Resume a matching pull request instead of creating duplicate work.
+4. After each pull request is green and ready, stop for human merge unless the user explicitly allowed merging for this run.
+5. When merging is allowed, merge only after required checks and review are clean. Sync the latest remote default branch before starting the next issue.
+6. Refresh the milestone before each issue. Record pull request links, proof, blockers, and final state in the tracker when access permits.
+7. Report completed issues, merged and open pull requests, blockers, checks, and anything not verified.
+
+## Boundaries
+
+- Work only on issues in the milestone.
+- Use one branch and pull request per issue unless combining issues is required for a working result. Explain any combination before starting it.
+- Do not batch unrelated issues or reimplement the inner delivery workflow.
+- Never merge without explicit permission.
+- Do not merge with failing checks, important unresolved feedback, missing acceptance criteria, or unexplained test gaps.
+- Stop when an issue has unresolved product or technical decisions, requires missing secrets or permissions, already has conflicting work, or grows beyond its acceptance criteria.


### PR DESCRIPTION
## What changed

- restore `/milestone` as an installable skill
- restore `/task-to-pr` as a workflow command, not a skill
- keep `/implement` as the single canonical delivery workflow
- update README, repository policy, Claude setup, and migration guidance

## Why

The milestone workflow remains useful for completing a release slice one issue at a time. The restored skill now fits the phase model by delegating each issue to `/task-to-pr`, which is a thin named entry point over `/implement`.

## Behavior

Milestone work stops for human merge after each green pull request unless the user explicitly delegates merging for the run. No `skills/task-to-pr` directory is restored.

## Checks

- `git diff --cached --check`
- YAML frontmatter validation for all six skills and both commands
- relative Markdown link validation
- `npx --yes skills add . --list` discovers six skills including `milestone`
- confirmed `skills/task-to-pr` is absent
- independent review: Approve, no findings