### PR TITLE
feat(review): make engineering checks evidence-based

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 - Keep one skill per meaningful engineering phase or delivery outcome.
 - Skip phases that add no value. Small, decided work can go straight to implementation.
 - A task is ready when a new agent can finish it without asking product or technical questions.
-- Tests prove the requested behavior. Review checks that the proof and implementation are sound.
+- Each pull request delivers one focused, self-contained outcome with its related proof. A change is reviewable when its outcome, behavior, and proof can be understood without first separating unrelated work. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review.
+- Logic changes include automated tests for changed behavior and failure paths affected by the change or named in its acceptance criteria. Refactors include tests for behavior that must not change. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.
+- Review checks correctness. If the same outcome and proof can be delivered with less state, indirection, duplication, or operational work, request the simpler design. Do not block on personal taste. Cite technical evidence or repository conventions.
 - Browser behavior is proven in a real browser, not by reading source.
 - If the task, design, or plan is wrong, update it before changing more code.
 - Prefer the smallest complete change. Do not mix product work with unrelated cleanup.
@@ -18,7 +20,7 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 
 - `/design`: decide what to build, why, and how. Stop for human review.
 - `/plan`: split decided work into ordered, agent-ready tasks. Stop before implementation.
-- `/test`: prove acceptance criteria and important failures, including browser checks when relevant.
+- `/test`: prove acceptance criteria and failure paths affected by the change, including real-browser checks when browser-rendered behavior changes.
 - `/review`: use a fresh subagent for an independent, read-only review.
 - `/improve`: inspect existing code and improve its clarity, simplicity, and structure without changing intended behavior.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ For a larger architecture example, read the [Dispatch local control-plane design
 
 - **Encode process, not knowledge.** Give agents outcomes, constraints, and proof; trust them with local mechanics.
 - **One skill per phase or delivery outcome.** Skills share one installation and invocation model.
-- **Proof is part of the work.** Tests establish behavior. Review checks that the implementation and proof are sound.
+- **Keep changes reviewable.** Deliver one focused, self-contained outcome with its related proof. A reviewer should not need to separate unrelated work first. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review.
+- **Use concrete review standards.** Check correctness. If the same outcome and proof can be delivered with less state, indirection, duplication, or operational work, request the simpler design. Do not block on personal taste. Cite technical evidence or repository conventions.
+- **Proof is part of the work.** Test changed behavior, failure paths affected by the change or named in its acceptance criteria, and behavior a refactor must preserve. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.
 - **Use the real surface.** Browser behavior is checked in a browser. Live PR feedback is read from the PR.
 - **Fix the source of truth.** If implementation exposes a bad requirement, update the task or design before continuing.
 - **Prefer less.** Keep the smallest complete change, shortest useful instruction, and no duplicate entry points.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -5,10 +5,12 @@ Review Blueprint as a small process product, not a prompt catalogue. Read the is
 - Does each skill represent one meaningful engineering phase or delivery outcome?
 - Is policy in `AGENTS.md`, with phase behavior and delivery orchestration in skills?
 - Are triggers, outputs, boundaries, proof, and stop conditions clear?
+- Is the change one focused, self-contained, reviewable outcome with its related proof?
 - Does `/task-to-pr` reach a tested, independently reviewed, green PR without merging by default?
 - Is browser-rendered behavior checked in a real browser?
 - Can a capable agent choose local mechanics without redundant instructions?
 - Are removed concepts handled by an explicit migration instead of compatibility clutter?
+- Can each judgment be decided from evidence? Replace vague terms such as "code health", "adequate", "robust", and "production-ready" with concrete criteria.
 - Is every sentence useful enough to compete for agent attention?
 
 Prefer the smallest wording that preserves the outcome. Treat extra skills, duplicate workflows, fake personas, and ceremony without proof as regressions.

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -10,11 +10,11 @@ argument-hint: "[code, files, diff, branch, or improvement focus]"
 ## Workflow
 
 1. Identify the target from the request, current diff, or recently changed code.
-2. Read the target, its tests, and relevant surrounding code. Establish the behavior that must not change.
+2. Read the target, its tests, and relevant surrounding code. Establish the behavior that must not change. If behavior named by the task or a public interface lacks tests, add focused characterization coverage before refactoring. If the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.
 3. Find unnecessary complexity, duplication, dead code, weak names, awkward boundaries, and abstractions that cost more than they help.
 4. Make focused improvements by deleting, deduplicating, renaming, simplifying, extracting, or inlining.
 5. Preserve public interfaces, data shapes, errors, and user-visible behavior unless the user explicitly asks to change them.
-6. Run the relevant tests and checks. Report what improved, what behavior was preserved, and the evidence.
+6. Run tests and checks that cover behavior the refactor can affect. Report what improved, what behavior was preserved, and the evidence.
 
 ## Boundaries
 

--- a/skills/milestone/SKILL.md
+++ b/skills/milestone/SKILL.md
@@ -15,7 +15,7 @@ Finish every open issue in a GitHub milestone.
 2. Order the remaining issues by dependency, risk, and reviewability. Put blockers, bugs, and shared seams before dependent feature work.
 3. Take one issue at a time to a tested, reviewed, green pull request: branch and worktree, implement the smallest complete change, test it, review it with a fresh agent, then open the PR. Resume a matching pull request instead of creating duplicate work.
 4. After each pull request is ready, stop for human merge unless the user explicitly allowed merging for this run.
-5. When merging is allowed, merge only after required checks and review are clean. Sync the latest remote default branch before starting the next issue.
+5. When merging is allowed, merge only after required checks pass or are confirmed unconfigured, the pull request is mergeable, every current comment has a disposition, no required change remains unresolved, and the description and checklist match the final head. Sync the latest remote default branch before starting the next issue.
 6. Refresh the milestone before each issue. Record pull request links, proof, blockers, and final state in the tracker when access permits.
 7. Report completed issues, merged and open pull requests, blockers, checks, and anything not verified.
 
@@ -25,5 +25,5 @@ Finish every open issue in a GitHub milestone.
 - Use one branch and pull request per issue unless combining issues is required for a working result. Explain any combination before starting it.
 - Do not batch unrelated issues.
 - Never merge without explicit permission.
-- Do not merge with failing checks, important unresolved feedback, missing acceptance criteria, or unexplained test gaps.
+- Do not merge with failing required checks, missing acceptance criteria, a current comment without a disposition, a required change unresolved, or an acceptance criterion or affected failure path left unverified without a user-accepted exception.
 - Stop when an issue has unresolved product or technical decisions, requires missing secrets or permissions, already has conflicting work, or grows beyond its acceptance criteria.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "<design, brief, issue, or request>"
 
 1. Read the source, repository instructions, and relevant code.
 2. Stop and return to design if product or technical choices remain open.
-3. Break the work into vertical, outcome-based tasks small enough for one agent run. Order them by dependency. Add milestones only when they create a useful delivery or review boundary.
+3. Break the work into vertical, outcome-based tasks. Each task must produce one focused, self-contained pull request whose outcome, behavior, and proof can be reviewed without separating unrelated work, and it must fit one agent run. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review. Order tasks by dependency. Add milestones only when they create a useful delivery or review boundary.
 4. Return the plan in chat by default. Create tracker tickets only when the user asks. Never write a plan document.
 5. Stop after planning. Do not implement.
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: "Independently reviews code for correctness, security, regressions, unnecessary complexity, and missing tests or evidence. Use when the user asks for a code review, PR review, diff review, security review, second opinion, or pre-merge review. Launches a fresh subagent and never edits the code."
+description: "Independently reviews whether a design can satisfy its requirements, plus behavior, security, regressions, complexity, test quality, documentation, and missing evidence. Use when the user asks for a code review, PR review, diff review, security review, second opinion, or pre-merge review. Launches a fresh subagent and never edits the code."
 user-invocable: true
 argument-hint: "[ticket, design, diff, branch, commit, PR, or file path]"
 ---
@@ -9,12 +9,21 @@ argument-hint: "[ticket, design, diff, branch, commit, PR, or file path]"
 
 The reviewer must be a fresh subagent that did not implement the change. Do not edit files.
 
-## Workflow
+## Standard
 
-1. Give the reviewer the task, acceptance criteria, repository guidance, diff or PR, and test evidence.
-2. Have it read the relevant surrounding code and try to prove the change wrong. Check behavior, edge cases, failures, security boundaries, interfaces, compatibility, regressions, scope, complexity, and whether tests exercise the changed behavior.
-3. Have it run focused checks when practical.
-4. Return actionable findings in severity order. For each finding give the location, impact, evidence, and smallest fix direction.
+Approve only when the change matches its source, behaves as required, and has no known defect or unmitigated risk that could violate the source or repository policy in security, data loss, compatibility, or operations. If the same outcome and proof can be delivered with less state, indirection, duplication, or operational work, request the simpler design. Do not demand perfection or block on personal taste. Cite technical evidence or repository conventions.
+
+The verdict is independent agent evidence. It is not GitHub approval or a replacement for human review.
+
+## Review order
+
+1. **Set the frame.** Give the reviewer the task, acceptance criteria, repository guidance, complete diff or pull request, and test evidence. Identify the user or developer affected by the change.
+2. **Take the broad view.** Read the available change summary, local execution outline, or pull request description, plus the relevant design or ticket. Confirm the change belongs in the system, matches the intended behavior, and is one reviewable outcome. Report a mismatch with the source or a design that cannot satisfy its requirements before reviewing details.
+3. **Review the main behavior.** Start with the files and flows that implement the outcome. Check functionality for users and developers, failures, security boundaries, interfaces, compatibility, migrations, concurrency, and operations.
+4. **Review every human-written changed line in context.** Inspect enough surrounding code to judge correctness, regressions, complexity, naming, comments, style, and documentation. For generated files or large data, inspect the generator or source and spot-check output. Keep findings within the change's scope.
+5. **Review the proof.** Check that tests cover the changed behavior and failure paths affected by the change or named in its acceptance criteria, assert observable behavior or a documented internal contract, would fail under a broken implementation, and do not duplicate implementation logic or obscure the scenario with setup. Run focused checks that can confirm or falsify a claim that could change a finding or verdict.
+6. **Check specialist coverage.** Identify security, privacy, concurrency, accessibility, internationalization, or domain-specific work. If the reviewer lacks evidence or expertise for a risk that could violate the source or repository policy, mark it unverified. Use `Blocked` when that gap could conceal such a violation and no qualified reviewer covers it.
+7. **Report findings.** Return actionable findings in severity order. For each finding give the location, impact, evidence, and smallest fix direction.
 
 - **blocker:** unsafe to merge.
 - **important:** should fix before merge.
@@ -28,6 +37,6 @@ If there are no findings, say so. End with `Approve`, `Request changes`, or `Blo
 
 ## Boundaries
 
-- Review only the change.
-- Do not turn preferences into findings.
+- Keep findings within the change, but inspect enough surrounding code to judge each changed line and its system effect.
+- Do not turn preferences into findings. Use technical evidence and repository conventions.
 - Do not approve solely because checks pass.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -12,21 +12,21 @@ Follow this workflow for the requested task, ticket, or pull request:
 1. **Resolve the source.** Resume an existing pull request and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or pull requests.
 2. **Branch.** Resume the branch and worktree for an existing pull request. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its pull request is merged or closed.
 3. **Read the context.** Read the repository instructions and inspect the relevant code.
-4. **Outline the change.** Define the smallest complete change and check it against the ticket, task, or pull request. This is a local execution outline for this one task, not a multi-task plan document. Do not create tickets or a plan document.
-5. **Implement.** Make the change and add tests where necessary.
-6. **Test.** Run any automated checks and tests, including real-browser checks for browser-rendered behavior.
+4. **Outline the change.** Define one focused, self-contained outcome with its related proof. A reviewer must be able to understand its behavior and proof without first separating unrelated work. If the source requires several such changes, split it or return to planning before coding. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review. This is a local execution outline, not a plan document.
+5. **Implement.** Make the change. Test changed behavior, failure paths affected by the change or named in its acceptance criteria, and behavior a refactor must preserve. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, record the concrete reason and substitute evidence.
+6. **Test and self-review.** Run tests and checks that cover the changed behavior and affected interfaces, including a real browser when browser-rendered behavior changes. Inspect the final diff for accidental scope, unclear code, and missing proof before independent review.
 7. **Review.** Review the change with a fresh subagent that did not implement it.
 8. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
 9. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request that meets the pull request standard below.
-10. **Pass CI.** Wait for checks, fix relevant failures, and rerun affected tests and review until required checks pass. If no checks are configured, continue.
-11. **Address feedback.** Inspect current human and bot feedback. Fix important findings, reply to addressed comments with evidence, and rerun affected tests and fresh review. Do not wait indefinitely for future human feedback.
+10. **Pass CI.** Wait for checks, fix failures caused by the change or required by repository policy, and rerun affected tests and review until required checks pass. If no checks are configured, continue.
+11. **Address feedback.** Inspect every current human and bot comment and review thread. Give each one a disposition: change the code or durable documentation, answer the question, push back with technical evidence, link a tracked follow-up and explain why a non-blocking suggestion is outside this pull request, or mark informational feedback as requiring no action. If a reviewer cannot understand the code, clarify the code or documentation before relying on a thread reply. Resolve a thread only when fully addressed. Rerun affected tests and fresh review after requested changes. Do not wait indefinitely for future feedback.
 12. **Refresh the pull request.** Update the title, description, and checklist to match the final head, verification, CI state, review findings, and feedback disposition.
 
 Commit and push every post-PR fix before reassessing checks or feedback.
 
 If the ticket, task, or design is wrong or incomplete, update the source of truth before continuing. Prefer the smallest complete change and no unrelated cleanup.
 
-Stop when the pull request is green, mergeable, and has no important unresolved feedback currently available. Never merge unless the user explicitly asks. Report an exact blocker when required access, checks, or independent review remain unavailable after safe alternatives are exhausted.
+Stop when the pull request is green, mergeable, every current comment has a disposition, and no required change remains unresolved. Never merge unless the user explicitly asks. Report an exact blocker when required access, checks, or independent review remain unavailable after safe alternatives are exhausted.
 
 ## Pull request standard
 
@@ -70,11 +70,11 @@ change, tell the reviewer where to start and what needs the closest scrutiny.
 - **Did you write or update tests?** <Yes | No | Not applicable>
   Evidence or why tests do not apply.
 - **Did you run the relevant tests and checks?** <Yes | No>
-  Commands, browser or manual checks, results, and important gaps.
+  Commands, browser or manual checks, results, and any unverified criteria or affected failure paths.
 - **Did you independently review the final diff and address valid findings?** <Yes | No>
   Review evidence, findings fixed, and anything unresolved.
 - **Did you update documentation when behavior changed?** <Yes | No | Not applicable>
   Documentation changed or why it was not needed.
 - **Did required CI checks pass?** <Yes | No | Pending | Not configured>
-  Result or relevant details.
+  Check names and results.
 ```

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -10,10 +10,11 @@ argument-hint: "<task, acceptance criteria, diff, branch, PR, URL, or flow>"
 ## Workflow
 
 1. Read the task, acceptance criteria, changed code, existing tests, and repository instructions.
-2. Map every acceptance criterion and important failure path to proof. Add or update focused tests when proof is missing.
-3. Run the narrowest relevant checks, then wider checks when shared behavior or interfaces changed.
-4. For browser-rendered behavior, start the documented app and verify the main flow and important failure states in a real browser. Check desktop and mobile layout when relevant, keyboard use, console errors, and failed requests. Capture evidence. Source inspection is not browser proof.
-5. Report each criterion as pass, fail, or unverified with the command, browser flow, or evidence that supports it.
+2. Map every acceptance criterion and failure path affected by the change to proof. Test changed behavior, those failure paths, and behavior a refactor must preserve. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.
+3. Add or update focused tests where proof is missing. Check that assertions would fail when the changed behavior breaks and assert observable behavior rather than incidental implementation unless the internal contract is the target. Keep setup and assertions no more complex than the scenario requires.
+4. Run the narrowest checks that exercise the changed behavior and affected interfaces, then wider checks when shared behavior or interfaces changed.
+5. When browser-rendered behavior changes, start the documented app and verify the acceptance-criteria flows and affected failure states in a real browser. Check desktop and mobile when layout or responsive styles changed, and check keyboard use when interactions changed. Check console errors and failed requests during every browser flow. Capture evidence. Source inspection is not browser proof.
+6. Report each criterion as pass, fail, or unverified with the command, browser flow, or evidence that supports it.
 
 ## Boundaries
 


### PR DESCRIPTION
## What is this change?

Strengthen Blueprint review and delivery rules with evidence-based checks for reviewable scope, test coverage, review order, complexity, specialist gaps, current PR feedback, and milestone merge gates.

The change replaces vague terms such as “code health,” “important failures,” “review is clean,” and “when relevant” with conditions tied to the task source, repository policy, affected behavior, acceptance criteria, or explicit user decisions.

## Why is it important?

Vague quality rules let two capable agents reach different conclusions while both claim compliance. Concrete rules make task planning, implementation, testing, review, PR feedback, and milestone delivery more consistent and easier to audit.

The approach follows Google public guidance on small changes, broad-to-detailed review, testing changed behavior, and resolving every review comment without copying the ambiguous phrase “overall code health.”

## What should the reviewer know or consider?

PR #47 is merged. This PR is its focused follow-up for broader engineering-practice rules and targets `main` directly.

The seven-skill surface is unchanged. No skill was added, removed, or merged. The main review path is `skills/review/SKILL.md`, with matching policy and workflow changes across `/plan`, `/test`, `/improve`, `/task-to-pr`, and `/milestone`.

Pre-publication review can use the change summary or local execution outline; existing PR review can use the PR description. Test exceptions are limited to changes with no executable behavior or behavior that has no available automated interface and require substitute evidence. Milestone delivery cannot merge with unverified proof unless the user accepts the exception.

References:

- [Google: Small CLs](https://google.github.io/eng-practices/review/developer/small-cls.html)
- [Google: What to look for in a code review](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
- [Google: Navigating a CL in review](https://google.github.io/eng-practices/review/reviewer/navigate.html)
- [Google: Handling reviewer comments](https://google.github.io/eng-practices/review/developer/handling-comments.html)

## Checklist

- **Is this one focused, self-contained change?** Yes
  One prose-only outcome: make Blueprint engineering checks evidence-based.
- **Did you write or update tests?** Not applicable
  The change has no executable behavior. Metadata, inventory, wording, Markdown, template-parity, and diff checks provide substitute evidence.
- **Did you run the relevant tests and checks?** Yes
  `git diff --check origin/main`; YAML frontmatter parsing for all skills; exact seven-skill inventory; vague-language scan; Markdown rendering; six-of-six template and skill checklist parity; workflow-order and milestone-gate checks.
- **Did you independently review the final diff and address valid findings?** Yes
  Fresh reviewers found undefined risk, failure, refactor, comment-disposition, test-exception, milestone merge, and pre-publication review gates. Every valid finding was fixed and rereviewed. Final verdict on head `bffb46a`: Approve with no blocker or important findings. The GitHub review thread has an evidence reply and is resolved.
- **Did you update documentation when behavior changed?** Yes
  Updated repository policy, public principles, review guidance, and all affected skill instructions.
- **Did required CI checks pass?** Not configured
  GitHub reports no checks for this branch.