### PR TITLE
feat(task-to-pr): improve pull request publishing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,28 @@
-## Summary
+## What is this change?
 
-<!-- What changed? -->
+<!-- Summarize the major changes and observable behavior. -->
 
-## Why
+## Why is it important?
 
-<!-- Why was this needed? -->
+<!-- Explain the problem, who it affects, and why this approach was chosen. -->
 
-## Test plan
+## What should the reviewer know or consider?
 
-<!-- List checks run. Write "Not run" with a reason when checks were not run. -->
+<!-- Call out decisions, scope boundaries, tradeoffs, shortcomings, safety, compatibility, failure behavior, operational impact, known risks, and where to start. -->
 
-## Risks
+## Checklist
 
-<!-- What could break or need close review? -->
+- **Is this one focused, self-contained change?** <Yes | No>
+  <!-- Evidence or why the size and scope are necessary. -->
+- **Did you write or update tests?** <Yes | No | Not applicable>
+  <!-- Evidence or why tests do not apply. -->
+- **Did you run the relevant tests and checks?** <Yes | No>
+  <!-- Commands, browser or manual checks, results, and unverified criteria or affected failure paths. -->
+- **Did you independently review the final diff and address valid findings?** <Yes | No>
+  <!-- Review evidence, findings fixed, and anything unresolved. -->
+- **Did you update documentation when behavior changed?** <Yes | No | Not applicable>
+  <!-- Documentation changed or why it was not needed. -->
+- **Did required CI checks pass?** <Yes | No | Pending | Not configured>
+  <!-- Check names and results. -->
 
-## Related issue
-
-<!-- Closes #... or write "None". -->
+<!-- Add Closes #... when this pull request completes an issue. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,6 @@ For one end-to-end code change, follow the canonical [`/task-to-pr` skill](skill
 
 - Designs default to `docs/<feature-slug>/design.md`.
 - Plans are returned in chat by default or published as tracker tickets when asked. They are not stored as plan documents.
