### PR TITLE
feat(architecture): separate current state from design specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 
 ## Phases
 
-- `/architecture`: document the verified current system and its boundaries. Stop for human review.
+- `/architecture`: explain the verified current system in chat, or document it when a durable artifact is requested. Stop for human review.
 - `/design`: decide what to build, why, and how. Stop for human review.
 - `/plan`: split decided work into ordered, agent-ready tasks. Stop before implementation.
 - `/test`: prove acceptance criteria and failure paths affected by the change, including real-browser checks when browser-rendered behavior changes.
@@ -38,7 +38,7 @@ For one end-to-end code change, follow the canonical [`/task-to-pr` skill](skill
 
 ## Outputs
 
-- Whole-system architecture defaults to `ARCHITECTURE.md`. Explicitly scoped subsystem architecture defaults to its established document or `docs/<subsystem>/architecture.md`.
+- When a durable document is requested, whole-system architecture defaults to `ARCHITECTURE.md`. Explicitly scoped subsystem architecture defaults to its established document or `docs/<subsystem>/architecture.md`.
 - Designs default to `docs/<feature-slug>/design.md`.
 - Plans are returned in chat by default or published as tracker tickets when asked. They are not stored as plan documents.
 - Pull requests explain what changed, why it matters, what the reviewer should consider, and a truthful checklist covering tests, checks, independent review, findings, documentation, and CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 
 - Give agents outcomes, constraints, and proof. Trust them with mechanics.
 - Keep one skill per meaningful engineering phase or delivery outcome.
+- Keep current architecture separate from proposed design. Update existing architecture documents when implementation changes ownership, dependency direction, protocols, durable data, trust boundaries, deployment topology, or hard limits.
 - Skip phases that add no value. Small, decided work can go straight to implementation.
 - A task is ready when a new agent can finish it without asking product or technical questions.
 - Each pull request delivers one focused, self-contained outcome with its related proof. A change is reviewable when its outcome, behavior, and proof can be understood without first separating unrelated work. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review.
@@ -18,6 +19,7 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 
 ## Phases
 
+- `/architecture`: document the verified current system and its boundaries. Stop for human review.
 - `/design`: decide what to build, why, and how. Stop for human review.
 - `/plan`: split decided work into ordered, agent-ready tasks. Stop before implementation.
 - `/test`: prove acceptance criteria and failure paths affected by the change, including real-browser checks when browser-rendered behavior changes.
@@ -36,6 +38,7 @@ For one end-to-end code change, follow the canonical [`/task-to-pr` skill](skill
 
 ## Outputs
 
+- Whole-system architecture defaults to `ARCHITECTURE.md`. Explicitly scoped subsystem architecture defaults to its established document or `docs/<subsystem>/architecture.md`.
 - Designs default to `docs/<feature-slug>/design.md`.
 - Plans are returned in chat by default or published as tracker tickets when asked. They are not stored as plan documents.
 - Pull requests explain what changed, why it matters, what the reviewer should consider, and a truthful checklist covering tests, checks, independent review, findings, documentation, and CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Blueprint keeps shared repository policy in `AGENTS.md` and only Claude-specific setup here.
 
-Install Blueprint with `npx skills add owainlewis/blueprint`. Invoke the phase skills as `/design`, `/plan`, `/test`, `/review`, and `/improve`. Use `/task-to-pr` for one end-to-end code change and `/milestone` for every issue in a GitHub milestone.
+Install Blueprint with `npx skills add owainlewis/blueprint`. Invoke the phase skills as `/architecture`, `/design`, `/plan`, `/test`, `/review`, and `/improve`. Use `/task-to-pr` for one end-to-end code change and `/milestone` for every issue in a GitHub milestone.
 
 All Blueprint entry points are skills. `/task-to-pr` is the canonical delivery workflow, and `/milestone` runs it one issue at a time. `AGENTS.md` contains portable repository policy.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,11 +1,12 @@
 # Migrate to the phase model
 
-> **Breaking change:** Blueprint now ships five phase skills and two delivery skills. Old skill directories and copied workflow commands must be removed manually.
+> **Breaking change:** Blueprint now ships six phase skills and two delivery skills. Old skill directories and copied workflow commands must be removed manually.
 
 ## What changed
 
 | Before | Now |
 | --- | --- |
+| No previous equivalent | `/architecture` |
 | `design-doc`, `spec` | `/design` |
 | `browser-verify` | Browser proof inside `/test` |
 | `refactor` | `/improve` |
@@ -19,20 +20,20 @@
 The public skill surface is now:
 
 ```text
-/design · /plan · /test · /review · /improve · /task-to-pr · /milestone
+/architecture · /design · /plan · /test · /review · /improve · /task-to-pr · /milestone
 ```
 
 ## Clean upgrade
 
 1. **Remove old Blueprint entry points.** In the skill directory used by your coding tool, remove only the old Blueprint skill folders listed above. Also remove copied Blueprint `implement.md` and `task-to-pr.md` command files. Do not delete whole skill or command directories; they may contain unrelated files.
-2. **Install all seven skills.**
+2. **Install all eight skills.**
 
    ```bash
    npx skills add owainlewis/blueprint
    ```
 
 3. **Remove copied reviewer agents.** Delete any old Blueprint `code-reviewer` definition. The `/review` skill now launches a fresh generic subagent.
-4. **Check the result.** The `/design`, `/plan`, `/test`, `/review`, `/improve`, `/task-to-pr`, and `/milestone` skills should be available.
+4. **Check the result.** The `/architecture`, `/design`, `/plan`, `/test`, `/review`, `/improve`, `/task-to-pr`, and `/milestone` skills should be available.
 
 ## Why cleanup is manual
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Use the smallest entry point that resolves the uncertainty in front of you.
 
 | If you need to… | Start with | Result |
 | --- | --- | --- |
-| Decide what to build or resolve important technical choices | `/design` | A reviewed design with requirements and acceptance criteria |
+| Document or audit how an implemented system works | `/architecture` | A verified current-state architecture reference |
+| Specify a feature or change to part of a system | `/design` | A reviewed design with requirements and acceptance criteria |
 | Split a decided feature into work for several agent runs | `/plan` | Ordered tasks in chat or tracker tickets |
 | Take one task through delivery | `/task-to-pr` | A tested, reviewed, green pull request |
 | Complete every issue in a GitHub milestone | `/milestone` | One green pull request at a time, with human merge checkpoints |
@@ -24,15 +25,19 @@ Use the smallest entry point that resolves the uncertainty in front of you.
 | Get an independent second opinion | `/review` | Findings and a pre-merge verdict from a fresh subagent |
 | Simplify existing code without changing behavior | `/improve` | Clearer, smaller, better-structured code |
 
-Small, decided work can go straight to `/task-to-pr`. Use `/design` only when decisions need review, and `/plan` only when the work needs splitting.
+Small, decided work can go straight to `/task-to-pr`. Use `/architecture` for implemented reality, `/design` when proposed behavior needs review, and `/plan` only when the work needs splitting.
 
 ## How Blueprint fits together
 
 ```mermaid
 flowchart TB
+    Existing([Implemented system]) --> Architecture["/architecture"]
+    Architecture --> Current["Current architecture"]
+
     subgraph Decide["Decide only as much as needed"]
         Idea([Idea or problem]) --> Design["/design"]
         Idea -->|already decided| Task([One task])
+        Current -.-> Design
         Design -->|one task| Task
         Design -->|needs splitting| Plan["/plan"] --> Task
     end
@@ -48,18 +53,19 @@ flowchart TB
     PR --> Merge([Human merge])
 ```
 
-`/improve` is a separate maintenance path for existing code, not a step every change must pass through.
+`/architecture` is a current-system documentation path, and `/improve` is a behavior-preserving maintenance path. Neither is a step every change must pass through.
 
 The model has two layers:
 
 1. **Repository instructions define policy.** `AGENTS.md` says what good work means in a codebase.
 2. **Skills define phases and workflows.** Each skill has one durable engineering outcome and a clear stopping point. `/task-to-pr` and `/milestone` compose the phases into delivery paths.
 
-## The five phases
+## The six phase skills
 
 | Skill | Owns | Stops when |
 | --- | --- | --- |
-| `/design` | What, why, requirements, acceptance criteria, technical design, constraints, risks, and scope | The design is ready for human review |
+| `/architecture` | Current system context, invariants, components, dependencies, flows, boundaries, operations, and verified limitations | The architecture reference is ready for human review |
+| `/design` | A proposed feature or system-part specification: executive summary, system fit, behavior, boundaries, decisions, requirements, proof, and scope | The design is ready for human review |
 | `/plan` | Vertical, ordered tasks and optional milestones | The work is ready to hand off |
 | `/test` | Automated checks, failure paths, and real-browser proof when relevant | Every criterion is pass, fail, or explicitly unverified |
 | `/review` | Independent review of correctness, security, regressions, complexity, and proof | Findings and a verdict are reported |
@@ -86,7 +92,7 @@ It does not wait forever for future human feedback, manufacture tracker artifact
 
 ## Install
 
-Install all seven skills:
+Install all eight skills:
 
 ```bash
 npx skills add owainlewis/blueprint
@@ -97,7 +103,7 @@ Upgrading from the older skill catalogue? Follow the [migration guide](MIGRATION
 ## Repository map
 
 ```text
-skills/                 five phases and two delivery workflow skills
+skills/                 six phase skills and two delivery workflow skills
 AGENTS.md                portable repository policy
 CLAUDE.md                Claude Code adapter
 REVIEW.md                review standard for Blueprint itself
@@ -113,12 +119,13 @@ The RAG chatbot example follows one idea through the decision flow:
 2. [reviewed design](examples/rag-chatbot/design.md)
 3. [captured chat plan](examples/rag-chatbot/plan.md)
 
-For a larger architecture example, read the [Dispatch local control-plane design](examples/dispatch-control-plane/design.md).
+For a larger system-part specification, read the [Dispatch local control-plane design](examples/dispatch-control-plane/design.md).
 
 ## Principles
 
 - **Encode process, not knowledge.** Give agents outcomes, constraints, and proof; trust them with local mechanics.
 - **One skill per phase or delivery outcome.** Skills share one installation and invocation model.
+- **Separate current state from proposals.** Architecture documents describe verified implemented reality. Design documents specify future changes.
 - **Keep changes reviewable.** Deliver one focused, self-contained outcome with its related proof. A reviewer should not need to separate unrelated work first. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review.
 - **Use concrete review standards.** Check correctness. If the same outcome and proof can be delivered with less state, indirection, duplication, or operational work, request the simpler design. Do not block on personal taste. Cite technical evidence or repository conventions.
 - **Proof is part of the work.** Test changed behavior, failure paths affected by the change or named in its acceptance criteria, and behavior a refactor must preserve. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use the smallest entry point that resolves the uncertainty in front of you.
 
 | If you need to… | Start with | Result |
 | --- | --- | --- |
-| Document or audit how an implemented system works | `/architecture` | A verified current-state architecture reference |
+| Explain, document, or audit how an implemented system works | `/architecture` | A verified current-state report or architecture reference |
 | Specify a feature or change to part of a system | `/design` | A reviewed design with requirements and acceptance criteria |
 | Split a decided feature into work for several agent runs | `/plan` | Ordered tasks in chat or tracker tickets |
 | Take one task through delivery | `/task-to-pr` | A tested, reviewed, green pull request |
@@ -64,7 +64,7 @@ The model has two layers:
 
 | Skill | Owns | Stops when |
 | --- | --- | --- |
-| `/architecture` | Current system context, invariants, components, dependencies, flows, boundaries, operations, and verified limitations | The architecture reference is ready for human review |
+| `/architecture` | Current system context, invariants, components, dependencies, flows, boundaries, operations, and verified limitations | The requested report or architecture reference is ready for human review |
 | `/design` | A proposed feature or system-part specification: executive summary, system fit, behavior, boundaries, decisions, requirements, proof, and scope | The design is ready for human review |
 | `/plan` | Vertical, ordered tasks and optional milestones | The work is ready to hand off |
 | `/test` | Automated checks, failure paths, and real-browser proof when relevant | Every criterion is pass, fail, or explicitly unverified |

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -4,6 +4,8 @@ Review Blueprint as a small process product, not a prompt catalogue. Read the is
 
 - Does each skill represent one meaningful engineering phase or delivery outcome?
 - Is policy in `AGENTS.md`, with phase behavior and delivery orchestration in skills?
+- Does `/architecture` describe verified current implementation while `/design` describes a proposed feature or system-part change?
+- When a change affects ownership, dependency direction, protocols, durable data, trust boundaries, topology, or hard limits, is the current architecture reference updated?
 - Are triggers, outputs, boundaries, proof, and stop conditions clear?
 - Is the change one focused, self-contained, reviewable outcome with its related proof?
 - Does `/task-to-pr` reach a tested, independently reviewed, green PR without merging by default?

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -5,6 +5,7 @@ Review Blueprint as a small process product, not a prompt catalogue. Read the is
 - Does each skill represent one meaningful engineering phase or delivery outcome?
 - Is policy in `AGENTS.md`, with phase behavior and delivery orchestration in skills?
 - Does `/architecture` describe verified current implementation while `/design` describes a proposed feature or system-part change?
+- Does a read-only architecture explanation, mapping, review, or audit remain in chat unless the user asks for a durable document?
 - When a change affects ownership, dependency direction, protocols, durable data, trust boundaries, topology, or hard limits, is the current architecture reference updated?
 - Are triggers, outputs, boundaries, proof, and stop conditions clear?
 - Is the change one focused, self-contained, reviewable outcome with its related proof?

--- a/examples/dispatch-control-plane/design.md
+++ b/examples/dispatch-control-plane/design.md
@@ -3,6 +3,8 @@
 > **Status:** Proposed for review
 >
 > **Scope:** Local-first v1
+>
+> **Example:** Reviewed golden output
 
 ## 1. Executive summary
 
@@ -34,11 +36,11 @@ The control plane is authoritative for task definitions, assignments, status, an
 
 ### How it works
 
-A developer creates a task containing a title, prompt, working directory, and ordered steps. A worker registers, heartbeats, and polls for work. The control plane atomically changes one pending task to running and creates a run before returning its steps.
+A developer creates a task containing a title and prompt, with an optional working directory and optional ordered steps. When no usable steps are supplied, the control plane creates one default agent step from the prompt. A worker registers, heartbeats every 5 seconds, and polls every 2 seconds while idle. The control plane atomically changes one pending task to running and creates a run before returning its steps.
 
-The worker executes each step in order. It marks the step running, streams system, stdout, stderr, and agent events with stable sequence numbers, and records the result. A failed step stops later steps. If every step succeeds, the worker completes the run and task as succeeded.
+The worker executes each step in order. It marks the run-specific step record running, streams system, stdout, stderr, and agent events with stable sequence numbers, and records the result. A failed step marks every later run step skipped. If every step succeeds, the worker completes the run and task as succeeded.
 
-A follow-up comment on a completed task creates a new run. When the previous run recorded a Claude session ID, the new agent step can resume that session while preserving the earlier history.
+A user follow-up on a terminal task, either `succeeded` or `failed`, atomically changes the task back to `pending` and stores that comment ID as the pending trigger. The next claim consumes the pending trigger and creates one run linked to it in the same store mutation. An initial run uses the task prompt. A follow-up run stores an effective prompt containing the original task prompt followed by the triggering comment body under a `Follow-up:` label. Further comments while the task is pending or running are recorded but do not queue more runs. When the previous run recorded a Claude session ID, the first Claude agent step in the new run resumes that session with the effective prompt while preserving the earlier history. Any later Claude agent steps start new sessions with the same effective prompt, and the run records the most recently returned session ID.
 
 ```mermaid
 sequenceDiagram
@@ -48,16 +50,20 @@ sequenceDiagram
 
     W->>API: Claim next task
     API-->>W: Task, run, and ordered steps
-    loop Each step
+    loop Each step until one fails
         W->>API: Mark step running
         W->>R: Execute shell command or agent prompt
         R-->>W: Output, events, and exit code
-        W->>API: Append events and step result
+        W->>API: Append events
+        alt Step succeeds
+            W->>API: Complete run step as succeeded
+        else Step fails
+            W->>API: Complete run step as failed
+            API->>API: Skip later steps and fail run and task
+        end
     end
-    alt Every step succeeds
+    opt Every step succeeds
         W->>API: Complete run as succeeded
-    else A step fails
-        W->>API: Complete run as failed
     end
 ```
 
@@ -68,7 +74,7 @@ sequenceDiagram
 | Next.js UI | Task creation and review experience | Control-plane API | Task state or process execution |
 | Control-plane API | Validation, assignment, status transitions, and event ordering | Store | Local command execution |
 | JSON store | Durable local task, run, step, comment, and event records | Local filesystem | Concurrency across control-plane processes |
-| Go worker | Polling, heartbeats, and sequential step execution | Control-plane API and local runtimes | Scheduling or durable history |
+| Go worker | Host identity, polling, heartbeats, and sequential step execution | Control-plane API and local runtimes | Scheduling or durable history |
 | Agent adapter | Structured Claude invocation and session continuation | Agent runtime | Task policy or Git behavior |
 
 ### Decisions
@@ -85,11 +91,11 @@ sequenceDiagram
 
 ### Invariants
 
-1. At most one worker owns a task run at a time.
+1. Each running run has one owning worker, and each worker owns at most one running run.
 2. A worker executes a run's steps in ascending index order.
-3. A failed step prevents every later step in that run from starting.
+3. A failed step marks every later step in that run skipped before the run becomes failed.
 4. Event sequence numbers increase monotonically within a run.
-5. A follow-up creates a new run and never rewrites earlier run history.
+5. A terminal-task follow-up stores at most one pending trigger, which a claim consumes into exactly one new run without rewriting earlier history.
 6. The control plane, not a worker, is authoritative for task and run status.
 
 ### Requirements
@@ -97,8 +103,9 @@ sequenceDiagram
 - Developers can create tasks from a web UI or API.
 - One or more local workers can register, heartbeat, claim tasks, and report completion.
 - Tasks contain ordered shell and agent steps.
-- Runs retain comments, status, and ordered event streams for review.
-- Follow-up replies can continue a completed Claude Code session.
+- Tasks retain comments. Runs retain status and ordered event streams for review.
+- Follow-up replies on terminal tasks can continue the previous Claude Code session.
+- A developer can recover an abandoned run after its worker has been disconnected for at least 15 seconds, then submit a follow-up to retry it.
 - The control plane starts with `just dev`; workers run as separate processes.
 - Checkout, setup, test, and push behavior remains explicit in task steps.
 
@@ -110,38 +117,67 @@ The shared TypeScript model is the contract used by the UI, API, store, and work
 | --- | --- |
 | `Host` | Machine identity and labels |
 | `Worker` | Runtime process attached to a host |
-| `Task` | User-facing work item and current state |
-| `TaskStep` | Ordered shell or agent operation |
-| `TaskRun` | Execution attempt and optional Claude session ID |
-| `TaskComment` | User, agent, or system comment |
+| `Task` | User-facing work item, current state, and optional pending trigger comment ID |
+| `TaskStep` | Reusable ordered shell or agent definition |
+| `TaskRun` | Execution attempt, immutable worker ID, effective prompt, status, failure reason, optional trigger comment ID, and optional Claude session ID |
+| `TaskRunStep` | Per-run step status, timing, exit result, and failure reason |
+| `TaskComment` | Task-owned user, agent, or system comment |
 | `TaskEvent` | Ordered output or lifecycle event |
 
 Task creation accepts a title, prompt, optional working directory, and optional step definitions. When no usable steps are supplied, the control plane creates one default agent step from the task prompt.
 
-Claude Code has a structured adapter. Other agent commands use this fallback contract:
+Every comment belongs to one task and is immutable. When the first terminal-task follow-up moves the task to `pending`, the task stores that comment ID as its pending trigger. A successful claim atomically copies the ID and resolved effective prompt to the new run, records the claiming worker ID as the immutable owner, and clears the trigger from the task. An initial claim copies the task prompt instead. The claim response includes this effective prompt. The JSON store preserves the trigger across control-plane restarts, and serialized mutation means only one of several concurrent comments can perform the terminal-to-pending transition. Other comments have no run link.
+
+The worker protocol uses these operations:
 
 ```text
-<command> -p "<task prompt>"
+POST /api/tasks                            -> created pending task
+POST /api/tasks/{task_id}/comments         -> recorded comment and queue result
+POST /api/workers/register                 -> host and worker record
+POST /api/workers/{worker_id}/heartbeat    -> refreshed heartbeat
+POST /api/workers/{worker_id}/claim        -> task, run, and run steps; no work; or worker_busy
+POST /api/runs/{run_id}/steps/{index}/start
+POST /api/runs/{run_id}/events
+POST /api/runs/{run_id}/steps/{index}/complete
+POST /api/runs/{run_id}/complete
+POST /api/runs/{run_id}/fail               -> worker-reported run failure
+POST /api/runs/{run_id}/recover            -> guarded manual recovery
+```
+
+Task status moves from `pending` to `running` to `succeeded` or `failed`. A follow-up can move a terminal task back to `pending`. Run status is `running`, `succeeded`, or `failed`; a run is created only by a successful claim. Run-step status moves from `pending` to `running` to `succeeded` or `failed`, while unstarted steps after a failure move from `pending` to `skipped`. A claim from a worker that already owns a running run returns `409` with `worker_busy` and changes no task. Every worker mutation includes its worker ID, and the control plane rejects it unless it matches the run's immutable owner. The control plane also validates every transition and rejects updates to terminal runs.
+
+Claude Code has a structured adapter. Every agent step receives the run's effective prompt. Other agent commands receive that prompt as a direct argument without shell interpolation:
+
+```text
+argv[0] = <command>
+argv[1] = -p
+argv[2] = <run effective prompt>
 ```
 
 ### Naming and identity
 
-The control plane generates opaque IDs for hosts, workers, tasks, runs, comments, and events. A task step is identified by its task ID and stable zero-based index. Event sequence numbers are allocated by the control plane, not accepted from workers. A resumed Claude session ID is provider metadata attached to a run and never used as Dispatch identity.
+On first start, a worker generates an opaque host ID and stores it in its local configuration directory. Later worker processes reuse that host ID and fail startup if the identity file exists but cannot be read. Deleting the file deliberately creates a new host identity on the next start; existing records keep the old ID. Each process registration receives a new opaque worker ID, so a restart preserves host identity but creates a new worker session.
+
+The control plane generates opaque IDs for tasks, runs, comments, and events. A task step is identified by its task ID and stable zero-based index. Event sequence numbers are allocated by the control plane, not accepted from workers. A resumed Claude session ID is provider metadata attached to a run and never used as Dispatch identity.
 
 ## 7. Failure behavior and lifecycle
 
-- A failed step records its output and exit status, marks the run and task failed, and stops remaining steps.
-- A worker claims one task at a time. Loss of its heartbeat makes the worker visibly disconnected, but V1 does not reassign its running task automatically.
+- A failed step records its output and exit status, marks later run steps skipped, marks the run and task failed, and stops execution.
+- A worker claims one task at a time. The UI marks it disconnected when no heartbeat arrives for 15 seconds, but V1 does not reassign its running task automatically.
+- A developer may recover an abandoned run only after the owning worker has been disconnected for at least 15 seconds. One atomic store mutation marks a running step failed with reason `worker_lost`, or the lowest-index pending step when none is running, then marks later pending steps skipped and marks the run and task failed. If every run step already succeeded but the worker disappeared before completing the run, recovery preserves those step results and marks only the run and task failed with reason `worker_lost`.
+- Worker event, step, completion, and failure reports with a missing or different worker ID are rejected.
+- After manual recovery, the control plane rejects late events and completion reports from the abandoned run because terminal history cannot be rewritten.
 - A corrupt store file stops mutations and reports an operator-visible error instead of replacing the file with empty state.
 - A failed store replacement leaves the previous complete file in place.
 - Restarting the control plane reloads the JSON store. Restarting a worker registers a new worker session and does not silently resume an in-flight command.
-- Shutdown stops new claims, lets the active store mutation finish, and terminates worker child processes before exit.
+- Control-plane shutdown stops new claims and lets the active serialized store mutation finish before exit.
+- Worker shutdown stops polling, sends `SIGTERM` to an active child process, waits up to 10 seconds, then sends `SIGKILL`. It then reports the run and task failed with reason `worker_shutdown`. The same transition rule fails the running step or next pending step and skips later pending steps; if all steps succeeded, their results remain unchanged. If the worker cannot reach the control plane, the run remains non-terminal until the developer uses the disconnected-worker recovery action.
 
 ## 8. Security, privacy, and operations
 
 Shell commands and agent runtimes execute with the worker user's permissions. V1 has no sandbox, secret boundary, authentication, or tenant isolation and must stay on developer-controlled machines and networks.
 
-Each worker runs at most one task at a time. One control-plane process serializes all store mutations. Task events and output grow the JSON file without a retention cap in V1, so the UI and documentation must describe manual cleanup and the lack of a production capacity guarantee.
+Each worker runs at most one task at a time, heartbeats every 5 seconds, and polls every 2 seconds only while idle. One control-plane process serializes all store mutations. Task events and output grow the JSON file without a retention cap in V1. If a write or atomic replacement fails, including from a full disk, the API returns an operator-visible error and keeps the previous complete file. The UI and documentation must describe manual cleanup and the lack of a production capacity guarantee.
 
 The control plane exposes worker heartbeat age, task and run status, step exit codes, and ordered event history. Logs include task and run IDs but must not copy secrets from command output into separate metadata.
 
@@ -150,10 +186,18 @@ The control plane exposes worker heartbeat age, task and run status, step exit c
 - A developer can create a task and see it move from `pending` to `running` to `succeeded` or `failed`.
 - A worker claims at most one task at a time and executes its steps in order.
 - Concurrent claim requests assign a pending task to at most one worker.
+- A worker keeps one host ID across restarts, receives a new worker ID for each process, and appears disconnected after 15 seconds without a heartbeat.
 - Shell and agent output appears in the task event stream with stable sequence numbers.
 - A failed step stops the remaining steps and records the failure.
-- A follow-up comment creates a new run, preserves previous history, and can reuse the prior Claude session ID.
+- Every run has separate step status and exit records; a follow-up never resets or reuses an earlier run's step records.
+- A user follow-up on a succeeded or failed task persists its comment ID as the pending trigger. The next claim consumes that marker to create exactly one linked run, preserves previous history, and can reuse the prior Claude session ID. Extra or concurrent comments before that claim do not replace the marker or create extra runs.
+- The initial run uses the task prompt. A follow-up run uses the original task prompt plus the labeled triggering comment body, and its first Claude agent step receives that resolved text when resuming the prior session.
+- Agent prompts containing quotes or shell syntax arrive as one literal process argument.
 - A corrupt store or failed file replacement does not reset existing state.
+- Worker shutdown sends `SIGTERM`, escalates to `SIGKILL` after 10 seconds, and reports interrupted work as failed with reason `worker_shutdown` when the control plane is reachable.
+- A developer can recover abandoned work only after its worker has been disconnected for at least 15 seconds. Recovery handles disconnection before the first step, during a step, between steps, and after the last step but before run completion according to the documented atomic transition.
+- Late events or completion reports cannot change a manually failed run.
+- A worker that does not own a run cannot append events or change its step, run, or task state.
 - The full local flow works with `scripts/fake-claude` before a real agent runtime is required.
 
 ## 10. Test approach
@@ -161,10 +205,18 @@ The control plane exposes worker heartbeat age, task and run status, step exit c
 - Start the control plane and a worker using `scripts/fake-claude`.
 - Create a task containing both shell and agent steps and verify ordered execution, event sequence numbers, and terminal status in the UI.
 - Race two workers against one pending task and verify only one claim succeeds.
-- Force a step failure and verify later steps do not run.
-- Add a follow-up comment and verify a new run preserves previous history and session ID.
+- Give one worker two pending tasks, claim once, then verify its second claim returns `409` with `worker_busy` and leaves the other task pending.
+- Restart a worker and verify the host ID is stable, the worker ID changes, and the old worker becomes disconnected after 15 seconds.
+- Force a step failure and verify later run steps become skipped without starting.
+- Run a follow-up and verify it receives new run-step records while the previous run's records remain unchanged.
+- Add follow-ups to succeeded and failed tasks and verify each next claim creates exactly one linked run without rewriting history. Restart the control plane before the claim and verify the pending trigger survives. Race two follow-up comments and verify exactly one becomes the trigger while both remain in task history.
+- Inspect the claim and fake Claude invocation to verify an initial run receives the task prompt. Verify a follow-up run receives the original prompt plus one labeled copy of the triggering comment body in the resumed first Claude step.
+- Submit event, step, completion, and failure reports with a different worker ID and verify every mutation is rejected.
+- Pass a prompt containing spaces, quotes, `$()`, and semicolons through the fallback adapter and verify it arrives as one literal argument without shell execution.
 - Corrupt a copied store and force a replacement failure to verify the original state is not replaced.
-- Interrupt the control plane and worker during active work to verify shutdown and restart behavior.
+- Interrupt the control plane during a store mutation and verify the mutation finishes before exit.
+- Interrupt a worker during active work and verify `SIGTERM`, 10-second escalation, and the `worker_shutdown` failure when the control plane is reachable.
+- Make the control plane unreachable during worker shutdown, then verify the disconnected-worker recovery action is unavailable before 15 seconds. After 15 seconds, exercise recovery after claim but before step start, during a step, between steps, and after the final step but before run completion. Verify `worker_lost`, failed and skipped step states where applicable, and failed run and task state. Submit a late event and completion report from the old worker and verify both are rejected.
 - Repeat the happy path with a real Claude Code worker before declaring the adapter complete.
 
 ## 11. Risks and tradeoffs
@@ -172,7 +224,7 @@ The control plane exposes worker heartbeat age, task and run status, step exit c
 | Risk | Consequence | Mitigation for V1 |
 | --- | --- | --- |
 | JSON storage | Lost updates or slow rewrites as history grows | Run one control-plane process, serialize mutations, and replace files atomically |
-| Abandoned tasks | A crashed worker can leave work running forever | Expose stale heartbeat and document manual recovery; automatic leases are out of scope |
+| Abandoned tasks | A crashed worker can leave work running forever | Expose stale heartbeat and a guarded manual failure action; automatic leases are out of scope |
 | TypeScript and Go models drift | Runtime contract failures | Keep the worker API small and cover it with shared fixtures |
 | Local command execution | Host access and secret exposure | Limit V1 to developer-controlled machines and document the trust boundary |
 | Explicit task steps | More setup for users | Provide useful defaults without hiding the execution model |

--- a/examples/dispatch-control-plane/design.md
+++ b/examples/dispatch-control-plane/design.md
@@ -2,113 +2,43 @@
 
 > **Status:** Proposed for review
 >
-> **Scope:** Local-first v1 architecture
+> **Scope:** Local-first v1
 
-## What and why
+## 1. Executive summary
 
 Dispatch lets a developer delegate agent work from a web control plane instead of managing every run in an interactive terminal. A local worker claims tasks, runs explicit shell and agent steps, streams evidence back, and preserves enough run history for review and follow-up.
 
-The first version should prove this delegation loop without committing to production infrastructure. It favors inspectable local state and explicit execution over hidden automation.
+Use a Next.js control plane with JSON-backed local state and a separate Go worker for execution. This proves the delegation loop with inspectable state and explicit commands, while accepting single-process storage and developer-machine trust boundaries that are unsuitable for production.
 
-## Requirements
+## 2. Context and scope
 
-- Developers can create tasks from a web UI or API.
-- One or more local workers can register, heartbeat, claim tasks, and report completion.
-- Tasks contain ordered shell and agent steps.
-- Runs retain comments, status, and ordered event streams for review.
-- Follow-up replies can continue a completed Claude Code session.
-- The control plane starts with `just dev`; workers run as separate processes.
-- Checkout, setup, test, and push behavior remains explicit in task steps.
+The current workflow requires a developer to start and supervise each agent in a terminal. Dispatch adds a local task queue, execution history, and web UI without hiding checkout, setup, test, or push behavior inside the platform.
 
-## Acceptance criteria
+V1 covers one local control-plane process and developer-controlled workers. It does not promise production durability, multi-user isolation, remote-machine provisioning, or automatic recovery of abandoned tasks.
 
-- A developer can create a task and see it move from `pending` to `running` to `succeeded` or `failed`.
-- A worker claims at most one task at a time and executes its steps in order.
-- Shell and agent output appears in the task event stream with stable sequence numbers.
-- A failed step stops the remaining steps and records the failure.
-- A follow-up comment creates a new run and can reuse the prior Claude session ID.
-- The full local flow works with `scripts/fake-claude` before a real agent runtime is required.
-
-## Design
-
-Dispatch uses a control-plane and worker split. The Next.js application owns the UI, API, shared TypeScript model, and JSON-backed state. A separate Go process owns local execution.
+## 3. System context
 
 ```mermaid
 flowchart TB
     Developer([Developer]) --> UI["Next.js UI"]
     UI --> API["Control-plane API"]
     API <--> Store[("Local JSON store")]
-    API <-->|tasks · status · events| Worker["Go worker"]
+    Worker["Go worker"] <-->|tasks, status, events| API
     Worker -->|execute| Shell["Local shell"]
-    Worker -->|delegate| Agent["Claude Code"]
+    Worker -->|delegate| Agent["Claude Code or compatible command"]
 ```
 
-### Control plane
+The control plane is authoritative for task definitions, assignments, status, and history. Workers own local process execution but do not decide task ordering or durable state.
 
-The control plane stores hosts, workers, tasks, runs, steps, comments, and events in `.agentctrl-data/store.json`. API routes create tasks, serve UI state, register workers, assign pending work, append events, and complete runs.
+## 4. Proposed design
 
-All mutations pass through `withStore` in `control-plane/lib/store.ts`, which reads the file, changes an in-memory object, and writes the result. This is sufficient for a local prototype but is not a production concurrency model.
+### How it works
 
-### Worker
+A developer creates a task containing a title, prompt, working directory, and ordered steps. A worker registers, heartbeats, and polls for work. The control plane atomically changes one pending task to running and creates a run before returning its steps.
 
-The worker:
+The worker executes each step in order. It marks the step running, streams system, stdout, stderr, and agent events with stable sequence numbers, and records the result. A failed step stops later steps. If every step succeeds, the worker completes the run and task as succeeded.
 
-1. registers its host and worker identity;
-2. heartbeats while polling;
-3. claims one pending task;
-4. executes its steps sequentially;
-5. streams system, stdout, stderr, and agent events;
-6. completes the run and task as `succeeded` or `failed`.
-
-Claude Code has a structured adapter. Other agent commands use the fallback contract:
-
-```text
-<command> -p "<task prompt>"
-```
-
-### Tasks, runs, and events
-
-A task is the user-facing unit of work. A run is one execution attempt. A task can have several runs so a follow-up can continue the same work without rewriting history.
-
-```mermaid
-classDiagram
-    Task "1" --> "*" TaskRun : attempts
-    Task "1" --> "*" TaskStep : defines
-    TaskRun "1" --> "*" TaskEvent : records
-    TaskRun "0..1" --> "0..1" TaskComment : triggered by
-
-    class Task {
-        id
-        title
-        prompt
-        workDir
-        status
-    }
-    class TaskRun {
-        id
-        taskId
-        status
-        sessionId
-    }
-    class TaskStep {
-        index
-        type
-        command
-        status
-    }
-    class TaskEvent {
-        seq
-        stream
-        message
-    }
-    class TaskComment {
-        id
-        author
-        body
-    }
-```
-
-### Execution
+A follow-up comment on a completed task creates a new run. When the previous run recorded a Claude session ID, the new agent step can resume that session while preserving the earlier history.
 
 ```mermaid
 sequenceDiagram
@@ -131,9 +61,50 @@ sequenceDiagram
     end
 ```
 
-## Interfaces and data
+### Components and responsibilities
 
-The shared TypeScript model is the contract between the UI, API, store, and worker responses.
+| Component | Owns | Depends on | Does not own |
+| --- | --- | --- | --- |
+| Next.js UI | Task creation and review experience | Control-plane API | Task state or process execution |
+| Control-plane API | Validation, assignment, status transitions, and event ordering | Store | Local command execution |
+| JSON store | Durable local task, run, step, comment, and event records | Local filesystem | Concurrency across control-plane processes |
+| Go worker | Polling, heartbeats, and sequential step execution | Control-plane API and local runtimes | Scheduling or durable history |
+| Agent adapter | Structured Claude invocation and session continuation | Agent runtime | Task policy or Git behavior |
+
+### Decisions
+
+**Keep execution outside Next.js.** Running workers inside the web server would simplify startup, but task lifetimes would share the web process and make separate or remote workers harder later.
+
+**Start with serialized JSON storage.** Postgres would improve concurrency and durability, but adds setup before the local delegation loop is validated. All mutations therefore pass through one `withStore` path that reads, changes, and atomically replaces the file.
+
+**Represent work as ordered steps.** A single prompt is smaller, but it cannot make checkout, setup, test, and push behavior explicit. Defaults may create one agent step without hiding the step model.
+
+**Keep repository operations explicit.** Dispatch executes the supplied steps rather than embedding project-specific Git and workspace policy.
+
+## 5. Invariants and requirements
+
+### Invariants
+
+1. At most one worker owns a task run at a time.
+2. A worker executes a run's steps in ascending index order.
+3. A failed step prevents every later step in that run from starting.
+4. Event sequence numbers increase monotonically within a run.
+5. A follow-up creates a new run and never rewrites earlier run history.
+6. The control plane, not a worker, is authoritative for task and run status.
+
+### Requirements
+
+- Developers can create tasks from a web UI or API.
+- One or more local workers can register, heartbeat, claim tasks, and report completion.
+- Tasks contain ordered shell and agent steps.
+- Runs retain comments, status, and ordered event streams for review.
+- Follow-up replies can continue a completed Claude Code session.
+- The control plane starts with `just dev`; workers run as separate processes.
+- Checkout, setup, test, and push behavior remains explicit in task steps.
+
+## 6. Interfaces and data
+
+The shared TypeScript model is the contract used by the UI, API, store, and worker responses.
 
 | Type | Purpose |
 | --- | --- |
@@ -147,53 +118,75 @@ The shared TypeScript model is the contract between the UI, API, store, and work
 
 Task creation accepts a title, prompt, optional working directory, and optional step definitions. When no usable steps are supplied, the control plane creates one default agent step from the task prompt.
 
-## Failure behavior
+Claude Code has a structured adapter. Other agent commands use this fallback contract:
 
-- A failed step stops the task and records its output and exit status.
-- A worker claims only one task, preventing parallel execution inside one process.
-- Heartbeats expose disconnected workers, but v1 does not reclaim abandoned tasks automatically.
-- Corrupt or concurrent JSON writes are local-prototype risks; production use requires transactional storage.
-- Shell commands and agent runtimes execute with the local user's permissions. There is no sandbox or secret boundary in v1.
+```text
+<command> -p "<task prompt>"
+```
 
-## Test approach
+### Naming and identity
+
+The control plane generates opaque IDs for hosts, workers, tasks, runs, comments, and events. A task step is identified by its task ID and stable zero-based index. Event sequence numbers are allocated by the control plane, not accepted from workers. A resumed Claude session ID is provider metadata attached to a run and never used as Dispatch identity.
+
+## 7. Failure behavior and lifecycle
+
+- A failed step records its output and exit status, marks the run and task failed, and stops remaining steps.
+- A worker claims one task at a time. Loss of its heartbeat makes the worker visibly disconnected, but V1 does not reassign its running task automatically.
+- A corrupt store file stops mutations and reports an operator-visible error instead of replacing the file with empty state.
+- A failed store replacement leaves the previous complete file in place.
+- Restarting the control plane reloads the JSON store. Restarting a worker registers a new worker session and does not silently resume an in-flight command.
+- Shutdown stops new claims, lets the active store mutation finish, and terminates worker child processes before exit.
+
+## 8. Security, privacy, and operations
+
+Shell commands and agent runtimes execute with the worker user's permissions. V1 has no sandbox, secret boundary, authentication, or tenant isolation and must stay on developer-controlled machines and networks.
+
+Each worker runs at most one task at a time. One control-plane process serializes all store mutations. Task events and output grow the JSON file without a retention cap in V1, so the UI and documentation must describe manual cleanup and the lack of a production capacity guarantee.
+
+The control plane exposes worker heartbeat age, task and run status, step exit codes, and ordered event history. Logs include task and run IDs but must not copy secrets from command output into separate metadata.
+
+## 9. Acceptance criteria
+
+- A developer can create a task and see it move from `pending` to `running` to `succeeded` or `failed`.
+- A worker claims at most one task at a time and executes its steps in order.
+- Concurrent claim requests assign a pending task to at most one worker.
+- Shell and agent output appears in the task event stream with stable sequence numbers.
+- A failed step stops the remaining steps and records the failure.
+- A follow-up comment creates a new run, preserves previous history, and can reuse the prior Claude session ID.
+- A corrupt store or failed file replacement does not reset existing state.
+- The full local flow works with `scripts/fake-claude` before a real agent runtime is required.
+
+## 10. Test approach
 
 - Start the control plane and a worker using `scripts/fake-claude`.
-- Create a task containing both shell and agent steps.
-- Verify ordered execution, event sequence numbers, and terminal status in the UI.
+- Create a task containing both shell and agent steps and verify ordered execution, event sequence numbers, and terminal status in the UI.
+- Race two workers against one pending task and verify only one claim succeeds.
 - Force a step failure and verify later steps do not run.
-- Add a follow-up comment and verify a new run preserves the previous history and session ID.
+- Add a follow-up comment and verify a new run preserves previous history and session ID.
+- Corrupt a copied store and force a replacement failure to verify the original state is not replaced.
+- Interrupt the control plane and worker during active work to verify shutdown and restart behavior.
 - Repeat the happy path with a real Claude Code worker before declaring the adapter complete.
 
-## Risks
+## 11. Risks and tradeoffs
 
-| Risk | Consequence | Mitigation for v1 |
+| Risk | Consequence | Mitigation for V1 |
 | --- | --- | --- |
-| JSON storage | Lost updates under concurrent writes | Keep v1 local and serialize mutations through `withStore` |
-| Long polling | Extra latency and repeated requests | Accept the tradeoff until the delegation loop is proven |
-| TypeScript and Go models drift | Runtime contract failures | Keep the model small; consider generated clients before production |
-| Local command execution | Host access and secret exposure | Limit v1 to developer-controlled machines and document the trust boundary |
+| JSON storage | Lost updates or slow rewrites as history grows | Run one control-plane process, serialize mutations, and replace files atomically |
+| Abandoned tasks | A crashed worker can leave work running forever | Expose stale heartbeat and document manual recovery; automatic leases are out of scope |
+| TypeScript and Go models drift | Runtime contract failures | Keep the worker API small and cover it with shared fixtures |
+| Local command execution | Host access and secret exposure | Limit V1 to developer-controlled machines and document the trust boundary |
 | Explicit task steps | More setup for users | Provide useful defaults without hiding the execution model |
 
-## Alternatives considered
+## 12. Open questions
 
-- **Run workers inside Next.js.** Simpler startup, but task execution would share the web server lifecycle and make remote workers harder later.
-- **Start with Postgres.** Better durability and concurrency, but unnecessary setup before the local loop is validated.
-- **Represent every task as one prompt.** Smaller model, but no explicit checkout, setup, test, or push steps.
-- **Hide Git and workspace operations.** Easier demos, but forces project-specific policy into Dispatch too early.
+- What event retention or compaction policy should replace manual cleanup before production use? This does not block local V1.
+- What lease and idempotency model should reclaim abandoned tasks? This blocks distributed or unattended use, not local V1.
 
-## Rollout
-
-1. Prove the complete flow with the fake agent runtime.
-2. Run real local Claude Code tasks and follow-ups.
-3. Validate failure reporting and abandoned-worker behavior.
-4. Replace JSON with Postgres while preserving task, run, step, comment, and event concepts.
-5. Add authentication, worker tokens, secret handling, and workspace isolation before networked or multi-user use.
-
-## Out of scope
+## 13. Out of scope
 
 - Production durability or horizontally scaled control planes
 - Multi-user authentication and tenant isolation
 - Worker-machine provisioning
-- A distributed scheduler or lease-recovery system
+- A distributed scheduler or automatic lease recovery
 - Budgets and agent-created task trees
 - Equal first-class support for every agent runtime

--- a/examples/rag-chatbot/design.md
+++ b/examples/rag-chatbot/design.md
@@ -1,14 +1,16 @@
 # RAG Chatbot API
 
-> **Status:** Reviewed example
+> **Status:** Proposed for review
 >
 > **Source:** [`examples/input.md`](../input.md)
+>
+> **Example:** Reviewed golden output
 
 ## 1. Executive summary
 
 Build a single-user Python API for uploading PDFs and asking questions answered from their contents. Answers must be grounded in retrieved chunks and include source references so the service does not invent information outside the uploaded documents.
 
-Use FastAPI, PostgreSQL with pgvector, and the OpenAI API behind a replaceable adapter. Keep ingestion synchronous and the retrieval model deliberately small. This favors a clear local system and deterministic tests over background processing or retrieval sophistication.
+Use FastAPI, PostgreSQL with pgvector, and the OpenAI API behind a replaceable adapter, with `uv` managing the Python project. Keep ingestion synchronous and the retrieval model deliberately small. This favors a clear local system and deterministic tests over background processing or retrieval sophistication.
 
 ## 2. Context and scope
 
@@ -67,7 +69,7 @@ Deleting a document removes its chunks through a database cascade. Later retriev
 
 ### Invariants
 
-1. Every returned factual answer is generated only from chunks included in its source list.
+1. The answer generator receives no document context except the chunks returned in that response's source list.
 2. A deleted document has no chunks available to retrieval.
 3. A failed upload leaves no document or chunk rows behind.
 4. Provider failures never appear as successful grounded answers.
@@ -80,25 +82,32 @@ Deleting a document removes its chunks through a database cascade. Later retriev
 - Answer a question with an answer and ordered source references from relevant chunks.
 - Return a fixed no-information response when no relevant chunk exists.
 - Run locally with Docker Compose using FastAPI and PostgreSQL with pgvector.
+- Use `uv` for Python package and environment management.
 - Keep configuration in environment variables and OpenAI calls replaceable in tests.
+- Expose a health endpoint that reports whether the API can reach PostgreSQL.
 
 ## 6. Interfaces and data
 
 ```text
-POST   /api/v1/documents      -> {id, filename, uploaded_at, chunk_count}
+GET    /health                -> {status: "ok"}
+POST   /api/v1/documents      <- multipart/form-data with one file field
+                              -> {id, filename, uploaded_at, chunk_count}
 GET    /api/v1/documents      -> [{id, filename, uploaded_at, chunk_count}]
 DELETE /api/v1/documents/{id} -> {deleted: true}
-POST   /api/v1/chat           -> {answer, sources: [{document_id, filename, chunk_index, content}]}
+POST   /api/v1/chat           <- {message}
+                              -> {answer, sources: [{document_id, filename, chunk_index, content}]}
 Errors                        -> {error: {code, message}}
 ```
 
-Error codes are `bad_request`, `payload_too_large`, `not_found`, and `upstream_error`.
+Error codes are `bad_request`, `payload_too_large`, `not_found`, `internal_error`, `service_unavailable`, and `upstream_error`.
 
 Store one row per document and many related chunk rows. Each chunk holds its text, zero-based position, embedding, and document ID. The document foreign key cascades on delete.
 
 `RAG_RELEVANCE_THRESHOLD` configures the minimum inclusive cosine similarity and defaults to `0.75`. Startup accepts both `0` and `1` and fails unless the value is numeric and satisfies `0 <= value <= 1`.
 
 `SERVER_GRACEFUL_SHUTDOWN_SECONDS` configures the shutdown deadline and defaults to `10`. Startup fails unless it is an integer from `1` through `60`.
+
+`DATABASE_URL` and `OPENAI_API_KEY` are required. Startup fails before serving traffic when either setting is missing.
 
 ### Naming and identity
 
@@ -110,8 +119,10 @@ The service generates an opaque UUID for each uploaded document. The original fi
 - Reject a PDF over 25 MiB using `413` and `payload_too_large`.
 - Return `404` and `not_found` when deleting a missing document.
 - Return `502` and `upstream_error` when embedding or answer generation fails.
-- Roll back the upload transaction when persistence fails.
+- Return `503` and `service_unavailable` when `/health` cannot reach PostgreSQL. The health check does not call OpenAI.
+- Return `500` and `internal_error` when a document or chat database operation fails. A failed upload transaction rolls back before this response is returned.
 - Return the fixed no-information response with status `200` when retrieval has no qualifying chunks.
+- Return `400` and `bad_request` when the chat message is missing or empty.
 - Fail startup before serving traffic when required database or OpenAI configuration is missing.
 - On shutdown, stop accepting new requests and wait up to `SERVER_GRACEFUL_SHUTDOWN_SECONDS` for in-flight requests. After the deadline, cancel remaining requests and let open database transactions roll back.
 
@@ -124,28 +135,39 @@ Uploads are limited to 25 MiB and rejected before extraction when larger. Chat r
 ## 9. Acceptance criteria
 
 - `POST /api/v1/documents` accepts a PDF up to 25 MiB and returns its ID, filename, upload time, and chunk count.
+- `GET /health` returns `200` with `{"status":"ok"}` when the API can reach PostgreSQL and `503` with `service_unavailable` when it cannot.
 - Uploading a non-PDF, an empty-text PDF, or a file over 25 MiB returns `400` with `bad_request`, `400` with `bad_request`, or `413` with `payload_too_large` respectively and creates no rows.
 - `GET /api/v1/documents` lists uploaded documents.
 - `DELETE /api/v1/documents/{id}` removes the document and makes its chunks unavailable to retrieval.
 - `POST /api/v1/chat` returns a grounded answer and ordered source references for known fixture content.
+- Chat retrieves at most five qualifying chunks, and the mocked answer generator receives exactly the same ordered chunk content returned in `sources`.
 - A chunk with cosine similarity exactly equal to `RAG_RELEVANCE_THRESHOLD` qualifies; a lower score does not.
 - Chunks with equal similarity are ordered by document ID and then chunk index.
 - Threshold configuration accepts `0` and `1` and rejects non-numeric values, values below `0`, and values above `1` before startup.
 - Chat with no relevant content returns `{"answer":"No relevant information found in uploaded documents.","sources":[]}`.
+- After a failed upload or document deletion, chat for that document's fixture content returns the fixed no-information response with no sources.
+- A missing or empty chat message returns `400` with `bad_request`.
 - Missing deletion returns `404`, and upstream OpenAI failures return `502`, both with the documented error shape.
+- A forced upload persistence failure returns `500` with `internal_error` and leaves no document or chunk rows.
+- Database failures while listing, deleting, or retrieving for chat return `500` with `internal_error`.
+- Startup fails before serving traffic when `DATABASE_URL` or `OPENAI_API_KEY` is missing or when either bounded numeric setting is invalid.
 - Shutdown stops new requests, gives in-flight requests 10 seconds by default, then cancels remaining work without committing a partial upload.
 - The full test suite passes against PostgreSQL with pgvector while OpenAI calls are mocked.
+- `uv sync --frozen` and `uv run pytest` are the supported local dependency and test commands.
 
 ## 10. Test approach
 
 - Use `pytest` and `httpx` for endpoint tests.
 - Test persistence and vector behavior against PostgreSQL with pgvector.
 - Mock OpenAI calls with deterministic embeddings and answers.
-- Use a small PDF fixture containing known text to prove grounded chat and source references.
+- Use a small PDF fixture containing the sentence "PostgreSQL with pgvector stores the embeddings." to prove grounded chat and source references.
 - Use deterministic embeddings that produce scores equal to, immediately below, and immediately above `RAG_RELEVANCE_THRESHOLD`.
+- Create more than five qualifying chunks, then assert that retrieval, generator context, and returned sources use the same ordered first five chunks.
 - Cover threshold configuration at `0`, at `1`, below `0`, above `1`, and with a non-numeric value.
 - Start a deliberately slow upload, request shutdown, and cover completion before the configured deadline and cancellation with transaction rollback after it.
-- Cover upload, list, delete, relevant chat, no-result chat, transaction rollback, and the `400`, `404`, `413`, and `502` paths.
+- Cover upload, list, delete, relevant chat, no-result chat, transaction rollback, and the `400`, `404`, `413`, `500`, and `502` paths.
+- Cover health with PostgreSQL available and unavailable, missing or empty chat messages, and database failures during list, delete, and chat retrieval.
+- Cover startup with each required setting missing.
 - Assert through the public API that a deleted document and a failed upload leave no retrievable chunks.
 
 ## 11. Risks and tradeoffs

--- a/examples/rag-chatbot/design.md
+++ b/examples/rag-chatbot/design.md
@@ -4,54 +4,85 @@
 >
 > **Source:** [`examples/input.md`](../input.md)
 
-## What and why
+## 1. Executive summary
 
-Build a Python API that lets one user upload PDFs and ask questions answered from their contents. Answers must be grounded in retrieved chunks so the service does not invent information outside the uploaded documents.
+Build a single-user Python API for uploading PDFs and asking questions answered from their contents. Answers must be grounded in retrieved chunks and include source references so the service does not invent information outside the uploaded documents.
 
-## Requirements
+Use FastAPI, PostgreSQL with pgvector, and the OpenAI API behind a replaceable adapter. Keep ingestion synchronous and the retrieval model deliberately small. This favors a clear local system and deterministic tests over background processing or retrieval sophistication.
+
+## 2. Context and scope
+
+The project starts with no existing application. V1 must support the complete local path from PDF upload to grounded answer, plus listing and deleting documents. It runs with Docker Compose and assumes one trusted user, so authentication and tenant isolation are outside this design.
+
+## 3. System context
+
+```mermaid
+flowchart TB
+    subgraph API["FastAPI service"]
+        Upload["Document endpoints"]
+        Chat["Chat endpoint"]
+        Extract["PDF extraction and chunking"]
+        Provider["OpenAI adapter"]
+    end
+
+    User([User]) --> Upload
+    User --> Chat
+    Upload --> Extract --> Provider
+    Chat --> Provider
+    Upload --> DB[("PostgreSQL + pgvector")]
+    Chat --> DB
+    Provider --> OpenAI["OpenAI API"]
+```
+
+The API owns request validation and orchestration. PostgreSQL is the source of truth for documents and chunks. OpenAI supplies embeddings and answer generation but owns no application state.
+
+## 4. Proposed design
+
+### How it works
+
+For upload, the API validates the file, extracts text, creates overlapping chunks, requests embeddings, and writes the document and all chunks in one database transaction. It returns document metadata only after the transaction commits.
+
+For chat, the API embeds the question and calculates cosine similarity as `1 - (embedding <=> query_embedding)` in pgvector. A chunk qualifies when its score is greater than or equal to `RAG_RELEVANCE_THRESHOLD`, which defaults to `0.75` and must satisfy `0 <= value <= 1`. The API retrieves at most five qualifying chunks. If nothing qualifies, it returns the fixed no-information response. Otherwise it sends only those chunks to the answer generator and returns the answer with sources ordered by descending score, then document ID and chunk index for stable ties.
+
+Deleting a document removes its chunks through a database cascade. Later retrieval therefore cannot return deleted content.
+
+### Components and responsibilities
+
+| Component | Owns | Depends on | Does not own |
+| --- | --- | --- | --- |
+| FastAPI routes | HTTP validation and response shapes | Application services | Persistence or provider-specific calls |
+| Ingestion and chat services | Use-case ordering and failure mapping | Repository and OpenAI adapter | HTTP details |
+| PostgreSQL repository | Documents, chunks, embeddings, and vector queries | PostgreSQL with pgvector | Answer generation |
+| OpenAI adapter | Provider request and response translation | OpenAI API | Retrieval policy or durable state |
+
+### Decisions
+
+**Use PostgreSQL with pgvector.** This keeps metadata and vectors in one transactional store. A separate vector database could scale independently, but it would add another service and consistency boundary before V1 needs either.
+
+**Use fixed-size chunks.** Chunks are about 500 tokens with about 50 tokens of overlap. Semantic chunking may improve retrieval, but fixed chunking is easier to reason about and test for the initial product.
+
+**Use a relevance threshold before generation.** Returning a fixed no-information response is safer than asking the model to answer from weak context. The threshold is configurable because useful values vary by embedding model and content.
+
+## 5. Invariants and requirements
+
+### Invariants
+
+1. Every returned factual answer is generated only from chunks included in its source list.
+2. A deleted document has no chunks available to retrieval.
+3. A failed upload leaves no document or chunk rows behind.
+4. Provider failures never appear as successful grounded answers.
+
+### Requirements
 
 - Upload a PDF, extract text, chunk it, embed it, and store the document and chunks.
 - List uploaded documents with basic metadata.
 - Delete a document and all related chunks and embeddings.
-- Answer a question with an answer and source references from relevant chunks.
+- Answer a question with an answer and ordered source references from relevant chunks.
 - Return a fixed no-information response when no relevant chunk exists.
 - Run locally with Docker Compose using FastAPI and PostgreSQL with pgvector.
 - Keep configuration in environment variables and OpenAI calls replaceable in tests.
 
-## Acceptance criteria
-
-- `POST /api/v1/documents` accepts a PDF and returns its ID, filename, upload time, and chunk count.
-- `GET /api/v1/documents` lists uploaded documents.
-- `DELETE /api/v1/documents/{id}` removes the document and makes its chunks unavailable to retrieval.
-- `POST /api/v1/chat` returns a grounded answer and ordered source references for known fixture content.
-- Chat with no relevant content returns `{"answer":"No relevant information found in uploaded documents.","sources":[]}`.
-- Non-PDF uploads return `400`, missing deletions return `404`, and upstream OpenAI failures return `502`, all with the documented error shape.
-- The full test suite passes against PostgreSQL with pgvector while OpenAI calls are mocked.
-
-## Design
-
-Use FastAPI for HTTP, PostgreSQL with pgvector for metadata and vector search, and the OpenAI API for embeddings and answer generation. Keep OpenAI behind a small adapter so tests can replace embedding and chat calls with deterministic fakes.
-
-```mermaid
-flowchart TB
-    subgraph Ingest["Document ingestion"]
-        direction LR
-        Upload([Upload PDF]) --> Extract["extract"] --> Chunk["chunk"] --> Embed["embed"] --> Store[("PostgreSQL<br/>+ pgvector")]
-    end
-
-    subgraph Answer["Grounded answer"]
-        direction LR
-        Question([Ask question]) --> Query["embed query"] --> Retrieve["retrieve chunks"] --> Generate["generate from context"] --> Response([Answer + sources])
-    end
-
-    Store --> Retrieve
-```
-
-Store one row per document and many related chunk rows. Each chunk holds text, position, embedding, and document ID. Database cascading removes chunks when a document is deleted.
-
-Use fixed-size chunks of about 500 tokens with about 50 tokens of overlap. For chat, embed the question, retrieve at most five chunks by vector similarity, and send only those chunks to the answer generator. Return sources in relevance order.
-
-## Interfaces and data
+## 6. Interfaces and data
 
 ```text
 POST   /api/v1/documents      -> {id, filename, uploaded_at, chunk_count}
@@ -61,34 +92,78 @@ POST   /api/v1/chat           -> {answer, sources: [{document_id, filename, chun
 Errors                        -> {error: {code, message}}
 ```
 
-Error codes are `bad_request`, `not_found`, and `upstream_error`.
+Error codes are `bad_request`, `payload_too_large`, `not_found`, and `upstream_error`.
 
-## Failure behavior
+Store one row per document and many related chunk rows. Each chunk holds its text, zero-based position, embedding, and document ID. The document foreign key cascades on delete.
 
-- Reject a non-PDF upload with `400` and `bad_request`.
+`RAG_RELEVANCE_THRESHOLD` configures the minimum inclusive cosine similarity and defaults to `0.75`. Startup accepts both `0` and `1` and fails unless the value is numeric and satisfies `0 <= value <= 1`.
+
+`SERVER_GRACEFUL_SHUTDOWN_SECONDS` configures the shutdown deadline and defaults to `10`. Startup fails unless it is an integer from `1` through `60`.
+
+### Naming and identity
+
+The service generates an opaque UUID for each uploaded document. The original filename is display metadata and never forms identity. Chunk identity is the document UUID plus its zero-based position, which remains stable for the lifetime of that document.
+
+## 7. Failure behavior and lifecycle
+
+- Reject a non-PDF or a PDF with no extractable text using `400` and `bad_request`.
+- Reject a PDF over 25 MiB using `413` and `payload_too_large`.
 - Return `404` and `not_found` when deleting a missing document.
-- Return `502` and `upstream_error` when embedding or chat generation fails.
-- Return the fixed no-information response with status `200` when retrieval has no relevant chunks.
-- Fail startup clearly when required database configuration is missing.
+- Return `502` and `upstream_error` when embedding or answer generation fails.
+- Roll back the upload transaction when persistence fails.
+- Return the fixed no-information response with status `200` when retrieval has no qualifying chunks.
+- Fail startup before serving traffic when required database or OpenAI configuration is missing.
+- On shutdown, stop accepting new requests and wait up to `SERVER_GRACEFUL_SHUTDOWN_SECONDS` for in-flight requests. After the deadline, cancel remaining requests and let open database transactions roll back.
 
-## Test approach
+## 8. Security, privacy, and operations
+
+V1 is for one trusted local user. It has no authentication, authorization, or tenant isolation and must not be exposed as a shared public service. Document text is sent to OpenAI for embeddings and relevant chunks are sent again for answer generation.
+
+Uploads are limited to 25 MiB and rejected before extraction when larger. Chat retrieves at most five chunks. Docker Compose owns local service startup and persistent database storage.
+
+## 9. Acceptance criteria
+
+- `POST /api/v1/documents` accepts a PDF up to 25 MiB and returns its ID, filename, upload time, and chunk count.
+- Uploading a non-PDF, an empty-text PDF, or a file over 25 MiB returns `400` with `bad_request`, `400` with `bad_request`, or `413` with `payload_too_large` respectively and creates no rows.
+- `GET /api/v1/documents` lists uploaded documents.
+- `DELETE /api/v1/documents/{id}` removes the document and makes its chunks unavailable to retrieval.
+- `POST /api/v1/chat` returns a grounded answer and ordered source references for known fixture content.
+- A chunk with cosine similarity exactly equal to `RAG_RELEVANCE_THRESHOLD` qualifies; a lower score does not.
+- Chunks with equal similarity are ordered by document ID and then chunk index.
+- Threshold configuration accepts `0` and `1` and rejects non-numeric values, values below `0`, and values above `1` before startup.
+- Chat with no relevant content returns `{"answer":"No relevant information found in uploaded documents.","sources":[]}`.
+- Missing deletion returns `404`, and upstream OpenAI failures return `502`, both with the documented error shape.
+- Shutdown stops new requests, gives in-flight requests 10 seconds by default, then cancels remaining work without committing a partial upload.
+- The full test suite passes against PostgreSQL with pgvector while OpenAI calls are mocked.
+
+## 10. Test approach
 
 - Use `pytest` and `httpx` for endpoint tests.
 - Test persistence and vector behavior against PostgreSQL with pgvector.
 - Mock OpenAI calls with deterministic embeddings and answers.
 - Use a small PDF fixture containing known text to prove grounded chat and source references.
-- Cover upload, list, delete, relevant chat, no-result chat, and the `400`, `404`, and `502` paths.
+- Use deterministic embeddings that produce scores equal to, immediately below, and immediately above `RAG_RELEVANCE_THRESHOLD`.
+- Cover threshold configuration at `0`, at `1`, below `0`, above `1`, and with a non-numeric value.
+- Start a deliberately slow upload, request shutdown, and cover completion before the configured deadline and cancellation with transaction rollback after it.
+- Cover upload, list, delete, relevant chat, no-result chat, transaction rollback, and the `400`, `404`, `413`, and `502` paths.
+- Assert through the public API that a deleted document and a failed upload leave no retrievable chunks.
 
-## Risks
+## 11. Risks and tradeoffs
 
-- Text extraction quality varies across PDFs. Keep V1 to text PDFs and fail clearly when no text can be extracted.
+- Text extraction quality varies across PDFs. V1 accepts text PDFs only and fails clearly when no text can be extracted.
 - A fixed relevance threshold may miss useful chunks or include weak ones. Make the threshold configurable and cover the boundary with deterministic tests.
-- Deleting a document must not leave retrievable vectors. Enforce this in the database and prove it through the public API.
+- Synchronous embedding makes upload latency proportional to document size. The 25 MiB limit bounds the initial risk; background ingestion remains outside V1.
+- Sending document text to OpenAI may not suit sensitive documents. The README must disclose that boundary.
 
-## Out of scope
+## 12. Open questions
 
-- Authentication or multiple users
+None block implementation. Authentication, provider selection, and asynchronous ingestion require new designs if the deployment scope expands beyond one trusted user.
+
+## 13. Out of scope
+
+- Authentication, multiple users, or tenant isolation
 - Conversation history, streaming, or reranking
 - Non-PDF formats or OCR
 - Retrieval tuning beyond the simple V1 defaults
+- Background ingestion
 - Cloud deployment beyond local Docker Compose

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -12,9 +12,11 @@ Source design: [RAG chatbot design](design.md)
 
 - Use FastAPI, PostgreSQL with pgvector, Docker Compose, and OpenAI.
 - Use fixed-size chunks with overlap for V1.
+- Limit PDF uploads to 25 MiB.
+- Store a document and all of its chunks atomically.
 - Mock OpenAI in tests.
 - Add focused tests with each task and run them against PostgreSQL with pgvector.
-- Keep API errors shaped as `{error: {code, message}}`.
+- Keep API errors shaped as `{error: {code, message}}`, including `payload_too_large` for a PDF over 25 MiB.
 - Return a fixed no-information answer instead of hallucinating when retrieval has no relevant chunks.
 
 ---
@@ -38,12 +40,15 @@ This task creates the base service shape for every later endpoint. It should est
 - Use `uv` for Python package management.
 - Use Docker Compose for the API and PostgreSQL with pgvector.
 - Keep configuration in environment variables.
+- Read the shutdown deadline from `SERVER_GRACEFUL_SHUTDOWN_SECONDS`, defaulting to `10`, and fail startup unless it is an integer from `1` through `60`.
 
 #### Acceptance criteria
 
 - The API and database start with Docker Compose.
 - `GET /health` returns `{"status":"ok"}` when the API can reach the database.
-- The app fails clearly when required database configuration is missing.
+- The app fails clearly when required database or OpenAI configuration is missing.
+- Graceful shutdown stops new requests, waits up to `SERVER_GRACEFUL_SHUTDOWN_SECONDS`, then cancels remaining requests.
+- The README states that V1 is for one trusted user and sends document text to OpenAI.
 - A baseline `pytest` run is available for later tasks.
 
 #### Design reference
@@ -57,6 +62,8 @@ docker compose up -d
 curl http://localhost:8000/health
 pytest
 ```
+
+Also start a deliberately slow request, signal shutdown, and verify both completion before the deadline and cancellation after it.
 
 #### Out of scope
 
@@ -81,15 +88,20 @@ This task proves the ingestion path: validation, text extraction, chunking, embe
 #### Constraints
 
 - Accept PDFs only.
+- Reject uploads over 25 MiB before text extraction.
 - Use fixed-size chunks of about 500 tokens with about 50 tokens of overlap.
+- Commit the document and all chunks in one database transaction.
 - Mock OpenAI calls in tests.
 
 #### Acceptance criteria
 
 - `POST /api/v1/documents` accepts a PDF and returns `{id, filename, uploaded_at, chunk_count}`.
 - Uploaded PDFs are stored with chunks and embeddings that can be queried later.
-- Non-PDF uploads return `400` with `{error: {code, message}}`.
+- Non-PDF and empty-text PDF uploads return `400` with `{error: {code, message}}`.
+- Uploads over 25 MiB return `413` with `payload_too_large` and create no rows.
 - OpenAI embedding failures return `502` with `{error: {code, message}}`.
+- Embedding and persistence failures leave no document or chunk rows behind.
+- Cancelling a deliberately slow upload at the graceful shutdown deadline leaves no document or chunk rows behind.
 - A PDF fixture exists with known text for later retrieval tests.
 
 #### Design reference
@@ -102,6 +114,8 @@ The [RAG chatbot design](design.md) covers document storage, chunking defaults, 
 pytest
 curl -F "file=@tests/fixtures/test.pdf" http://localhost:8000/api/v1/documents
 ```
+
+Also run focused tests for a non-PDF, an empty-text PDF, an oversized upload, an embedding failure, a forced persistence failure, and shutdown cancellation during a slow upload. Each failure must leave the document list unchanged.
 
 #### Out of scope
 
@@ -164,7 +178,9 @@ This task combines vector retrieval, prompt construction, OpenAI chat completion
 #### Constraints
 
 - Retrieve at most 5 chunks for each question.
-- Return sources ordered by relevance.
+- Calculate cosine similarity as `1 - (embedding <=> query_embedding)`.
+- Read the inclusive threshold from `RAG_RELEVANCE_THRESHOLD`, defaulting to `0.75`, accept `0` and `1`, and fail startup unless it is numeric and satisfies `0 <= value <= 1`.
+- Return sources by descending similarity, then document ID and chunk index for stable ties.
 - Do not add conversation history or streaming.
 
 #### Acceptance criteria
@@ -172,6 +188,9 @@ This task combines vector retrieval, prompt construction, OpenAI chat completion
 - `POST /api/v1/chat` accepts a message and returns `{answer, sources}`.
 - Sources include `document_id`, `filename`, `chunk_index`, and `content`.
 - A question answerable from the fixture returns an answer grounded in that fixture and at least one source.
+- A chunk scoring exactly `RAG_RELEVANCE_THRESHOLD` qualifies, while a lower score does not.
+- Chunks with equal similarity are ordered by document ID and then chunk index.
+- Threshold configuration accepts `0` and `1` and rejects non-numeric values, values below `0`, and values above `1` before startup.
 - If no relevant chunks are found, the endpoint returns `{"answer":"No relevant information found in uploaded documents.","sources":[]}`.
 - OpenAI embedding or chat failures return `502` with `{error: {code, message}}`.
 
@@ -184,6 +203,8 @@ The [RAG chatbot design](design.md) covers retrieval defaults, chat response sha
 ```bash
 pytest
 ```
+
+Focused tests use deterministic embeddings with scores equal to, immediately below, and immediately above the configured threshold. Configuration tests cover `0`, `1`, values below `0`, values above `1`, and a non-numeric value.
 
 Manual smoke check: upload `tests/fixtures/test.pdf`, ask `What database is used for embeddings?`, and confirm the response mentions PostgreSQL with pgvector and includes at least one source.
 

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -11,6 +11,7 @@ Source design: [RAG chatbot design](design.md)
 ## Shared decisions
 
 - Use FastAPI, PostgreSQL with pgvector, Docker Compose, and OpenAI.
+- Use `uv` for Python package and environment management.
 - Use fixed-size chunks with overlap for V1.
 - Limit PDF uploads to 25 MiB.
 - Store a document and all of its chunks atomically.
@@ -18,6 +19,7 @@ Source design: [RAG chatbot design](design.md)
 - Add focused tests with each task and run them against PostgreSQL with pgvector.
 - Keep API errors shaped as `{error: {code, message}}`, including `payload_too_large` for a PDF over 25 MiB.
 - Return a fixed no-information answer instead of hallucinating when retrieval has no relevant chunks.
+- Require `DATABASE_URL` and `OPENAI_API_KEY`.
 
 ---
 
@@ -40,16 +42,15 @@ This task creates the base service shape for every later endpoint. It should est
 - Use `uv` for Python package management.
 - Use Docker Compose for the API and PostgreSQL with pgvector.
 - Keep configuration in environment variables.
-- Read the shutdown deadline from `SERVER_GRACEFUL_SHUTDOWN_SECONDS`, defaulting to `10`, and fail startup unless it is an integer from `1` through `60`.
+- Require `DATABASE_URL` and `OPENAI_API_KEY`.
 
 #### Acceptance criteria
 
 - The API and database start with Docker Compose.
-- `GET /health` returns `{"status":"ok"}` when the API can reach the database.
-- The app fails clearly when required database or OpenAI configuration is missing.
-- Graceful shutdown stops new requests, waits up to `SERVER_GRACEFUL_SHUTDOWN_SECONDS`, then cancels remaining requests.
+- `GET /health` returns `200` with `{"status":"ok"}` when the API can reach the database and `503` with `service_unavailable` when it cannot.
+- The app fails before serving traffic when `DATABASE_URL` or `OPENAI_API_KEY` is missing.
 - The README states that V1 is for one trusted user and sends document text to OpenAI.
-- A baseline `pytest` run is available for later tasks.
+- A baseline `uv run pytest` succeeds for later tasks.
 
 #### Design reference
 
@@ -60,10 +61,11 @@ The [RAG chatbot design](design.md) covers the stack, Docker Compose surface, en
 ```bash
 docker compose up -d
 curl http://localhost:8000/health
-pytest
+uv sync --frozen
+uv run pytest
 ```
 
-Also start a deliberately slow request, signal shutdown, and verify both completion before the deadline and cancellation after it.
+Also make PostgreSQL unavailable and verify that `/health` returns the documented `503`. Cover each missing required setting.
 
 #### Out of scope
 
@@ -92,17 +94,21 @@ This task proves the ingestion path: validation, text extraction, chunking, embe
 - Use fixed-size chunks of about 500 tokens with about 50 tokens of overlap.
 - Commit the document and all chunks in one database transaction.
 - Mock OpenAI calls in tests.
+- Read the shutdown deadline from `SERVER_GRACEFUL_SHUTDOWN_SECONDS`, defaulting to `10`, and fail startup unless it is an integer from `1` through `60`.
 
 #### Acceptance criteria
 
 - `POST /api/v1/documents` accepts a PDF and returns `{id, filename, uploaded_at, chunk_count}`.
 - Uploaded PDFs are stored with chunks and embeddings that can be queried later.
-- Non-PDF and empty-text PDF uploads return `400` with `{error: {code, message}}`.
+- Non-PDF and empty-text PDF uploads return `400` with `bad_request`.
 - Uploads over 25 MiB return `413` with `payload_too_large` and create no rows.
-- OpenAI embedding failures return `502` with `{error: {code, message}}`.
+- OpenAI embedding failures return `502` with `upstream_error`.
+- A persistence failure returns `500` with `internal_error`.
 - Embedding and persistence failures leave no document or chunk rows behind.
+- A slow upload that finishes before the graceful shutdown deadline commits normally.
 - Cancelling a deliberately slow upload at the graceful shutdown deadline leaves no document or chunk rows behind.
-- A PDF fixture exists with known text for later retrieval tests.
+- Startup accepts shutdown values from `1` through `60` and rejects zero, negative, greater values, and non-integers.
+- A PDF fixture contains the sentence "PostgreSQL with pgvector stores the embeddings." for later retrieval tests.
 
 #### Design reference
 
@@ -111,11 +117,11 @@ The [RAG chatbot design](design.md) covers document storage, chunking defaults, 
 #### Checks
 
 ```bash
-pytest
+uv run pytest
 curl -F "file=@tests/fixtures/test.pdf" http://localhost:8000/api/v1/documents
 ```
 
-Also run focused tests for a non-PDF, an empty-text PDF, an oversized upload, an embedding failure, a forced persistence failure, and shutdown cancellation during a slow upload. Each failure must leave the document list unchanged.
+Also run focused tests for a non-PDF, an empty-text PDF, an oversized upload, an embedding failure, a forced persistence failure returning `500` with `internal_error`, shutdown completion and cancellation during slow uploads, and each shutdown setting boundary. Query PostgreSQL in the test fixture and prove each failed upload leaves document and chunk row counts unchanged.
 
 #### Out of scope
 
@@ -140,7 +146,8 @@ Documents and chunks exist after Task 2. This task adds the document management 
 
 - `GET /api/v1/documents` returns documents with `id`, `filename`, `uploaded_at`, and `chunk_count`.
 - `DELETE /api/v1/documents/{id}` removes the document and its related chunks.
-- Deleting a missing document returns `404` with `{error: {code, message}}`.
+- Deleting a missing document returns `404` with `not_found`.
+- Database failures during listing or deletion return `500` with `internal_error`; a failed deletion leaves the document and chunks intact.
 - After deletion, the document no longer appears in the list and its chunks are gone.
 
 #### Design reference
@@ -150,8 +157,10 @@ The [RAG chatbot design](design.md) defines the document listing/deletion API sh
 #### Checks
 
 ```bash
-pytest
+uv run pytest
 ```
+
+Focused tests force database failures during listing and deletion and assert `500` with `internal_error`. After a failed deletion, query PostgreSQL and prove the document and chunks remain.
 
 Manual smoke check: upload `tests/fixtures/test.pdf`, list documents, delete the returned ID, then confirm the ID no longer appears in `GET /api/v1/documents`.
 
@@ -186,13 +195,17 @@ This task combines vector retrieval, prompt construction, OpenAI chat completion
 #### Acceptance criteria
 
 - `POST /api/v1/chat` accepts a message and returns `{answer, sources}`.
+- A missing or empty message returns `400` with `bad_request`.
 - Sources include `document_id`, `filename`, `chunk_index`, and `content`.
 - A question answerable from the fixture returns an answer grounded in that fixture and at least one source.
+- With more than five qualifying chunks, retrieval returns five and the mocked generator receives exactly the same ordered content returned in `sources`.
 - A chunk scoring exactly `RAG_RELEVANCE_THRESHOLD` qualifies, while a lower score does not.
 - Chunks with equal similarity are ordered by document ID and then chunk index.
 - Threshold configuration accepts `0` and `1` and rejects non-numeric values, values below `0`, and values above `1` before startup.
 - If no relevant chunks are found, the endpoint returns `{"answer":"No relevant information found in uploaded documents.","sources":[]}`.
-- OpenAI embedding or chat failures return `502` with `{error: {code, message}}`.
+- After a failed fixture upload or deletion of an uploaded fixture, asking about its known text returns the fixed no-information response with no sources.
+- OpenAI embedding or chat failures return `502` with `upstream_error`.
+- A database failure during retrieval returns `500` with `internal_error`.
 
 #### Design reference
 
@@ -201,10 +214,10 @@ The [RAG chatbot design](design.md) covers retrieval defaults, chat response sha
 #### Checks
 
 ```bash
-pytest
+uv run pytest
 ```
 
-Focused tests use deterministic embeddings with scores equal to, immediately below, and immediately above the configured threshold. Configuration tests cover `0`, `1`, values below `0`, values above `1`, and a non-numeric value.
+Focused tests cover a missing and empty message, a forced retrieval database failure, and deterministic embeddings with scores equal to, immediately below, and immediately above the configured threshold. A test with more than five qualifying chunks inspects the mocked generator call and proves its context matches the ordered first five returned sources. Force a fixture upload to fail, then ask about its known text and verify the fixed no-information response. Upload and delete the fixture, ask the same question, and verify the same response. Configuration tests cover `0`, `1`, values below `0`, values above `1`, and a non-numeric value.
 
 Manual smoke check: upload `tests/fixtures/test.pdf`, ask `What database is used for embeddings?`, and confirm the response mentions PostgreSQL with pgvector and includes at least one source.
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture
-description: "Documents the current architecture of an implemented system, including its context, invariants, components, dependencies, critical flows, interfaces, data ownership, security boundaries, operations, and verified limitations. Use when the user asks to create, explain, audit, or update ARCHITECTURE.md or map how an existing system works. Do not use for a proposed feature or future system design; use the design skill instead."
+description: "Documents or explains the current architecture of an implemented system, including its context, invariants, components, dependencies, critical flows, interfaces, data ownership, security boundaries, operations, and verified limitations. Use when the user asks to create, explain, audit, or update ARCHITECTURE.md or map how an existing system works. Do not use for a proposed feature or future system design; use the design skill instead."
 user-invocable: true
 argument-hint: "[repository, system, subsystem, or existing ARCHITECTURE.md]"
 ---
@@ -10,13 +10,13 @@ argument-hint: "[repository, system, subsystem, or existing ARCHITECTURE.md]"
 ## Workflow
 
 1. Read the request, repository instructions, existing architecture material, manifests, entry points, configuration, schemas, migrations, infrastructure, tests, and the implementation of representative flows.
-2. Establish the document boundary. For a whole repository, write or update `ARCHITECTURE.md` at the root. For an explicitly scoped subsystem, update its established architecture document or write `docs/<subsystem>/architecture.md`.
+2. Choose the requested output. When the user asks to create or update a durable architecture document, establish its boundary: use root `ARCHITECTURE.md` for a whole repository, or the established document or `docs/<subsystem>/architecture.md` for an explicitly scoped subsystem. When the user asks only to explain, map, review, or audit the current system, return a report in chat and do not modify files.
 3. Treat code, schemas, configuration, infrastructure, and executable tests as evidence. Treat existing prose as a claim to verify. Resolve contradictions before repeating them.
-4. Write the current implemented system using the shape below. Link proposed changes to their design documents instead of presenting them as current behavior.
-5. Run the review pass. Correct every claim you can verify, mark unresolved evidence gaps under Verification, and keep Known limitations restricted to verified implementation gaps.
-6. Stop for human review. Do not design future behavior, plan work, or change implementation.
+4. Describe the current implemented system. For a durable document, use the shape below. For a chat report, keep the same evidence priorities and use only the sections that help answer the request. Link proposed changes to their design documents instead of presenting them as current behavior.
+5. Run the review pass. Correct every claim you can verify, identify unresolved evidence gaps, and keep limitations restricted to verified implementation gaps.
+6. Return the document or report for human review. Do not design future behavior, plan work, or change implementation.
 
-## Document shape
+## Durable document shape
 
 ```markdown
 # <System> architecture
@@ -61,6 +61,7 @@ Link the small set of files that are authoritative for entry points, boundaries,
 
 ## Writing rules
 
+- Keep read-only explanation, mapping, review, and audit requests read-only. Create or update a file only when the user asks for a durable architecture document.
 - Describe implemented reality, not intended architecture. Use a design document for future behavior.
 - Use `working tree based on <commit>` when the architecture document and implementation change together before commit. Do not claim that an uncommitted state was verified at the base commit.
 - Start with the mental model and boundaries. Do not turn the document into a file inventory.

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: architecture
+description: "Documents the current architecture of an implemented system, including its context, invariants, components, dependencies, critical flows, interfaces, data ownership, security boundaries, operations, and verified limitations. Use when the user asks to create, explain, audit, or update ARCHITECTURE.md or map how an existing system works. Do not use for a proposed feature or future system design; use the design skill instead."
+user-invocable: true
+argument-hint: "[repository, system, subsystem, or existing ARCHITECTURE.md]"
+---
+
+# Architecture
+
+## Workflow
+
+1. Read the request, repository instructions, existing architecture material, manifests, entry points, configuration, schemas, migrations, infrastructure, tests, and the implementation of representative flows.
+2. Establish the document boundary. For a whole repository, write or update `ARCHITECTURE.md` at the root. For an explicitly scoped subsystem, update its established architecture document or write `docs/<subsystem>/architecture.md`.
+3. Treat code, schemas, configuration, infrastructure, and executable tests as evidence. Treat existing prose as a claim to verify. Resolve contradictions before repeating them.
+4. Write the current implemented system using the shape below. Link proposed changes to their design documents instead of presenting them as current behavior.
+5. Run the review pass. Correct every claim you can verify, mark unresolved evidence gaps under Verification, and keep Known limitations restricted to verified implementation gaps.
+6. Stop for human review. Do not design future behavior, plan work, or change implementation.
+
+## Document shape
+
+```markdown
+# <System> architecture
+
+> **Status:** Current implementation
+>
+> **Verification basis:** `<commit or version>` or `working tree based on <commit>`
+
+## 1. Executive summary
+In two or three short paragraphs, explain what the system is, its central architectural idea, where authoritative state lives, and the most important boundary a contributor must preserve.
+
+## 2. System context
+Show the system, its users, external dependencies, and deployment boundary. Include a small diagram when relationships are easier to understand visually.
+
+## 3. Architectural invariants
+Numbered statements that the implemented system must preserve. Keep them observable or traceable to enforcement in code, configuration, schemas, or tests.
+
+## 4. Components and dependencies
+For each meaningful component, state what it owns, what it depends on, and what it deliberately does not own. Show dependency direction when crossing a boundary is consequential.
+
+## 5. Critical flows
+Trace the important end-to-end paths in execution order. Include authentication, validation, persistence, side effects, response timing, cleanup, and recovery where they matter.
+
+## 6. Interfaces and data
+Document public protocols, APIs, events, commands, durable schemas, identifiers, compatibility boundaries, and which component owns each source of truth.
+
+## 7. Security and trust boundaries
+State how identity is established, where authorization is enforced, what input is untrusted, what fails closed, and which process or service permissions form the trust boundary.
+
+## 8. Failure, capacity, and operations
+Document partial failure, retry and recovery, concurrency controls, hard limits, finite resources, deployment topology, observability, startup, shutdown, and operator actions.
+
+## 9. Verification
+Point to the tests, checks, dashboards, or runbooks that prove the important invariants and flows. State what remains unverified.
+
+## 10. Known limitations
+List verified gaps in the current implementation. Do not mix in aspirations, roadmap items, or speculative redesigns.
+
+## 11. Source map
+Link the small set of files that are authoritative for entry points, boundaries, schemas, configuration, and critical flows.
+```
+
+## Writing rules
+
+- Describe implemented reality, not intended architecture. Use a design document for future behavior.
+- Use `working tree based on <commit>` when the architecture document and implementation change together before commit. Do not claim that an uncommitted state was verified at the base commit.
+- Start with the mental model and boundaries. Do not turn the document into a file inventory.
+- Keep the length proportional to the system. A small repository may satisfy a section with one paragraph; do not pad it to resemble a large platform.
+- Prefer exact execution order, ownership, and failure behavior over broad labels such as "service layer" or "robust".
+- Give every component a positive and negative boundary: what it owns and what it does not own.
+- Use diagrams for system context, dependencies, or flows only when they make a relationship materially clearer.
+- Verify volatile facts such as counts, limits, ports, timeouts, and dependency versions immediately before writing them. Omit facts that add maintenance cost without helping a contributor make a decision.
+- Link to detailed protocol, operations, or testing documents instead of duplicating them.
+- Keep proposed work in linked designs. Known limitations describe present gaps only.
+- Use plain words, define project-specific terms, and do not use em dashes.
+
+## Review pass
+
+Reread the draft and check each category against current evidence.
+
+1. **Current state.** Does every declarative claim describe code and configuration that exist at the stated verification basis?
+2. **Authority.** Is each durable state, identifier, policy, and public contract owned in one named place?
+3. **Boundaries.** Does every component say what it owns, depends on, and does not own? Does the dependency direction match imports and runtime calls?
+4. **Flows.** Do the critical paths include their real ordering, response point, side effects, cleanup, and failure branches?
+5. **Security.** Are authentication, authorization, tenant or user isolation, untrusted input, secret access, and fail-open or fail-closed behavior explicit?
+6. **Operations.** Are finite resources, concurrency, backpressure, retry, startup, shutdown, observability, and recovery covered where they affect behavior?
+7. **Drift.** Do repeated claims agree with README, repository instructions, contributor docs, schemas, config, and tests? Remove duplication or name the authoritative source when they do not.
+8. **Limitations.** Are gaps verified and current, with planned changes kept out of the present-state narrative?
+
+Put unresolved evidence gaps under Verification and state what would verify them.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: "Designs what to build and how it should work, including requirements, acceptance criteria, interfaces, data, errors, technical choices, constraints, risks, and scope. Use when the user asks to design or architect a feature, write a spec or design doc, define requirements, or resolve important product or technical decisions before implementation."
+description: "Writes a proposed specification for a feature or part of a system, including its executive summary, context, system fit, behavior, boundaries, decisions, invariants, requirements, interfaces, data, failures, constraints, risks, acceptance criteria, and proof. Use when the user asks to design or architect a change, write a spec or design doc, define requirements, or resolve important product or technical decisions before implementation. Do not use to document the current architecture of an implemented system; use the architecture skill instead."
 user-invocable: true
 argument-hint: "<feature, problem, or brief>"
 ---
@@ -11,7 +11,7 @@ argument-hint: "<feature, problem, or brief>"
 
 1. Read the request, repository instructions, relevant code, and linked material.
 2. Resolve choices that would change behavior, interfaces, data, errors, security, operations, or tests. Ask only questions whose answers materially change the design. Recommend an answer when asking.
-3. Write `docs/<feature-slug>/design.md` using the shape below. Keep it short and omit sections that do not apply.
+3. Write `docs/<feature-slug>/design.md` using the numbered shape below. Keep it short, preserve the logical order, and omit only sections that genuinely do not apply.
 4. Run the review pass. Fix what you can. List the rest under Open questions.
 5. Stop for human review. Do not plan or implement.
 
@@ -20,46 +20,61 @@ argument-hint: "<feature, problem, or brief>"
 ```markdown
 # <Title>
 
-## What and why
-The problem, who it affects, and what changes once this ships. Plain prose.
+> **Status:** Proposed for review
 
-## How it works
-Walk one real case from start to finish. Name the thing that arrives, what handles it, what gets written down, and what the user sees. A reader should be able to picture the system running before they read any requirements.
+## 1. Executive summary
+In two or three short paragraphs, explain the problem, who it affects, the outcome, the proposed approach, and the most important tradeoff. A reviewer should understand the decision before reading the detail.
 
-## Decisions
-For each choice that could reasonably have gone another way: what you chose, what you rejected, and what it costs. One short paragraph each. Skip the choices nobody would argue about.
+## 2. Context and scope
+Describe the current behavior, why it is insufficient, what changes once this ships, and the boundary of this design.
 
-## Invariants
+## 3. System context
+Show where the change fits in the existing architecture, which components and external systems it touches, and which boundaries it must preserve. Include a small diagram when the relationships are easier to understand visually.
+
+## 4. Proposed design
+
+### How it works
+Walk one real case from start to finish. Name the thing that arrives, what handles it, what gets written down, and what the user sees.
+
+### Components and responsibilities
+For each changed component, state what it owns, what it depends on, and what it deliberately does not own.
+
+### Decisions
+For each choice that could reasonably have gone another way: what you chose, what you rejected, and what it costs. One short paragraph each. Skip choices nobody would argue about.
+
+## 5. Invariants and requirements
+
+### Invariants
 Numbered statements that must hold at all times. These are what a reviewer checks a diff against, so keep them short and testable.
 
-## Requirements
+### Requirements
 - Observable behavior and constraints.
 
-## Interfaces and data
+## 6. Interfaces and data
 APIs, commands, events, schemas, config, compatibility, or migration.
 
-## Naming and identity
+### Naming and identity
 How every durable name or ID is derived, what happens when derivation fails, and what happens if the source of the name changes after state exists.
 
-## Failure behavior
-What can fail, what state it moves to, whether it retries and how, and how it recovers. Say what happens when everything fails at once, not just one thing.
+## 7. Failure behavior and lifecycle
+What can fail, what state it moves to, whether it retries and how, and how it recovers. Cover startup, config or state changes, work in flight, shutdown, and what happens when everything fails at once.
 
-## Limits and budgets
-Anything shared and finite: rate limits, connections, disk, memory, cost. Say what happens when it runs out.
+## 8. Security, privacy, and operations
+State the trust boundary, authorization checks, sensitive data handling, and operational impact. Cover anything shared and finite such as rate limits, connections, disk, memory, or cost, and say what happens when it runs out.
 
-## Acceptance criteria
+## 9. Acceptance criteria
 - Testable conditions that prove the work is complete.
 
-## Test approach
+## 10. Test approach
 How each invariant and each important requirement will be proved.
 
-## Risks
+## 11. Risks and tradeoffs
 - Risk and mitigation.
 
-## Open questions
+## 12. Open questions
 - Question, and whether it blocks starting work.
 
-## Out of scope
+## 13. Out of scope
 - Related work this design does not include.
 ```
 
@@ -69,6 +84,10 @@ How each invariant and each important requirement will be proved.
 - A bullet cannot carry a decision by itself. Write the reason next to it in a sentence.
 - Use plain words. Say "the process crashed" instead of "an availability event occurred". Prefer short sentences.
 - Define a term the first time you use it, or do not use it.
+- Keep current architecture and proposed behavior distinct. Link to `ARCHITECTURE.md` when it exists and say exactly which current boundary changes.
+- Give each changed component a positive and negative boundary: what it owns and what it does not own.
+- Use numbered top-level sections so reviewers can refer to stable parts of the specification.
+- Use diagrams only when they make system context, dependency direction, data flow, or lifecycle materially clearer.
 - Prefer one clear recommendation over a list of options.
 - Record rejected options only when the tradeoff matters later.
 - Do not repeat the same fact in several sections with different wording.
@@ -78,12 +97,15 @@ How each invariant and each important requirement will be proved.
 
 Reread the draft once and check each category. Fix any gap you can resolve from the available evidence.
 
-1. **Names and identity.** Where does every durable identifier come from? What happens when it is missing, ambiguous, or changes after state exists?
-2. **Failure and recovery.** What creates a bad state? Does the system retry, with what backoff, and can it recover without a restart? What happens when everything is bad at startup?
-3. **Shared resources.** What finite resource does the feature consume? State the budget and the behavior at the limit.
-4. **Timing and fairness.** Replace words such as "eventually" and "will not starve" with a bound someone can test.
-5. **Lifecycle.** Cover config reload, enable and disable behavior, work already in flight, and shutdown.
-6. **Undefined terms.** Define words that carry a specific meaning in the design.
-7. **Either/or acceptance criteria.** Do not allow both sides of "recovers or retains" to pass. Choose one observable behavior.
+1. **Executive summary.** Does it state the problem, outcome, approach, and decisive tradeoff without requiring the rest of the document?
+2. **Architecture fit.** Does the design show the current system boundary, the boundary being changed, and the owner of each new responsibility?
+3. **Names and identity.** Where does every durable identifier come from? What happens when it is missing, ambiguous, or changes after state exists?
+4. **Failure and recovery.** What creates a bad state? Does the system retry, with what backoff, and can it recover without a restart? What happens when everything is bad at startup?
+5. **Security and privacy.** Where is identity established, authorization enforced, untrusted input validated, and sensitive data exposed or retained?
+6. **Shared resources.** What finite resource does the feature consume? State the budget and the behavior at the limit.
+7. **Timing and fairness.** Replace words such as "eventually" and "will not starve" with a bound someone can test.
+8. **Lifecycle.** Cover config reload, enable and disable behavior, work already in flight, and shutdown.
+9. **Undefined terms.** Define words that carry a specific meaning in the design.
+10. **Either/or acceptance criteria.** Do not allow both sides of "recovers or retains" to pass. Choose one observable behavior.
 
 Put anything you cannot resolve under Open questions and state whether it blocks task breakdown.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -13,7 +13,7 @@ Follow this workflow for the requested task, ticket, or pull request:
 2. **Branch.** Resume the branch and worktree for an existing pull request. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its pull request is merged or closed.
 3. **Read the context.** Read the repository instructions and inspect the relevant code.
 4. **Outline the change.** Define one focused, self-contained outcome with its related proof. A reviewer must be able to understand its behavior and proof without first separating unrelated work. If the source requires several such changes, split it or return to planning before coding. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review. This is a local execution outline, not a plan document.
-5. **Implement.** Make the change. Test changed behavior, failure paths affected by the change or named in its acceptance criteria, and behavior a refactor must preserve. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, record the concrete reason and substitute evidence.
+5. **Implement.** Make the change. Test changed behavior, failure paths affected by the change or named in its acceptance criteria, and behavior a refactor must preserve. If implementation changes documented ownership, dependency direction, protocols, durable data, trust boundaries, deployment topology, or hard limits, update the existing architecture reference in the same change. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, record the concrete reason and substitute evidence.
 6. **Test and self-review.** Run tests and checks that cover the changed behavior and affected interfaces, including a real browser when browser-rendered behavior changes. Inspect the final diff for accidental scope, unclear code, and missing proof before independent review.
 7. **Review.** Review the change with a fresh subagent that did not implement it.
 8. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
@@ -74,7 +74,7 @@ change, tell the reviewer where to start and what needs the closest scrutiny.
 - **Did you independently review the final diff and address valid findings?** <Yes | No>
   Review evidence, findings fixed, and anything unresolved.
 - **Did you update documentation when behavior changed?** <Yes | No | Not applicable>
-  Documentation changed or why it was not needed.
+  User, contributor, and architecture documentation changed or why each was not needed.
 - **Did required CI checks pass?** <Yes | No | Pending | Not configured>
   Check names and results.
 ```


### PR DESCRIPTION
## What is this change?

Adds `/architecture` as a distinct current-state documentation skill and strengthens `/design` as a numbered specification for a proposed feature or part of a system.

`/architecture` produces a verified current-state report in chat or writes an `ARCHITECTURE.md` or scoped subsystem architecture reference when the user asks for a durable document. It covers the executive mental model, context, invariants, component ownership and negative boundaries, critical flows, interfaces and data, security, operations, verification, known limitations, and source evidence. It explicitly separates implemented reality from proposed designs, keeps read-only explanation and audit requests read-only, and supports truthful working-tree verification when documentation and implementation change together.

`/design` now uses a numbered 13-section specification with an executive summary, current system context, component responsibilities, decisions, invariants, security, lifecycle, acceptance criteria, and proof. Both published design examples and the downstream RAG plan now follow that contract.

A follow-up consistency audit made the examples agent-ready rather than merely illustrative. The RAG design and plan now agree on tooling, API and error contracts, configuration bounds, shutdown behavior, grounding proof, database failures, and task ordering. The Dispatch design now defines run-step state, prompt resolution, worker ownership, durable follow-up triggers, bounded heartbeats and shutdown, manual recovery, and the matching failure sequence.

The public documentation, migration guide, repository policy, review standard, Claude adapter, install count, and `/task-to-pr` documentation trigger now describe the eight-skill surface.

## Why is it important?

Current system architecture and proposed feature design answer different questions and have different evidence requirements. Keeping them in one skill risks presenting intended behavior as implemented fact. The new split gives agents one explicit outcome for documenting what exists and another for specifying what should change.

The numbered design format also makes large specifications easier to scan and review while carrying useful architecture practices into feature work: an executive summary, system fit, positive and negative ownership boundaries, ordered flows, security, finite resources, lifecycle, and verified proof.

## What should the reviewer know or consider?

Start with `skills/architecture/SKILL.md` and `skills/design/SKILL.md`, then inspect the Dispatch and RAG examples.

The architecture skill is not a mandatory delivery step. It is a current-system documentation path. `/task-to-pr` updates an existing architecture reference only when implementation changes ownership, dependency direction, protocols, durable data, trust boundaries, deployment topology, or hard limits.

This change has no executable product behavior. The relevant proof is structural consistency, rendered diagrams, example completeness, and independent review.

Default `markdownlint-cli2` is not a configured repository gate. Version 0.23.2 reports 242 issues on `main` and 404 on this branch, primarily the repository's established long-line style and repeated task-template headings.

## Checklist

- **Is this one focused, self-contained change?** Yes
  The skill, revised specification format, examples, routing, and public documentation all deliver one architecture-versus-design separation.
- **Did you write or update tests?** Not applicable
  The repository contains Markdown instruction artifacts with no executable behavior or configured test harness.
- **Did you run the relevant tests and checks?** Yes
  Validated all eight skill directories and frontmatter names, exact numbered section sequences, required task sections, local example links, public skill counts, review-fix contracts, `bash -n examples/regenerate.sh`, stale-pattern absence, and `git diff --check`. Rendered all four changed Mermaid diagrams with Mermaid CLI and visually inspected them, including rerendering the revised Dispatch failure sequence. Also inspected the published branch README in Chrome and confirmed GitHub renders the routing table and complete Mermaid workflow correctly.
- **Did you independently review the final diff and address valid findings?** Yes
  Fresh independent review rounds drove fixes for RAG threshold, grounding, error, shutdown, database-failure, and plan contracts; Dispatch identity, ownership, prompt, follow-up, recovery, concurrency, and lifecycle contracts; and architecture verification provenance. Live PR feedback found and drove the read-only architecture output boundary. The feedback was fixed, independently approved, answered on its original thread, and resolved. Final reviews reported no blocker or important inconsistencies.
- **Did you update documentation when behavior changed?** Yes
  Updated README, AGENTS, CLAUDE, MIGRATION, REVIEW, both design examples, the RAG plan, and `/task-to-pr`.
- **Did required CI checks pass?** Not configured
  `gh workflow list` returns no configured GitHub Actions workflows.
