### PR TITLE
docs: remove skill cross-references from task-to-pr and milestone

### DIFF
--- a/skills/milestone/SKILL.md
+++ b/skills/milestone/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: milestone
-description: "Completes all open GitHub issues in a milestone by running the task-to-pr skill one issue at a time. Use when the user asks to complete, deliver, work through, or finish a GitHub milestone."
+description: "Completes all open GitHub issues in a milestone, taking each one to a tested, reviewed, green pull request. Use when the user asks to complete, deliver, work through, or finish a GitHub milestone."
 user-invocable: true
 argument-hint: "<GitHub milestone URL or name>"
 ---
@@ -13,7 +13,7 @@ Finish every open issue in a GitHub milestone.
 
 1. Resolve the milestone and repository. Inspect its open issues, dependencies, linked pull requests, checks, and current project state.
 2. Order the remaining issues by dependency, risk, and reviewability. Put blockers, bugs, and shared seams before dependent feature work.
-3. Take one issue at a time through `/task-to-pr`. Resume a matching pull request instead of creating duplicate work.
+3. Take one issue at a time to a tested, reviewed, green pull request: branch and worktree, implement the smallest complete change, test it, get it reviewed by a fresh agent, then open the PR. Resume a matching pull request instead of creating duplicate work.
 4. After each pull request is ready, stop for human merge unless the user explicitly allowed merging for this run.
 5. When merging is allowed, merge only after required checks and review are clean. Sync the latest remote default branch before starting the next issue.
 6. Refresh the milestone before each issue. Record pull request links, proof, blockers, and final state in the tracker when access permits.
@@ -23,7 +23,7 @@ Finish every open issue in a GitHub milestone.
 
 - Work only on issues in the milestone.
 - Use one branch and pull request per issue unless combining issues is required for a working result. Explain any combination before starting it.
-- Do not batch unrelated issues or reimplement the inner delivery workflow.
+- Do not batch unrelated issues.
 - Never merge without explicit permission.
 - Do not merge with failing checks, important unresolved feedback, missing acceptance criteria, or unexplained test gaps.
 - Stop when an issue has unresolved product or technical decisions, requires missing secrets or permissions, already has conflicting work, or grows beyond its acceptance criteria.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -12,10 +12,10 @@ Follow this workflow for the requested task, ticket, or pull request:
 1. **Resolve the source.** Resume an existing pull request and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or pull requests.
 2. **Isolate the work before editing.** Resume the branch and worktree for an existing pull request. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its pull request is merged or closed.
 3. **Read the context.** Read the repository instructions and inspect the relevant code.
-4. **Outline the change.** Define the smallest complete change and check it against the ticket, task, or pull request. This is a local execution outline, not the `/plan` phase. Do not create tickets or a plan document.
+4. **Outline the change.** Define the smallest complete change and check it against the ticket, task, or pull request. This is a local execution outline for this one task, not a multi-task plan document. Do not create tickets or a plan document.
 5. **Implement.** Make the change and add tests where necessary.
-6. **Test.** Run the `/test` phase, including real-browser checks for browser-rendered behavior.
-7. **Review.** Run the `/review` phase with a fresh subagent.
+6. **Test.** Run any automated checks and tests, including real-browser checks for browser-rendered behavior.
+7. **Review.** Review the change with a fresh subagent that did not implement it.
 8. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
 9. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request. Link the ticket when one exists and include test and review evidence.
 10. **Finish CI.** Wait for checks to finish. Fix relevant failures and rerun affected tests and review until required checks pass. If no checks are configured, continue.


### PR DESCRIPTION
## Summary
- `task-to-pr` referenced `/plan`, `/test`, and `/review` by slash-command name; `milestone` referenced `/task-to-pr`. These assume the other skills are installed under those exact names in the consuming tool.
- Rewrote the referencing lines to describe the behavior directly (run automated checks, review with a fresh subagent, etc.) so each skill stands alone.

## Test plan
- [ ] Docs-only change; no automated checks apply.