-- Pull requests state the outcome, link the ticket, and include test, browser, and review evidence as relevant.
+- Pull requests lead with the outcome and user impact, explain important behavior and safety rules, link the ticket, and include only test, browser, manual, and independent-review evidence that actually exists.
 
 Exploration does not require a design, plan, or ticket. Do not create process artifacts that do not improve a decision, handoff, or proof.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,6 @@ For one end-to-end code change, follow the canonical [`/task-to-pr` skill](skill
 
 - Designs default to `docs/<feature-slug>/design.md`.
 - Plans are returned in chat by default or published as tracker tickets when asked. They are not stored as plan documents.
-- Pull requests lead with the outcome and user impact, explain important behavior and safety rules, link the ticket, and include only test, browser, manual, and independent-review evidence that actually exists.
+- Pull requests explain what changed, why it matters, what the reviewer should consider, and a truthful checklist covering tests, checks, independent review, findings, documentation, and CI.
 
 Exploration does not require a design, plan, or ticket. Do not create process artifacts that do not improve a decision, handoff, or proof.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use the smallest entry point that resolves the uncertainty in front of you.
 | --- | --- | --- |
 | Decide what to build or resolve important technical choices | `/design` | A reviewed design with requirements and acceptance criteria |
 | Split a decided feature into work for several agent runs | `/plan` | Ordered tasks in chat or tracker tickets |
-| Take one task through delivery | `/task-to-pr` | A tested, reviewed, green pull request |
+| Take one task or prepared change through delivery | `/task-to-pr` | A tested, reviewed, green pull request |
 | Complete every issue in a GitHub milestone | `/milestone` | One green pull request at a time, with human merge checkpoints |
 | Prove a change works | `/test` | Acceptance criteria mapped to evidence |
 | Get an independent second opinion | `/review` | Findings and a pre-merge verdict from a fresh subagent |
@@ -74,7 +74,7 @@ Writing code is a base capability, not a phase skill. Branching, committing, ope
 1. resolves the source and isolates work before editing;
 2. implements the smallest complete change;
 3. runs `/test` and independent `/review` loops;
-4. creates Conventional Commits and opens or updates the PR;
+4. creates Conventional Commits and opens or updates a reviewer-focused PR that explains the outcome, behavior, risks, and actual verification;
 5. waits for CI, handles feedback that exists, and records evidence;
 6. stops at a green, mergeable PR for a human to merge.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use the smallest entry point that resolves the uncertainty in front of you.
 | --- | --- | --- |
 | Decide what to build or resolve important technical choices | `/design` | A reviewed design with requirements and acceptance criteria |
 | Split a decided feature into work for several agent runs | `/plan` | Ordered tasks in chat or tracker tickets |
-| Take one task or prepared change through delivery | `/task-to-pr` | A tested, reviewed, green pull request |
+| Take one task through delivery | `/task-to-pr` | A tested, reviewed, green pull request |
 | Complete every issue in a GitHub milestone | `/milestone` | One green pull request at a time, with human merge checkpoints |
 | Prove a change works | `/test` | Acceptance criteria mapped to evidence |
 | Get an independent second opinion | `/review` | Findings and a pre-merge verdict from a fresh subagent |
@@ -74,7 +74,7 @@ Writing code is a base capability, not a phase skill. Branching, committing, ope
 1. resolves the source and isolates work before editing;
 2. implements the smallest complete change;
 3. runs `/test` and independent `/review` loops;
-4. creates Conventional Commits and opens or updates a reviewer-focused PR that explains the outcome, behavior, risks, and actual verification;
+4. creates Conventional Commits and opens or updates a reviewer-focused PR that explains what changed, why it matters, what to review, and the evidence checklist;
 5. waits for CI, handles feedback that exists, and records evidence;
 6. stops at a green, mergeable PR for a human to merge.
 

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -36,7 +36,7 @@ Treat the pull request title and body as durable history for reviewers now and e
 - Include enough context to understand the change without opening the ticket or reading the entire diff.
 - Answer the reviewer questions with concrete behavior, decisions, risks, shortcomings, and evidence. Do not write an inventory of edited files.
 - For a complex change, say where to start and which parts need the closest scrutiny.
-- Mark a checklist item only when its answer and evidence are present. When an item does not apply, mark it complete and state why.
+- Answer every checklist item with an explicit status and evidence. Use `Not applicable`, `Not configured`, or `Pending` instead of a checked box that implies success.
 - Treat independent agent review as evidence, not GitHub approval or a replacement for human review.
 - Preserve useful human-written context when updating an existing pull request.
 - Keep the body current when later commits change behavior, risk, or verification.
@@ -64,16 +64,16 @@ change, tell the reviewer where to start and what needs the closest scrutiny.
 
 ## Checklist
 
-- [ ] Is this one focused, self-contained change?
-  - Evidence or why the size and scope are necessary.
-- [ ] Did you write or update tests?
-  - Evidence or why tests do not apply.
-- [ ] Did you run the relevant tests and checks?
-  - Commands, browser or manual checks, results, and important gaps.
-- [ ] Did you independently review the final diff and address valid findings?
-  - Review evidence, findings fixed, and anything unresolved.
-- [ ] Did you update documentation when behavior changed?
-  - Documentation changed or why it was not needed.
-- [ ] Did required CI checks pass?
-  - Result, pending state, or why no checks apply.
+- **Is this one focused, self-contained change?** <Yes | No>
+  Evidence or why the size and scope are necessary.
+- **Did you write or update tests?** <Yes | No | Not applicable>
+  Evidence or why tests do not apply.
+- **Did you run the relevant tests and checks?** <Yes | No>
+  Commands, browser or manual checks, results, and important gaps.
+- **Did you independently review the final diff and address valid findings?** <Yes | No>
+  Review evidence, findings fixed, and anything unresolved.
+- **Did you update documentation when behavior changed?** <Yes | No | Not applicable>
+  Documentation changed or why it was not needed.
+- **Did required CI checks pass?** <Yes | No | Pending | Not configured>
+  Result or relevant details.
 ```

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -20,6 +20,7 @@ Follow this workflow for the requested task, ticket, or pull request:
 9. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request that meets the pull request standard below.
 10. **Pass CI.** Wait for checks, fix relevant failures, and rerun affected tests and review until required checks pass. If no checks are configured, continue.
 11. **Address feedback.** Inspect current human and bot feedback. Fix important findings, reply to addressed comments with evidence, and rerun affected tests and fresh review. Do not wait indefinitely for future human feedback.
+12. **Refresh the pull request.** Update the title, description, and checklist to match the final head, verification, CI state, review findings, and feedback disposition.
 
 Commit and push every post-PR fix before reassessing checks or feedback.
 
@@ -29,7 +30,7 @@ Stop when the pull request is green, mergeable, and has no important unresolved 
 
 ## Pull request standard
 
-Treat the pull request title and body as durable history for reviewers now and engineers later. Follow a required repository template when one exists. Otherwise use the structure below.
+Treat the pull request title and body as durable history for reviewers now and engineers later. Follow a required repository template and add any information or evidence below that it does not cover. If no template exists, use the structure below.
 
 - Follow the repository's title convention. Otherwise use a short, standalone title that states the delivered outcome.
 - Link the source ticket with the repository's closing syntax when the pull request completes it.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: task-to-pr
-description: "Takes one task, ticket, or existing pull request to a tested, independently reviewed, green pull request ready for human merge. Use when the user asks to implement, build, fix, deliver, or take one task or issue to a pull request."
+description: "Takes one task, ticket, prepared local change, branch, or existing pull request to a tested, independently reviewed, green pull request ready for human merge. Use when the user asks to implement, build, fix, deliver, publish changes, open or update a pull request, or improve a pull request description."
 user-invocable: true
-argument-hint: "<ticket, task, or pull request>"
+argument-hint: "<ticket, task, local change, branch, or pull request>"
 ---
 
 # Task to PR
 
-Follow this workflow for the requested task, ticket, or pull request:
+Follow this workflow for the requested task, ticket, prepared change, branch, or pull request. For prepared changes or an existing pull request, inspect the implementation and current evidence, then perform only the missing or outdated steps. Never claim inherited checks or review unless they apply to the current head.
 
-1. **Resolve the source.** Resume an existing pull request and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or pull requests.
-2. **Branch.** Resume the branch and worktree for an existing pull request. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its pull request is merged or closed.
+1. **Resolve the source.** Inspect the current branch, worktree, local diff, existing pull request, and linked ticket. Resume an existing pull request when one exists. Treat prepared local changes as source material and preserve them. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or pull requests.
+2. **Branch.** Reuse a suitable branch and worktree for prepared changes or an existing pull request. Do not move or discard local changes. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention. Remove a manually created worktree after its pull request is merged or closed.
 3. **Read the context.** Read the repository instructions and inspect the relevant code.
 4. **Outline the change.** Define the smallest complete change and check it against the ticket, task, or pull request. This is a local execution outline for this one task, not a multi-task plan document. Do not create tickets or a plan document.
 5. **Implement.** Make the change and add tests where necessary.
 6. **Test.** Run any automated checks and tests, including real-browser checks for browser-rendered behavior.
 7. **Review.** Review the change with a fresh subagent that did not implement it.
 8. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
-9. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request. Link the ticket when one exists and include test and review evidence.
+9. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request that meets the pull request standard below.
 10. **Pass CI.** Wait for checks, fix relevant failures, and rerun affected tests and review until required checks pass. If no checks are configured, continue.
 11. **Address feedback.** Inspect current human and bot feedback. Fix important findings, reply to addressed comments with evidence, and rerun affected tests and fresh review. Do not wait indefinitely for future human feedback.
 
@@ -26,3 +26,44 @@ Commit and push every post-PR fix before reassessing checks or feedback.
 If the ticket, task, or design is wrong or incomplete, update the source of truth before continuing. Prefer the smallest complete change and no unrelated cleanup.
 
 Stop when the pull request is green, mergeable, and has no important unresolved feedback currently available. Never merge unless the user explicitly asks. Report an exact blocker when required access, checks, or independent review remain unavailable after safe alternatives are exhausted.
+
+## Pull request standard
+
+Write the pull request for a reviewer deciding whether the change is safe and useful, not as an inventory of edited files.
+
+- Follow the repository's title convention. Otherwise use a title that states the delivered outcome.
+- Follow required repository pull request templates and preserve useful human-written context when updating an existing pull request.
+- Link the source ticket with the repository's closing syntax when the pull request completes it.
+- Lead with why the change matters and what becomes possible or behaves differently.
+- Explain observable behavior, important safety rules, compatibility, failure behavior, and operational impact. Include implementation detail only when it helps review a decision or risk.
+- Report only verification that actually ran. Separate automated checks, browser evidence, and manual checks when more than one kind exists. State important gaps.
+- Summarize independent agent review as supporting evidence. Do not describe it as GitHub approval or imply that it replaces human review.
+- Omit empty headings, boilerplate, process narration, and claims the available evidence does not support.
+- Keep the body current when later commits change behavior, risk, or verification.
+
+Use this shape when every section adds value:
+
+```markdown
+Closes #<ticket>
+
+## Outcome
+
+Why this change matters and its user or operator impact.
+
+## Behavior
+
+- Observable behavior and safety rules a reviewer must understand.
+- Compatibility, failure, migration, or operational notes when relevant.
+
+## Verification
+
+- `<command>`: what it proved
+- Browser or manual evidence when required
+- Any important unverified behavior
+
+## Independent review
+
+What was reviewed, which important findings were fixed, and whether actionable findings remain.
+```
+
+Adapt the headings to the work. A small fix may need only a short summary, ticket link, and verification.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: task-to-pr
-description: "Takes one task, ticket, prepared local change, branch, or existing pull request to a tested, independently reviewed, green pull request ready for human merge. Use when the user asks to implement, build, fix, deliver, publish changes, open or update a pull request, or improve a pull request description."
+description: "Takes one task, ticket, or existing pull request to a tested, independently reviewed, green pull request ready for human merge. Use when the user asks to implement, build, fix, deliver, or take one task or issue to a pull request."
 user-invocable: true
-argument-hint: "<ticket, task, local change, branch, or pull request>"
+argument-hint: "<ticket, task, or pull request>"
 ---
 
 # Task to PR
 
-Follow this workflow for the requested task, ticket, prepared change, branch, or pull request. For prepared changes or an existing pull request, inspect the implementation and current evidence, then perform only the missing or outdated steps. Never claim inherited checks or review unless they apply to the current head.
+Follow this workflow for the requested task, ticket, or pull request:
 
-1. **Resolve the source.** Inspect the current branch, worktree, local diff, existing pull request, and linked ticket. Resume an existing pull request when one exists. Treat prepared local changes as source material and preserve them. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or pull requests.
-2. **Branch.** Reuse a suitable branch and worktree for prepared changes or an existing pull request. Do not move or discard local changes. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention. Remove a manually created worktree after its pull request is merged or closed.
+1. **Resolve the source.** Resume an existing pull request and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or pull requests.
+2. **Branch.** Resume the branch and worktree for an existing pull request. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its pull request is merged or closed.
 3. **Read the context.** Read the repository instructions and inspect the relevant code.
 4. **Outline the change.** Define the smallest complete change and check it against the ticket, task, or pull request. This is a local execution outline for this one task, not a multi-task plan document. Do not create tickets or a plan document.
 5. **Implement.** Make the change and add tests where necessary.
@@ -29,41 +29,51 @@ Stop when the pull request is green, mergeable, and has no important unresolved 
 
 ## Pull request standard
 
-Write the pull request for a reviewer deciding whether the change is safe and useful, not as an inventory of edited files.
+Treat the pull request title and body as durable history for reviewers now and engineers later. Follow a required repository template when one exists. Otherwise use the structure below.
 
-- Follow the repository's title convention. Otherwise use a title that states the delivered outcome.
-- Follow required repository pull request templates and preserve useful human-written context when updating an existing pull request.
+- Follow the repository's title convention. Otherwise use a short, standalone title that states the delivered outcome.
 - Link the source ticket with the repository's closing syntax when the pull request completes it.
-- Lead with why the change matters and what becomes possible or behaves differently.
-- Explain observable behavior, important safety rules, compatibility, failure behavior, and operational impact. Include implementation detail only when it helps review a decision or risk.
-- Report only verification that actually ran. Separate automated checks, browser evidence, and manual checks when more than one kind exists. State important gaps.
-- Summarize independent agent review as supporting evidence. Do not describe it as GitHub approval or imply that it replaces human review.
-- Omit empty headings, boilerplate, process narration, and claims the available evidence does not support.
+- Include enough context to understand the change without opening the ticket or reading the entire diff.
+- Answer the reviewer questions with concrete behavior, decisions, risks, shortcomings, and evidence. Do not write an inventory of edited files.
+- For a complex change, say where to start and which parts need the closest scrutiny.
+- Mark a checklist item only when its answer and evidence are present. When an item does not apply, mark it complete and state why.
+- Treat independent agent review as evidence, not GitHub approval or a replacement for human review.
+- Preserve useful human-written context when updating an existing pull request.
 - Keep the body current when later commits change behavior, risk, or verification.
-
-Use this shape when every section adds value:
 
 ```markdown
 Closes #<ticket>
 
-## Outcome
+## What is this change?
 
-Why this change matters and its user or operator impact.
+Summarize the major changes and observable behavior so a reader understands
+what changed without reading the entire diff.
 
-## Behavior
+## Why is it important?
 
-- Observable behavior and safety rules a reviewer must understand.
-- Compatibility, failure, migration, or operational notes when relevant.
+Explain the problem, who it affects, the context behind the change, and why
+this approach was chosen.
 
-## Verification
+## What should the reviewer know or consider?
 
-- `<command>`: what it proved
-- Browser or manual evidence when required
-- Any important unverified behavior
+Call out decisions not obvious from the code, scope boundaries, tradeoffs,
+shortcomings, safety rules, compatibility, migrations, failure behavior,
+operational impact, and known risks. Link relevant designs, benchmarks, or
+related changes while preserving the essential context here. For a complex
+change, tell the reviewer where to start and what needs the closest scrutiny.
 
-## Independent review
+## Checklist
 
-What was reviewed, which important findings were fixed, and whether actionable findings remain.
+- [ ] Is this one focused, self-contained change?
+  - Evidence or why the size and scope are necessary.
+- [ ] Did you write or update tests?
+  - Evidence or why tests do not apply.
+- [ ] Did you run the relevant tests and checks?
+  - Commands, browser or manual checks, results, and important gaps.
+- [ ] Did you independently review the final diff and address valid findings?
+  - Review evidence, findings fixed, and anything unresolved.
+- [ ] Did you update documentation when behavior changed?
+  - Documentation changed or why it was not needed.
+- [ ] Did required CI checks pass?
+  - Result, pending state, or why no checks apply.
 ```
-
-Adapt the headings to the work. A small fix may need only a short summary, ticket link, and verification.


### PR DESCRIPTION
## What is this change?

Add a reviewer-focused pull request standard to Blueprint’s canonical `/task-to-pr` workflow.

Generated PR descriptions now answer three questions: what changed, why it matters, and what the reviewer should consider. The checklist records explicit statuses for change scope, tests, checks, independent review and addressed findings, documentation, and CI. Blueprint’s own PR template now implements the same standard.

## Why is it important?

A PR description is useful both to today’s reviewer and to engineers reading repository history later. A list of implementation details does not preserve the motivation, decisions, tradeoffs, or proof needed to judge a change safely.

This structure follows Google’s published guidance that change descriptions explain what and why, preserve context that cannot be recovered from code, guide reviewers through complex changes, and include related tests.

## What should the reviewer know or consider?

- This strengthens `/task-to-pr` instead of adding a separate publishing or PR-description skill. Blueprint continues to have one canonical delivery workflow.
- Required repository templates are preserved and supplemented with any evidence fields they omit.
- The workflow refreshes the title, description, and checklist after CI and feedback so the durable record matches the final head.
- Checklist questions use explicit `Yes`, `No`, `Not applicable`, `Pending`, or `Not configured` states. They do not use checked boxes that could visually contradict the evidence.
- Independent agent review is recorded as evidence, not presented as GitHub approval or a replacement for human review.
- Review found routing, checklist semantics, repository-template coverage, and final evidence-refresh issues. All were fixed and rereviewed.
- Reference guidance: [Google’s CL description guide](https://google.github.io/eng-practices/review/developer/cl-descriptions.html) and [small CL guidance](https://google.github.io/eng-practices/review/developer/small-cls.html).

## Checklist

- **Is this one focused, self-contained change?** Yes
  It changes only Blueprint’s PR-writing contract, repository template, and public summaries.
- **Did you write or update tests?** Not applicable
  This is prose-only skill guidance with no executable behavior. Metadata and template consistency checks provide substitute evidence.
- **Did you run the relevant tests and checks?** Yes
  `git diff --check` passed. YAML frontmatter validation passed. All six checklist items match between the repository template and `/task-to-pr`.
- **Did you independently review the final diff and address valid findings?** Yes
  Fresh independent review approved the final head after every valid finding was fixed. Both GitHub review threads have evidence replies and are resolved.
- **Did you update documentation when behavior changed?** Yes
  Updated `AGENTS.md`, `README.md`, `.github/pull_request_template.md`, and `/task-to-pr`.
- **Did required CI checks pass?** Not configured
  GitHub reports no checks for this branch.