### PR TITLE
docs: make Blueprint guidance easier to understand

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
-## What is this change?
+## Plain English summary
 
-<!-- Summarize the major changes and observable behavior. -->
+<!-- In two to four short sentences, explain the problem, what changed, and why it matters. Use everyday words. Do not list files or use unexplained technical terms. -->
 
-## Why is it important?
+## Details
 
-<!-- Explain the problem, who it affects, and why this approach was chosen. -->
+<!-- Add only the behavior or decisions that are not clear from the summary. Skip this section when the summary is enough. -->
 
-## What should the reviewer know or consider?
+## Reviewer notes
 
-<!-- Call out decisions, scope boundaries, tradeoffs, shortcomings, safety, compatibility, failure behavior, operational impact, known risks, and where to start. -->
+<!-- Include only facts that change how this PR should be reviewed: risk, tradeoff, failure behavior, compatibility, migration, or where to start. Write "None" when none apply. -->
 
 ## Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,24 @@
 # Blueprint repository policy
 
-Blueprint is a small, principles-first process for AI coding. It separates thinking phases from the workflow that ships code.
+Blueprint is a small set of instructions for AI coding. It separates deciding what to build from shipping code.
 
 ## Principles
 
 - Give agents outcomes, constraints, and proof. Trust them with mechanics.
 - Keep one skill per meaningful engineering phase or delivery outcome.
-- Keep current architecture separate from proposed design. Update existing architecture documents when implementation changes ownership, dependency direction, protocols, durable data, trust boundaries, deployment topology, or hard limits.
+- Keep current architecture separate from proposed design.
+- Update an existing architecture document when code changes ownership, dependency direction, protocols, stored data, trust boundaries, deployment topology, or hard limits.
+- Start with the simplest useful explanation. Use short sentences and everyday words. Define technical terms before using them.
+- Write for a new teammate. Put detail after the main idea. Remove anything that does not help someone decide, build, test, or review the work.
 - Skip phases that add no value. Small, decided work can go straight to implementation.
 - A task is ready when a new agent can finish it without asking product or technical questions.
-- Each pull request delivers one focused, self-contained outcome with its related proof. A change is reviewable when its outcome, behavior, and proof can be understood without first separating unrelated work. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review.
-- Logic changes include automated tests for changed behavior and failure paths affected by the change or named in its acceptance criteria. Refactors include tests for behavior that must not change. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.
-- Review checks correctness. If the same outcome and proof can be delivered with less state, indirection, duplication, or operational work, request the simpler design. Do not block on personal taste. Cite technical evidence or repository conventions.
+- Each pull request delivers one focused outcome and its proof. A reviewer should not have to separate unrelated work to understand it.
+- Separate refactoring when it would hide the behavior change. Small local cleanup may stay when it makes that change easier to review.
+- Logic changes include automated tests for changed behavior and affected failure paths, including any named in the acceptance criteria.
+- Refactors include tests for behavior that must not change.
+- If automated tests cannot exercise the affected behavior, explain why and give other evidence.
+- Review checks correctness. Ask for a simpler design when it can deliver the same outcome and proof with less state, indirection, duplication, or operational work.
+- Do not block on personal taste. Cite technical evidence or repository conventions.
 - Browser behavior is proven in a real browser, not by reading source.
 - If the task, design, or plan is wrong, update it before changing more code.
 - Prefer the smallest complete change. Do not mix product work with unrelated cleanup.
@@ -19,7 +26,7 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 
 ## Phases
 
-- `/architecture`: explain the verified current system in chat, or document it when a durable artifact is requested. Stop for human review.
+- `/architecture`: explain the verified current system in chat, or write an architecture document when asked. Stop for human review.
 - `/design`: decide what to build, why, and how. Stop for human review.
 - `/plan`: split decided work into ordered, agent-ready tasks. Stop before implementation.
 - `/test`: prove acceptance criteria and failure paths affected by the change, including real-browser checks when browser-rendered behavior changes.
@@ -28,19 +35,23 @@ Blueprint is a small, principles-first process for AI coding. It separates think
 
 ## Workflow: Milestones
 
-For a GitHub milestone, use `/milestone`. It orders open issues and runs `/task-to-pr` one issue at a time. Stop for human merge after each green pull request unless the user explicitly delegates merging for that run.
+For a GitHub milestone, use `/milestone`. It orders open issues and runs `/task-to-pr` one issue at a time.
 
-Writing code is a base capability, not a separate phase skill. Debugging and test-driven development are implementation techniques, not product-level entry points.
+Stop for human merge after each pull request passes its required checks. Continue through merges only when the user explicitly allows it for that run.
+
+Writing code is a basic agent ability, not a separate skill. Debugging and test-driven development are ways to implement a change, not separate product skills.
 
 ## Workflow: Code changes
 
-For one end-to-end code change, follow the canonical [`/task-to-pr` skill](skills/task-to-pr/SKILL.md). It owns ticket handling, worktree isolation, coding, tests, independent review, commits, pull requests, CI, and current feedback. Never merge unless the user explicitly asks.
+For one code change, follow the [`/task-to-pr` skill](skills/task-to-pr/SKILL.md). It covers the work from the source task through a tested and reviewed pull request. Never merge unless the user explicitly asks.
 
 ## Outputs
 
-- When a durable document is requested, whole-system architecture defaults to `ARCHITECTURE.md`. Explicitly scoped subsystem architecture defaults to its established document or `docs/<subsystem>/architecture.md`.
+- A whole-system architecture document defaults to `ARCHITECTURE.md`.
+- A named subsystem uses its existing document or `docs/<subsystem>/architecture.md`.
 - Designs default to `docs/<feature-slug>/design.md`.
 - Plans are returned in chat by default or published as tracker tickets when asked. They are not stored as plan documents.
-- Pull requests explain what changed, why it matters, what the reviewer should consider, and a truthful checklist covering tests, checks, independent review, findings, documentation, and CI.
+- Pull requests start with a short plain English summary. They then explain only the detail a reviewer needs.
+- The checklist states the real status of tests, checks, independent review, findings, documentation, and CI.
 
 Exploration does not require a design, plan, or ticket. Do not create process artifacts that do not improve a decision, handoff, or proof.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@
 
 Blueprint keeps shared repository policy in `AGENTS.md` and only Claude-specific setup here.
 
-Install Blueprint with `npx skills add owainlewis/blueprint`. Invoke the phase skills as `/architecture`, `/design`, `/plan`, `/test`, `/review`, and `/improve`. Use `/task-to-pr` for one end-to-end code change and `/milestone` for every issue in a GitHub milestone.
+Install Blueprint with `npx skills add owainlewis/blueprint`. Use `/architecture`, `/design`, `/plan`, `/test`, `/review`, and `/improve` for one kind of engineering work. Use `/task-to-pr` to deliver one code change and `/milestone` to deliver every issue in a GitHub milestone.
 
-All Blueprint entry points are skills. `/task-to-pr` is the canonical delivery workflow, and `/milestone` runs it one issue at a time. `AGENTS.md` contains portable repository policy.
+Everything you call in Blueprint is a skill. Use `/task-to-pr` to take one task from its source to a ready pull request. `/milestone` runs that workflow one issue at a time. `AGENTS.md` contains the repository rules.
 
 The `/review` phase uses a fresh generic subagent. Blueprint does not require a separate reviewer agent definition.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
-# Migrate to the phase model
+# Migrate from older Blueprint skills
 
-> **Breaking change:** Blueprint now ships six phase skills and two delivery skills. Old skill directories and copied workflow commands must be removed manually.
+> **Breaking change:** Blueprint now ships eight skills. You must remove old Blueprint skill folders and copied commands by hand.
 
 ## What changed
 
@@ -11,13 +11,13 @@
 | `browser-verify` | Browser proof inside `/test` |
 | `refactor` | `/improve` |
 | `branch`, `commit`, `implement`, `pr`, `pr-to-ready` | Steps inside `/task-to-pr` |
-| `task-to-pr` | Canonical `/task-to-pr` delivery skill |
+| `task-to-pr` | `/task-to-pr` |
 | `debug`, `tdd` | Techniques used while implementing |
 | `goal-design`, `multitask` | Ordinary instructions or project-specific workflows |
 | `milestone` | `/milestone` skill, backed by `/task-to-pr` |
 | `code-reviewer` agent definition | A fresh generic subagent launched by `/review` |
 
-The public skill surface is now:
+These are the eight skills you can call:
 
 ```text
 /architecture · /design · /plan · /test · /review · /improve · /task-to-pr · /milestone
@@ -25,7 +25,7 @@ The public skill surface is now:
 
 ## Clean upgrade
 
-1. **Remove old Blueprint entry points.** In the skill directory used by your coding tool, remove only the old Blueprint skill folders listed above. Also remove copied Blueprint `implement.md` and `task-to-pr.md` command files. Do not delete whole skill or command directories; they may contain unrelated files.
+1. **Remove old Blueprint skills and commands.** In the skill directory used by your coding tool, remove only the old Blueprint skill folders listed above. Also remove copied Blueprint `implement.md` and `task-to-pr.md` command files. Do not delete whole skill or command directories because they may contain unrelated files.
 2. **Install all eight skills.**
 
    ```bash
@@ -37,6 +37,6 @@ The public skill surface is now:
 
 ## Why cleanup is manual
 
-Some noninteractive skill updaters add and replace skills but do not remove directories that disappeared upstream. Running `npx skills update` alone can therefore leave the old and new models installed together.
+Some update commands add or replace skills but do not remove folders from an older version. Running `npx skills update` alone can therefore leave both the old and new skills installed.
 
-`/task-to-pr` is the only one-task delivery entry point. Keeping implementation, testing, review, publication, CI, and feedback in that skill avoids duplicate workflow names and routing ambiguity.
+Use `/task-to-pr` to deliver one task. It keeps implementation, testing, review, publication, CI, and feedback in one place so a reader does not have to choose between overlapping workflow names.

--- a/README.md
+++ b/README.md
@@ -2,30 +2,28 @@
 
 # Blueprint
 
-**A small, principles-first workflow for AI coding.**
-
-Clear decisions. Bounded work. Real proof. Independent review.
+**A small set of instructions for AI coding.**
 
 </div>
 
-Blueprint gives coding agents the engineering boundaries that matter without turning software delivery into a catalogue of tiny skills. It separates repository policy, reusable phases, and end-to-end workflows so each instruction has one clear job.
+Blueprint helps agents decide what to build, make one focused change, test it, get an independent review, and open a pull request for a human to merge.
 
 ## Start with the work, not the process
 
-Use the smallest entry point that resolves the uncertainty in front of you.
+Choose the first skill based on what you need.
 
 | If you need to… | Start with | Result |
 | --- | --- | --- |
-| Explain, document, or audit how an implemented system works | `/architecture` | A verified current-state report or architecture reference |
-| Specify a feature or change to part of a system | `/design` | A reviewed design with requirements and acceptance criteria |
+| Explain, document, or audit how an implemented system works | `/architecture` | A checked explanation of how the system works now |
+| Specify a feature or change to part of a system | `/design` | A reviewed spec for a proposed change |
 | Split a decided feature into work for several agent runs | `/plan` | Ordered tasks in chat or tracker tickets |
-| Take one task through delivery | `/task-to-pr` | A tested, reviewed, green pull request |
-| Complete every issue in a GitHub milestone | `/milestone` | One green pull request at a time, with human merge checkpoints |
+| Take one task through delivery | `/task-to-pr` | A tested and reviewed pull request, ready for human merge |
+| Complete every issue in a GitHub milestone | `/milestone` | One ready pull request per issue, with human merge checkpoints |
 | Prove a change works | `/test` | Acceptance criteria mapped to evidence |
 | Get an independent second opinion | `/review` | Findings and a pre-merge verdict from a fresh subagent |
 | Simplify existing code without changing behavior | `/improve` | Clearer, smaller, better-structured code |
 
-Small, decided work can go straight to `/task-to-pr`. Use `/architecture` for implemented reality, `/design` when proposed behavior needs review, and `/plan` only when the work needs splitting.
+Small, decided work can go straight to `/task-to-pr`. Use `/architecture` for the system as it works now. Use `/design` when a proposed change needs review. Use `/plan` only when the work needs splitting.
 
 ## How Blueprint fits together
 
@@ -47,31 +45,31 @@ flowchart TB
         Review -->|findings| Fix["fix"] --> Test
         Review -->|clean| Publish["publish PR"] --> Validate["CI + current feedback"]
         Validate -->|failure or finding| Fix
-        Validate -->|clean| PR["green PR"]
+        Validate -->|clean| PR["ready PR"]
     end
 
     PR --> Merge([Human merge])
 ```
 
-`/architecture` is a current-system documentation path, and `/improve` is a behavior-preserving maintenance path. Neither is a step every change must pass through.
+Use `/architecture` when you need to understand or document existing code. Use `/improve` to simplify code without changing what it does. Not every change needs either skill.
 
 The model has two layers:
 
 1. **Repository instructions define policy.** `AGENTS.md` says what good work means in a codebase.
-2. **Skills define phases and workflows.** Each skill has one durable engineering outcome and a clear stopping point. `/task-to-pr` and `/milestone` compose the phases into delivery paths.
+2. **Skills define each kind of work.** Each skill produces one clear result and has a clear stopping point. `/task-to-pr` and `/milestone` join the needed steps.
 
 ## The six phase skills
 
 | Skill | Owns | Stops when |
 | --- | --- | --- |
-| `/architecture` | Current system context, invariants, components, dependencies, flows, boundaries, operations, and verified limitations | The requested report or architecture reference is ready for human review |
-| `/design` | A proposed feature or system-part specification: executive summary, system fit, behavior, boundaries, decisions, requirements, proof, and scope | The design is ready for human review |
-| `/plan` | Vertical, ordered tasks and optional milestones | The work is ready to hand off |
+| `/architecture` | A checked explanation of the current system, its rules, parts, flows, boundaries, operations, and limits | The explanation is ready for human review |
+| `/design` | A spec for a proposed feature or system change | The spec is ready for human review |
+| `/plan` | Ordered tasks that each deliver working behavior, plus useful milestones | The work is ready to hand off |
 | `/test` | Automated checks, failure paths, and real-browser proof when relevant | Every criterion is pass, fail, or explicitly unverified |
 | `/review` | Independent review of correctness, security, regressions, complexity, and proof | Findings and a verdict are reported |
 | `/improve` | Behavior-preserving simplification of existing code | Relevant checks prove behavior was preserved |
 
-Writing code is a base capability, not a phase skill. Branching, committing, opening a PR, debugging, TDD, browser checking, and addressing feedback are techniques or workflow steps, not separate product concepts.
+Writing code is a basic agent ability, not a separate skill. Branching, committing, debugging, browser checks, and feedback are steps inside a workflow.
 
 ## One task to one pull request
 
@@ -80,15 +78,15 @@ Writing code is a base capability, not a phase skill. Branching, committing, ope
 1. resolves the source and isolates work before editing;
 2. implements the smallest complete change;
 3. runs `/test` and independent `/review` loops;
-4. creates Conventional Commits and opens or updates a reviewer-focused PR that explains what changed, why it matters, what to review, and the evidence checklist;
+4. creates Conventional Commits and opens or updates a PR with a plain summary, review notes, and an evidence checklist;
 5. waits for CI, handles feedback that exists, and records evidence;
-6. stops at a green, mergeable PR for a human to merge.
+6. stops at a mergeable PR whose required checks pass.
 
 It does not wait forever for future human feedback, manufacture tracker artifacts for trivial work, or merge without explicit permission.
 
 ## One milestone to completed issues
 
-`/milestone` is the release-slice workflow. It reads a GitHub milestone, orders open issues by dependency and risk, then runs `/task-to-pr` for one issue at a time. It stops for human merge after each green pull request unless the user explicitly delegates merging for that run.
+`/milestone` reads a GitHub milestone and orders open issues by dependency and risk. It runs `/task-to-pr` for one issue at a time. It stops for human merge after each ready pull request unless the user explicitly allows merging for that run.
 
 ## Install
 
@@ -98,7 +96,7 @@ Install all eight skills:
 npx skills add owainlewis/blueprint
 ```
 
-Upgrading from the older skill catalogue? Follow the [migration guide](MIGRATION.md). Removed skills can remain installed after a normal update, so the cleanup step matters.
+Upgrading from the older set of skills? Follow the [migration guide](MIGRATION.md). A normal update may leave removed skills installed, so the cleanup step matters.
 
 ## Repository map
 
@@ -107,7 +105,7 @@ skills/                 six phase skills and two delivery workflow skills
 AGENTS.md                portable repository policy
 CLAUDE.md                Claude Code adapter
 REVIEW.md                review standard for Blueprint itself
-MIGRATION.md             clean upgrade from the old catalogue
+MIGRATION.md             clean upgrade from the old skill set
 examples/                reviewed design and planning examples
 ```
 
@@ -123,15 +121,15 @@ For a larger system-part specification, read the [Dispatch local control-plane d
 
 ## Principles
 
-- **Encode process, not knowledge.** Give agents outcomes, constraints, and proof; trust them with local mechanics.
+- **Give agents the goal and the rules.** Give agents outcomes, constraints, and proof. Trust them with local mechanics.
 - **One skill per phase or delivery outcome.** Skills share one installation and invocation model.
 - **Separate current state from proposals.** Architecture documents describe verified implemented reality. Design documents specify future changes.
-- **Keep changes reviewable.** Deliver one focused, self-contained outcome with its related proof. A reviewer should not need to separate unrelated work first. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review.
-- **Use concrete review standards.** Check correctness. If the same outcome and proof can be delivered with less state, indirection, duplication, or operational work, request the simpler design. Do not block on personal taste. Cite technical evidence or repository conventions.
-- **Proof is part of the work.** Test changed behavior, failure paths affected by the change or named in its acceptance criteria, and behavior a refactor must preserve. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.
+- **Keep changes reviewable.** Deliver one focused outcome and its proof. A reviewer should not need to separate unrelated work. Keep refactoring separate when it would hide the behavior change.
+- **Use clear review standards.** Check correctness. Ask for a simpler design when it can deliver the same result with less state, indirection, duplication, or operational work. Do not block on personal taste.
+- **Proof is part of the work.** Test changed behavior and affected failure paths. Test behavior that a refactor must preserve. If automated tests cannot exercise the behavior, explain why and give other evidence.
 - **Use the real surface.** Browser behavior is checked in a browser. Live PR feedback is read from the PR.
-- **Fix the source of truth.** If implementation exposes a bad requirement, update the task or design before continuing.
-- **Prefer less.** Keep the smallest complete change, shortest useful instruction, and no duplicate entry points.
+- **Fix the original instruction.** If implementation exposes a bad requirement, update the task or design before continuing.
+- **Prefer less.** Keep the smallest complete change, shortest useful instruction, and no duplicate ways to start the same work.
 - **Keep irreversible judgment human.** Agents prepare the decision. Humans review designs and merge pull requests unless they explicitly delegate it.
 
 Blueprint is not an issue tracker, agent framework, release system, or reviewer-persona library. It is a compact engineering process for capable coding agents.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,19 +1,21 @@
 # Review Blueprint
 
-Review Blueprint as a small process product, not a prompt catalogue. Read the issue, complete diff, rendered public docs, and relevant surrounding files.
+Review Blueprint as a small set of engineering instructions. Read the issue, complete diff, rendered public docs, and relevant surrounding files.
 
+- Can a new teammate understand the summary without already knowing Blueprint terms?
+- Does the writing use short sentences, everyday words, and only useful detail?
 - Does each skill represent one meaningful engineering phase or delivery outcome?
-- Is policy in `AGENTS.md`, with phase behavior and delivery orchestration in skills?
+- Is policy in `AGENTS.md`, with each phase and delivery workflow in its skill?
 - Does `/architecture` describe verified current implementation while `/design` describes a proposed feature or system-part change?
-- Does a read-only architecture explanation, mapping, review, or audit remain in chat unless the user asks for a durable document?
-- When a change affects ownership, dependency direction, protocols, durable data, trust boundaries, topology, or hard limits, is the current architecture reference updated?
+- Does a read-only architecture explanation, mapping, review, or audit remain in chat unless the user asks for a document?
+- When a change affects ownership, dependency direction, protocols, stored data, trust boundaries, topology, or hard limits, is the current architecture document updated?
 - Are triggers, outputs, boundaries, proof, and stop conditions clear?
 - Is the change one focused, self-contained, reviewable outcome with its related proof?
-- Does `/task-to-pr` reach a tested, independently reviewed, green PR without merging by default?
+- Does `/task-to-pr` reach a tested and independently reviewed PR with passing required checks, without merging by default?
 - Is browser-rendered behavior checked in a real browser?
 - Can a capable agent choose local mechanics without redundant instructions?
 - Are removed concepts handled by an explicit migration instead of compatibility clutter?
 - Can each judgment be decided from evidence? Replace vague terms such as "code health", "adequate", "robust", and "production-ready" with concrete criteria.
 - Is every sentence useful enough to compete for agent attention?
 
-Prefer the smallest wording that preserves the outcome. Treat extra skills, duplicate workflows, fake personas, and ceremony without proof as regressions.
+Prefer the shortest wording that preserves the rule. Treat extra skills, duplicate workflows, fake reviewer roles, and steps without proof as regressions.

--- a/examples/dispatch-control-plane/design.md
+++ b/examples/dispatch-control-plane/design.md
@@ -8,13 +8,13 @@
 
 ## 1. Executive summary
 
-Dispatch lets a developer delegate agent work from a web control plane instead of managing every run in an interactive terminal. A local worker claims tasks, runs explicit shell and agent steps, streams evidence back, and preserves enough run history for review and follow-up.
+Dispatch gives a developer a local web page for giving work to coding agents and checking the results. This web app is the control plane: it stores tasks and decides what runs next. A separate worker runs shell commands and agent prompts, then sends output back to the page.
 
-Use a Next.js control plane with JSON-backed local state and a separate Go worker for execution. This proves the delegation loop with inspectable state and explicit commands, while accepting single-process storage and developer-machine trust boundaries that are unsuitable for production.
+The first version uses Next.js for the web app, a Go worker, and one JSON file for data. This makes the system easy to run and inspect, but it is not safe or reliable enough for a shared production service.
 
 ## 2. Context and scope
 
-The current workflow requires a developer to start and supervise each agent in a terminal. Dispatch adds a local task queue, execution history, and web UI without hiding checkout, setup, test, or push behavior inside the platform.
+Today, a developer must start and watch each agent in a terminal. Dispatch adds a local task queue, run history, and web page. Checkout, setup, test, and push commands stay visible in each task.
 
 V1 covers one local control-plane process and developer-controlled workers. It does not promise production durability, multi-user isolation, remote-machine provisioning, or automatic recovery of abandoned tasks.
 
@@ -30,17 +30,23 @@ flowchart TB
     Worker -->|delegate| Agent["Claude Code or compatible command"]
 ```
 
-The control plane is authoritative for task definitions, assignments, status, and history. Workers own local process execution but do not decide task ordering or durable state.
+The web app decides which task runs next and stores task status and history. Workers run local processes, but they do not choose task order or own stored data.
 
 ## 4. Proposed design
 
 ### How it works
 
-A developer creates a task containing a title and prompt, with an optional working directory and optional ordered steps. When no usable steps are supplied, the control plane creates one default agent step from the prompt. A worker registers, heartbeats every 5 seconds, and polls every 2 seconds while idle. The control plane atomically changes one pending task to running and creates a run before returning its steps.
+A developer creates a task with a title and prompt. The task may also name a working directory and an ordered set of steps. If it has no usable steps, the web app creates one agent step from the prompt.
 
-The worker executes each step in order. It marks the run-specific step record running, streams system, stdout, stderr, and agent events with stable sequence numbers, and records the result. A failed step marks every later run step skipped. If every step succeeds, the worker completes the run and task as succeeded.
+A worker registers and sends a heartbeat every 5 seconds. While idle, it asks for work every 2 seconds. The web app changes one pending task to running and creates its run in a single write before returning the steps.
 
-A user follow-up on a terminal task, either `succeeded` or `failed`, atomically changes the task back to `pending` and stores that comment ID as the pending trigger. The next claim consumes the pending trigger and creates one run linked to it in the same store mutation. An initial run uses the task prompt. A follow-up run stores an effective prompt containing the original task prompt followed by the triggering comment body under a `Follow-up:` label. Further comments while the task is pending or running are recorded but do not queue more runs. When the previous run recorded a Claude session ID, the first Claude agent step in the new run resumes that session with the effective prompt while preserving the earlier history. Any later Claude agent steps start new sessions with the same effective prompt, and the run records the most recently returned session ID.
+The worker runs each step in order. It marks the step as running, then sends four kinds of event: system messages, standard output (`stdout`), standard error (`stderr`), and agent events. Each event has a stable sequence number. The worker then records the result. A failed step marks every later step as skipped. If every step succeeds, the worker marks the run and task as succeeded.
+
+A user can follow up after a task has `succeeded` or `failed`. In one write, the web app changes the task back to `pending` and stores the new comment as its trigger. The next worker claim consumes that trigger and creates exactly one linked run.
+
+The first run uses the task prompt. A follow-up run uses the original prompt followed by the triggering comment under a `Follow-up:` label. More comments are saved while the task is pending or running, but they do not queue more runs.
+
+When the previous run has a Claude session ID, the first Claude step resumes that session with the follow-up prompt and keeps the earlier history. Later Claude steps start new sessions with the same prompt. The run stores the latest session ID it receives.
 
 ```mermaid
 sequenceDiagram
@@ -126,7 +132,15 @@ The shared TypeScript model is the contract used by the UI, API, store, and work
 
 Task creation accepts a title, prompt, optional working directory, and optional step definitions. When no usable steps are supplied, the control plane creates one default agent step from the task prompt.
 
-Every comment belongs to one task and is immutable. When the first terminal-task follow-up moves the task to `pending`, the task stores that comment ID as its pending trigger. A successful claim atomically copies the ID and resolved effective prompt to the new run, records the claiming worker ID as the immutable owner, and clears the trigger from the task. An initial claim copies the task prompt instead. The claim response includes this effective prompt. The JSON store preserves the trigger across control-plane restarts, and serialized mutation means only one of several concurrent comments can perform the terminal-to-pending transition. Other comments have no run link.
+Every comment belongs to one task and cannot change. The first follow-up on a finished task moves it to `pending` and stores that comment ID as the trigger.
+
+A successful claim makes these changes in one write:
+
+1. Copy the trigger ID and resolved prompt to the new run.
+2. Record the claiming worker ID as the run owner.
+3. Clear the trigger from the task.
+
+The first claim copies the task prompt because it has no follow-up. Every claim response includes the prompt to run. The JSON file keeps a pending trigger across web app restarts. Since writes run one at a time, only one of several comments can move a finished task to `pending`. The other comments stay in history but link to no run.
 
 The worker protocol uses these operations:
 
@@ -144,7 +158,11 @@ POST /api/runs/{run_id}/fail               -> worker-reported run failure
 POST /api/runs/{run_id}/recover            -> guarded manual recovery
 ```
 
-Task status moves from `pending` to `running` to `succeeded` or `failed`. A follow-up can move a terminal task back to `pending`. Run status is `running`, `succeeded`, or `failed`; a run is created only by a successful claim. Run-step status moves from `pending` to `running` to `succeeded` or `failed`, while unstarted steps after a failure move from `pending` to `skipped`. A claim from a worker that already owns a running run returns `409` with `worker_busy` and changes no task. Every worker mutation includes its worker ID, and the control plane rejects it unless it matches the run's immutable owner. The control plane also validates every transition and rejects updates to terminal runs.
+Task status moves from `pending` to `running`, then to `succeeded` or `failed`. A follow-up can move a finished task back to `pending`.
+
+A run is created only after a worker claims a task. Its status is `running`, `succeeded`, or `failed`. Each step moves from `pending` to `running`, then to `succeeded` or `failed`. After a failure, unstarted steps move to `skipped`.
+
+A worker that already owns a running run receives `409` with `worker_busy` when it tries to claim more work. The claim changes no task. Every worker update includes its worker ID. The web app rejects the update unless that ID owns the run. It also rejects invalid status changes and all updates to finished runs.
 
 Claude Code has a structured adapter. Every agent step receives the run's effective prompt. Other agent commands receive that prompt as a direct argument without shell interpolation:
 
@@ -156,7 +174,9 @@ argv[2] = <run effective prompt>
 
 ### Naming and identity
 
-On first start, a worker generates an opaque host ID and stores it in its local configuration directory. Later worker processes reuse that host ID and fail startup if the identity file exists but cannot be read. Deleting the file deliberately creates a new host identity on the next start; existing records keep the old ID. Each process registration receives a new opaque worker ID, so a restart preserves host identity but creates a new worker session.
+On first start, a worker creates an opaque host ID, which carries no user data, and stores it in its local configuration directory. Later worker processes reuse that ID. Startup fails if the identity file exists but cannot be read.
+
+Deleting the file creates a new host identity on the next start. Existing records keep the old ID. Each process registration receives a new opaque worker ID. A restart therefore keeps the host identity but creates a new worker session.
 
 The control plane generates opaque IDs for tasks, runs, comments, and events. A task step is identified by its task ID and stable zero-based index. Event sequence numbers are allocated by the control plane, not accepted from workers. A resumed Claude session ID is provider metadata attached to a run and never used as Dispatch identity.
 
@@ -164,20 +184,22 @@ The control plane generates opaque IDs for tasks, runs, comments, and events. A 
 
 - A failed step records its output and exit status, marks later run steps skipped, marks the run and task failed, and stops execution.
 - A worker claims one task at a time. The UI marks it disconnected when no heartbeat arrives for 15 seconds, but V1 does not reassign its running task automatically.
-- A developer may recover an abandoned run only after the owning worker has been disconnected for at least 15 seconds. One atomic store mutation marks a running step failed with reason `worker_lost`, or the lowest-index pending step when none is running, then marks later pending steps skipped and marks the run and task failed. If every run step already succeeded but the worker disappeared before completing the run, recovery preserves those step results and marks only the run and task failed with reason `worker_lost`.
+- A developer may recover an abandoned run only after its worker has been disconnected for at least 15 seconds. One store write marks the running step as failed with reason `worker_lost`. If no step is running, it fails the first pending step. It then skips later pending steps and fails the run and task. If all steps had succeeded, it keeps those results and fails only the run and task with reason `worker_lost`.
 - Worker event, step, completion, and failure reports with a missing or different worker ID are rejected.
 - After manual recovery, the control plane rejects late events and completion reports from the abandoned run because terminal history cannot be rewritten.
 - A corrupt store file stops mutations and reports an operator-visible error instead of replacing the file with empty state.
 - A failed store replacement leaves the previous complete file in place.
 - Restarting the control plane reloads the JSON store. Restarting a worker registers a new worker session and does not silently resume an in-flight command.
 - Control-plane shutdown stops new claims and lets the active serialized store mutation finish before exit.
-- Worker shutdown stops polling, sends `SIGTERM` to an active child process, waits up to 10 seconds, then sends `SIGKILL`. It then reports the run and task failed with reason `worker_shutdown`. The same transition rule fails the running step or next pending step and skips later pending steps; if all steps succeeded, their results remain unchanged. If the worker cannot reach the control plane, the run remains non-terminal until the developer uses the disconnected-worker recovery action.
+- Worker shutdown stops polling and sends `SIGTERM` to an active child process. It waits up to 10 seconds, then sends `SIGKILL`. It reports the run and task as failed with reason `worker_shutdown`. The running step, or next pending step, fails and later pending steps are skipped. Completed steps keep their results. If the worker cannot reach the web app, the run stays open until the developer recovers it.
 
 ## 8. Security, privacy, and operations
 
 Shell commands and agent runtimes execute with the worker user's permissions. V1 has no sandbox, secret boundary, authentication, or tenant isolation and must stay on developer-controlled machines and networks.
 
-Each worker runs at most one task at a time, heartbeats every 5 seconds, and polls every 2 seconds only while idle. One control-plane process serializes all store mutations. Task events and output grow the JSON file without a retention cap in V1. If a write or atomic replacement fails, including from a full disk, the API returns an operator-visible error and keeps the previous complete file. The UI and documentation must describe manual cleanup and the lack of a production capacity guarantee.
+Each worker runs at most one task at a time. It sends a heartbeat every 5 seconds and asks for work every 2 seconds while idle. One web app process runs all file changes one at a time.
+
+Task events and output make the JSON file grow without a limit in V1. If a write fails, including when the disk is full, the API shows an error and keeps the previous complete file. The UI and docs must explain manual cleanup and that this version has no production capacity promise.
 
 The control plane exposes worker heartbeat age, task and run status, step exit codes, and ordered event history. Logs include task and run IDs but must not copy secrets from command output into separate metadata.
 

--- a/examples/rag-chatbot/design.md
+++ b/examples/rag-chatbot/design.md
@@ -8,13 +8,13 @@
 
 ## 1. Executive summary
 
-Build a single-user Python API for uploading PDFs and asking questions answered from their contents. Answers must be grounded in retrieved chunks and include source references so the service does not invent information outside the uploaded documents.
+Build a small API where one person can upload PDFs and ask questions about them. Each answer must use the uploaded text and show which parts it used. If the documents do not contain the answer, the API says so.
 
-Use FastAPI, PostgreSQL with pgvector, and the OpenAI API behind a replaceable adapter, with `uv` managing the Python project. Keep ingestion synchronous and the retrieval model deliberately small. This favors a clear local system and deterministic tests over background processing or retrieval sophistication.
+Use FastAPI, OpenAI, and PostgreSQL with its pgvector search extension. Keep uploads in the request instead of using a background job. This makes the first version easier to run and test, but large uploads take longer.
 
 ## 2. Context and scope
 
-The project starts with no existing application. V1 must support the complete local path from PDF upload to grounded answer, plus listing and deleting documents. It runs with Docker Compose and assumes one trusted user, so authentication and tenant isolation are outside this design.
+The project starts with no application. The first version must support the full local path from PDF upload to an answer based on that PDF. It must also list and delete documents. It runs with Docker Compose and assumes one trusted user, so login and separation between users are outside this design.
 
 ## 3. System context
 
@@ -36,15 +36,17 @@ flowchart TB
     Provider --> OpenAI["OpenAI API"]
 ```
 
-The API owns request validation and orchestration. PostgreSQL is the source of truth for documents and chunks. OpenAI supplies embeddings and answer generation but owns no application state.
+The API checks requests and runs each step in the right order. PostgreSQL stores the documents and text chunks. OpenAI turns text into vectors for search and writes answers, but it stores no application data.
 
 ## 4. Proposed design
 
 ### How it works
 
-For upload, the API validates the file, extracts text, creates overlapping chunks, requests embeddings, and writes the document and all chunks in one database transaction. It returns document metadata only after the transaction commits.
+For upload, the API checks the file and extracts its text. It splits the text into overlapping chunks and asks OpenAI to turn them into search vectors, called embeddings. It writes the document and all chunks in one database transaction. It returns document details only after that transaction succeeds.
 
-For chat, the API embeds the question and calculates cosine similarity as `1 - (embedding <=> query_embedding)` in pgvector. A chunk qualifies when its score is greater than or equal to `RAG_RELEVANCE_THRESHOLD`, which defaults to `0.75` and must satisfy `0 <= value <= 1`. The API retrieves at most five qualifying chunks. If nothing qualifies, it returns the fixed no-information response. Otherwise it sends only those chunks to the answer generator and returns the answer with sources ordered by descending score, then document ID and chunk index for stable ties.
+For chat, the API turns the question into a vector and compares it with each text chunk. It calculates similarity as `1 - (embedding <=> query_embedding)` in pgvector. A chunk qualifies when its score is at least `RAG_RELEVANCE_THRESHOLD`. This value defaults to `0.75` and must be between `0` and `1`, including both limits.
+
+The API retrieves at most five matching chunks. If none match, it returns the fixed no-information response. Otherwise it sends only those chunks to OpenAI. It returns the answer and sources in score order. Equal scores are ordered by document ID and then chunk index.
 
 Deleting a document removes its chunks through a database cascade. Later retrieval therefore cannot return deleted content.
 

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -121,7 +121,9 @@ uv run pytest
 curl -F "file=@tests/fixtures/test.pdf" http://localhost:8000/api/v1/documents
 ```
 
-Also run focused tests for a non-PDF, an empty-text PDF, an oversized upload, an embedding failure, a forced persistence failure returning `500` with `internal_error`, shutdown completion and cancellation during slow uploads, and each shutdown setting boundary. Query PostgreSQL in the test fixture and prove each failed upload leaves document and chunk row counts unchanged.
+Also run focused tests for a non-PDF, an empty-text PDF, and an oversized upload. Test embedding failure and a forced database failure that returns `500` with `internal_error`. Cover shutdown completion and cancellation during slow uploads. Test each shutdown setting boundary.
+
+For every failed upload, query PostgreSQL in the test fixture and prove that document and chunk row counts did not change.
 
 #### Out of scope
 
@@ -217,7 +219,13 @@ The [RAG chatbot design](design.md) covers retrieval defaults, chat response sha
 uv run pytest
 ```
 
-Focused tests cover a missing and empty message, a forced retrieval database failure, and deterministic embeddings with scores equal to, immediately below, and immediately above the configured threshold. A test with more than five qualifying chunks inspects the mocked generator call and proves its context matches the ordered first five returned sources. Force a fixture upload to fail, then ask about its known text and verify the fixed no-information response. Upload and delete the fixture, ask the same question, and verify the same response. Configuration tests cover `0`, `1`, values below `0`, values above `1`, and a non-numeric value.
+Run focused tests for a missing or empty message and for a database failure during retrieval. Use fixed vectors with scores equal to, just below, and just above the threshold.
+
+Create more than five matching chunks. Check that the mocked answer generator receives the same first five chunks returned in the sources.
+
+Force a fixture upload to fail, then ask about its known text. Check the fixed no-information response. Upload and delete the fixture, ask the same question, and check the same response.
+
+Test threshold settings at `0`, `1`, below `0`, above `1`, and with a non-numeric value.
 
 Manual smoke check: upload `tests/fixtures/test.pdf`, ask `What database is used for embeddings?`, and confirm the response mentions PostgreSQL with pgvector and includes at least one source.
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture
-description: "Documents or explains the current architecture of an implemented system, including its context, invariants, components, dependencies, critical flows, interfaces, data ownership, security boundaries, operations, and verified limitations. Use when the user asks to create, explain, audit, or update ARCHITECTURE.md or map how an existing system works. Do not use for a proposed feature or future system design; use the design skill instead."
+description: "Explains how an existing system works today. Use for architecture maps, audits, or ARCHITECTURE.md. Return a chat report unless the user asks for a file. Use design for proposed changes."
 user-invocable: true
 argument-hint: "[repository, system, subsystem, or existing ARCHITECTURE.md]"
 ---
@@ -9,14 +9,17 @@ argument-hint: "[repository, system, subsystem, or existing ARCHITECTURE.md]"
 
 ## Workflow
 
-1. Read the request, repository instructions, existing architecture material, manifests, entry points, configuration, schemas, migrations, infrastructure, tests, and the implementation of representative flows.
-2. Choose the requested output. When the user asks to create or update a durable architecture document, establish its boundary: use root `ARCHITECTURE.md` for a whole repository, or the established document or `docs/<subsystem>/architecture.md` for an explicitly scoped subsystem. When the user asks only to explain, map, review, or audit the current system, return a report in chat and do not modify files.
+1. Read the request and repository instructions. Then inspect existing architecture docs, manifests, entry points, configuration, schemas, migrations, infrastructure, tests, and a few important flows.
+2. Choose the output:
+   - For a whole repository document, use root `ARCHITECTURE.md`.
+   - For a named subsystem, use its existing document or `docs/<subsystem>/architecture.md`.
+   - For an explanation, map, review, or audit, answer in chat and do not modify files.
 3. Treat code, schemas, configuration, infrastructure, and executable tests as evidence. Treat existing prose as a claim to verify. Resolve contradictions before repeating them.
-4. Describe the current implemented system. For a durable document, use the shape below. For a chat report, keep the same evidence priorities and use only the sections that help answer the request. Link proposed changes to their design documents instead of presenting them as current behavior.
+4. Describe the system that exists now. Use the shape below for a document. For a chat report, use only the sections that answer the request. Link proposed changes to their design documents.
 5. Run the review pass. Correct every claim you can verify, identify unresolved evidence gaps, and keep limitations restricted to verified implementation gaps.
 6. Return the document or report for human review. Do not design future behavior, plan work, or change implementation.
 
-## Durable document shape
+## Document shape
 
 ```markdown
 # <System> architecture
@@ -26,50 +29,53 @@ argument-hint: "[repository, system, subsystem, or existing ARCHITECTURE.md]"
 > **Verification basis:** `<commit or version>` or `working tree based on <commit>`
 
 ## 1. Executive summary
-In two or three short paragraphs, explain what the system is, its central architectural idea, where authoritative state lives, and the most important boundary a contributor must preserve.
+In two or three short paragraphs, say what the system does, name its main parts, explain how they work together, say where the real data lives, and name the one rule a contributor must not break.
 
 ## 2. System context
-Show the system, its users, external dependencies, and deployment boundary. Include a small diagram when relationships are easier to understand visually.
+Show the users, outside systems, and what runs inside or outside this system. Include a small diagram when it makes those relationships clearer.
 
 ## 3. Architectural invariants
-Numbered statements that the implemented system must preserve. Keep them observable or traceable to enforcement in code, configuration, schemas, or tests.
+List numbered rules that the current code must preserve. Each rule must be visible in behavior or backed by code, configuration, schemas, or tests.
 
 ## 4. Components and dependencies
-For each meaningful component, state what it owns, what it depends on, and what it deliberately does not own. Show dependency direction when crossing a boundary is consequential.
+For each important part, state what it owns, what it depends on, and what it does not own. Show which way a dependency points when crossing the boundary matters.
 
 ## 5. Critical flows
 Trace the important end-to-end paths in execution order. Include authentication, validation, persistence, side effects, response timing, cleanup, and recovery where they matter.
 
 ## 6. Interfaces and data
-Document public protocols, APIs, events, commands, durable schemas, identifiers, compatibility boundaries, and which component owns each source of truth.
+Document public protocols, APIs, events, commands, stored data, identifiers, compatibility rules, and which part owns each piece of data or policy.
 
 ## 7. Security and trust boundaries
 State how identity is established, where authorization is enforced, what input is untrusted, what fails closed, and which process or service permissions form the trust boundary.
 
 ## 8. Failure, capacity, and operations
-Document partial failure, retry and recovery, concurrency controls, hard limits, finite resources, deployment topology, observability, startup, shutdown, and operator actions.
+Document partial failure, retry and recovery, concurrency controls, hard limits, limited resources, deployment layout, monitoring, startup, shutdown, and operator actions.
 
 ## 9. Verification
-Point to the tests, checks, dashboards, or runbooks that prove the important invariants and flows. State what remains unverified.
+Point to the tests, checks, dashboards, or runbooks that prove the important rules and flows. State what remains unverified.
 
 ## 10. Known limitations
-List verified gaps in the current implementation. Do not mix in aspirations, roadmap items, or speculative redesigns.
+List gaps that current evidence confirms. Do not mix in goals, roadmap items, or possible redesigns.
 
 ## 11. Source map
-Link the small set of files that are authoritative for entry points, boundaries, schemas, configuration, and critical flows.
+Link the small set of files that define entry points, boundaries, schemas, configuration, and critical flows.
 ```
 
 ## Writing rules
 
-- Keep read-only explanation, mapping, review, and audit requests read-only. Create or update a file only when the user asks for a durable architecture document.
+- Keep explanation, mapping, review, and audit requests read-only. Create or update a file only when the user asks for an architecture document.
 - Describe implemented reality, not intended architecture. Use a design document for future behavior.
-- Use `working tree based on <commit>` when the architecture document and implementation change together before commit. Do not claim that an uncommitted state was verified at the base commit.
-- Start with the mental model and boundaries. Do not turn the document into a file inventory.
+- Use `working tree based on <commit>` when the document and code change together before commit. Do not claim that uncommitted code was verified at the base commit.
+- Start with the simplest useful explanation. Write for a new teammate, not someone who already knows the project.
+- Use short sentences and everyday words. Define technical terms before using them.
+- Put detail after the reader understands the main idea. Do not turn the document into a file inventory.
 - Keep the length proportional to the system. A small repository may satisfy a section with one paragraph; do not pad it to resemble a large platform.
 - Prefer exact execution order, ownership, and failure behavior over broad labels such as "service layer" or "robust".
 - Give every component a positive and negative boundary: what it owns and what it does not own.
 - Use diagrams for system context, dependencies, or flows only when they make a relationship materially clearer.
-- Verify volatile facts such as counts, limits, ports, timeouts, and dependency versions immediately before writing them. Omit facts that add maintenance cost without helping a contributor make a decision.
+- Check facts that can change immediately before writing them. Examples include counts, limits, ports, timeouts, and dependency versions.
+- Omit facts that add maintenance work without helping a contributor make a decision.
 - Link to detailed protocol, operations, or testing documents instead of duplicating them.
 - Keep proposed work in linked designs. Known limitations describe present gaps only.
 - Use plain words, define project-specific terms, and do not use em dashes.
@@ -78,13 +84,14 @@ Link the small set of files that are authoritative for entry points, boundaries,
 
 Reread the draft and check each category against current evidence.
 
-1. **Current state.** Does every declarative claim describe code and configuration that exist at the stated verification basis?
-2. **Authority.** Is each durable state, identifier, policy, and public contract owned in one named place?
-3. **Boundaries.** Does every component say what it owns, depends on, and does not own? Does the dependency direction match imports and runtime calls?
-4. **Flows.** Do the critical paths include their real ordering, response point, side effects, cleanup, and failure branches?
-5. **Security.** Are authentication, authorization, tenant or user isolation, untrusted input, secret access, and fail-open or fail-closed behavior explicit?
-6. **Operations.** Are finite resources, concurrency, backpressure, retry, startup, shutdown, observability, and recovery covered where they affect behavior?
-7. **Drift.** Do repeated claims agree with README, repository instructions, contributor docs, schemas, config, and tests? Remove duplication or name the authoritative source when they do not.
-8. **Limitations.** Are gaps verified and current, with planned changes kept out of the present-state narrative?
+1. **Clear summary.** Can a new teammate explain what the system does, how its main parts work together, where the real data lives, and the main rule to preserve?
+2. **Current state.** Does every statement describe code and configuration that exist at the stated verification basis?
+3. **Ownership.** Is each stored value, identifier, policy, and public contract owned in one named place?
+4. **Boundaries.** Does every component say what it owns, depends on, and does not own? Does the dependency direction match imports and runtime calls?
+5. **Flows.** Do the critical paths include their real ordering, response point, side effects, cleanup, and failure branches?
+6. **Security.** Are authentication, authorization, tenant or user isolation, untrusted input, secret access, and fail-open or fail-closed behavior explicit?
+7. **Operations.** Does the document cover limited resources, concurrency, retries, startup, shutdown, monitoring, and recovery? Does it say how the system slows incoming work when full?
+8. **Consistency.** Do repeated claims agree with README, repository instructions, contributor docs, schemas, config, and tests? Remove duplication or name the source when they do not.
+9. **Limitations.** Are gaps verified and current, with planned changes kept out of the current-system explanation?
 
 Put unresolved evidence gaps under Verification and state what would verify them.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: "Writes a proposed specification for a feature or part of a system, including its executive summary, context, system fit, behavior, boundaries, decisions, invariants, requirements, interfaces, data, failures, constraints, risks, acceptance criteria, and proof. Use when the user asks to design or architect a change, write a spec or design doc, define requirements, or resolve important product or technical decisions before implementation. Do not use to document the current architecture of an implemented system; use the architecture skill instead."
+description: "Writes a clear spec for a proposed feature or system change. Use when important product or technical choices must be settled before coding. Covers behavior, interfaces, failures, risks, acceptance criteria, and tests. Use architecture to explain the current system."
 user-invocable: true
 argument-hint: "<feature, problem, or brief>"
 ---
@@ -10,10 +10,11 @@ argument-hint: "<feature, problem, or brief>"
 ## Workflow
 
 1. Read the request, repository instructions, relevant code, and linked material.
-2. Resolve choices that would change behavior, interfaces, data, errors, security, operations, or tests. Ask only questions whose answers materially change the design. Recommend an answer when asking.
-3. Write `docs/<feature-slug>/design.md` using the numbered shape below. Keep it short, preserve the logical order, and omit only sections that genuinely do not apply.
-4. Run the review pass. Fix what you can. List the rest under Open questions.
-5. Stop for human review. Do not plan or implement.
+2. Resolve choices that would change behavior, interfaces, data, errors, security, operations, or tests.
+3. Ask only questions whose answers would change the design. Recommend an answer when asking.
+4. Write `docs/<feature-slug>/design.md` using the numbered shape below. Keep it short and in order. Omit only sections that do not apply.
+5. Run the review pass. Fix what you can. List the rest under Open questions.
+6. Stop for human review. Do not plan or implement.
 
 ## Document shape
 
@@ -23,13 +24,13 @@ argument-hint: "<feature, problem, or brief>"
 > **Status:** Proposed for review
 
 ## 1. Executive summary
-In two or three short paragraphs, explain the problem, who it affects, the outcome, the proposed approach, and the most important tradeoff. A reviewer should understand the decision before reading the detail.
+Say what is wrong today, who feels the problem, what will change, how we plan to fix it, and the main downside. Use simple words. Do not list sections or implementation details.
 
 ## 2. Context and scope
 Describe the current behavior, why it is insufficient, what changes once this ships, and the boundary of this design.
 
 ## 3. System context
-Show where the change fits in the existing architecture, which components and external systems it touches, and which boundaries it must preserve. Include a small diagram when the relationships are easier to understand visually.
+Show where the change fits in the current system. Name the parts and outside systems it touches and the boundaries it must preserve. Include a small diagram when it makes those relationships clearer.
 
 ## 4. Proposed design
 
@@ -37,15 +38,15 @@ Show where the change fits in the existing architecture, which components and ex
 Walk one real case from start to finish. Name the thing that arrives, what handles it, what gets written down, and what the user sees.
 
 ### Components and responsibilities
-For each changed component, state what it owns, what it depends on, and what it deliberately does not own.
+For each changed part, state what it owns, what it depends on, and what it does not own.
 
 ### Decisions
-For each choice that could reasonably have gone another way: what you chose, what you rejected, and what it costs. One short paragraph each. Skip choices nobody would argue about.
+For each real choice, say what you chose, what you rejected, and what the choice costs. Use one short paragraph. Skip choices nobody would question.
 
 ## 5. Invariants and requirements
 
 ### Invariants
-Numbered statements that must hold at all times. These are what a reviewer checks a diff against, so keep them short and testable.
+List numbered rules that must always hold. A reviewer checks the code against these rules, so keep them short and testable.
 
 ### Requirements
 - Observable behavior and constraints.
@@ -54,13 +55,13 @@ Numbered statements that must hold at all times. These are what a reviewer check
 APIs, commands, events, schemas, config, compatibility, or migration.
 
 ### Naming and identity
-How every durable name or ID is derived, what happens when derivation fails, and what happens if the source of the name changes after state exists.
+How every stored name or ID is created, what happens when that fails, and what happens if its source changes after data exists.
 
 ## 7. Failure behavior and lifecycle
-What can fail, what state it moves to, whether it retries and how, and how it recovers. Cover startup, config or state changes, work in flight, shutdown, and what happens when everything fails at once.
+Say what can fail, what state follows, whether the system retries, and how it recovers. Cover startup, config or state changes, work in flight, shutdown, and what happens when several things fail together.
 
 ## 8. Security, privacy, and operations
-State the trust boundary, authorization checks, sensitive data handling, and operational impact. Cover anything shared and finite such as rate limits, connections, disk, memory, or cost, and say what happens when it runs out.
+State the trust boundary, authorization checks, sensitive data handling, and operational impact. Name shared limits such as rate limits, connections, disk, memory, or cost. Say what happens at each limit.
 
 ## 9. Acceptance criteria
 - Testable conditions that prove the work is complete.
@@ -80,7 +81,8 @@ How each invariant and each important requirement will be proved.
 
 ## Writing rules
 
-- Prose is the default. Use bullets only for content that is genuinely a list, such as config fields, acceptance criteria, risks, and out of scope.
+- Start with the simplest useful explanation. Write for a new teammate, not someone who already knows the project.
+- Prose is the default. Use bullets only for real lists, such as config fields, acceptance criteria, risks, and out of scope.
 - A bullet cannot carry a decision by itself. Write the reason next to it in a sentence.
 - Use plain words. Say "the process crashed" instead of "an availability event occurred". Prefer short sentences.
 - Define a term the first time you use it, or do not use it.
@@ -97,12 +99,12 @@ How each invariant and each important requirement will be proved.
 
 Reread the draft once and check each category. Fix any gap you can resolve from the available evidence.
 
-1. **Executive summary.** Does it state the problem, outcome, approach, and decisive tradeoff without requiring the rest of the document?
+1. **Executive summary.** Can a new teammate understand the problem, outcome, approach, and main downside without reading the rest of the document?
 2. **Architecture fit.** Does the design show the current system boundary, the boundary being changed, and the owner of each new responsibility?
-3. **Names and identity.** Where does every durable identifier come from? What happens when it is missing, ambiguous, or changes after state exists?
-4. **Failure and recovery.** What creates a bad state? Does the system retry, with what backoff, and can it recover without a restart? What happens when everything is bad at startup?
+3. **Names and identity.** Where does every stored identifier come from? What happens when it is missing, unclear, or changes after data exists?
+4. **Failure and recovery.** What creates a bad state? Does the system retry, how long does it wait between attempts, and can it recover without a restart? What happens when everything is bad at startup?
 5. **Security and privacy.** Where is identity established, authorization enforced, untrusted input validated, and sensitive data exposed or retained?
-6. **Shared resources.** What finite resource does the feature consume? State the budget and the behavior at the limit.
+6. **Shared resources.** What limited resource does the feature use? State the budget and what happens at the limit.
 7. **Timing and fairness.** Replace words such as "eventually" and "will not starve" with a bound someone can test.
 8. **Lifecycle.** Cover config reload, enable and disable behavior, work already in flight, and shutdown.
 9. **Undefined terms.** Define words that carry a specific meaning in the design.

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: improve
-description: "Improves existing code without changing intended behavior by simplifying structure, removing duplication and dead code, clarifying names, and reducing unnecessary abstractions. Use when the user asks to improve, simplify, clean up, refactor, reduce complexity, remove duplication, or make existing code easier to understand."
+description: "Makes existing code easier to understand without changing behavior. Use to simplify structure, remove duplication or dead code, improve names, or remove unnecessary abstractions."
 user-invocable: true
 argument-hint: "[code, files, diff, branch, or improvement focus]"
 ---
@@ -10,11 +10,12 @@ argument-hint: "[code, files, diff, branch, or improvement focus]"
 ## Workflow
 
 1. Identify the target from the request, current diff, or recently changed code.
-2. Read the target, its tests, and relevant surrounding code. Establish the behavior that must not change. If behavior named by the task or a public interface lacks tests, add focused characterization coverage before refactoring. If the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.
-3. Find unnecessary complexity, duplication, dead code, weak names, awkward boundaries, and abstractions that cost more than they help.
-4. Make focused improvements by deleting, deduplicating, renaming, simplifying, extracting, or inlining.
-5. Preserve public interfaces, data shapes, errors, and user-visible behavior unless the user explicitly asks to change them.
-6. Run tests and checks that cover behavior the refactor can affect. Report what improved, what behavior was preserved, and the evidence.
+2. Read the target, its tests, and relevant surrounding code. State the behavior that must not change.
+3. If that behavior lacks tests, add focused coverage before refactoring. If automated tests cannot exercise it, explain why and give other evidence.
+4. Find unnecessary complexity, duplication, dead code, weak names, awkward boundaries, and abstractions that cost more than they help.
+5. Make focused improvements by deleting, deduplicating, renaming, simplifying, extracting, or inlining.
+6. Preserve public interfaces, data shapes, errors, and user-visible behavior unless the user explicitly asks to change them.
+7. Run tests and checks that cover behavior the refactor can affect. Report what improved, what behavior was preserved, and the evidence.
 
 ## Boundaries
 

--- a/skills/milestone/SKILL.md
+++ b/skills/milestone/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: milestone
-description: "Completes all open GitHub issues in a milestone, taking each one to a tested, reviewed, green pull request. Use when the user asks to complete, deliver, work through, or finish a GitHub milestone."
+description: "Completes every open issue in a GitHub milestone. Takes one issue at a time to a tested and reviewed pull request. Use when the user asks to finish or deliver a milestone."
 user-invocable: true
 argument-hint: "<GitHub milestone URL or name>"
 ---
@@ -12,12 +12,18 @@ Finish every open issue in a GitHub milestone.
 ## Workflow
 
 1. Resolve the milestone and repository. Inspect its open issues, dependencies, linked pull requests, checks, and current project state.
-2. Order the remaining issues by dependency, risk, and reviewability. Put blockers, bugs, and shared seams before dependent feature work.
-3. Take one issue at a time to a tested, reviewed, green pull request: branch and worktree, implement the smallest complete change, test it, review it with a fresh agent, then open the PR. Resume a matching pull request instead of creating duplicate work.
+2. Order the remaining issues by dependency, risk, and how easy each change will be to review. Put blockers, bugs, and shared foundations before features that depend on them.
+3. Take one issue at a time to a ready pull request. Create the branch and worktree, implement the smallest complete change, test it, review it with a fresh agent, then open the PR. Resume a matching pull request instead of creating duplicate work.
 4. After each pull request is ready, stop for human merge unless the user explicitly allowed merging for this run.
-5. When merging is allowed, merge only after required checks pass or are confirmed unconfigured, the pull request is mergeable, every current comment has a disposition, no required change remains unresolved, and the description and checklist match the final head. Sync the latest remote default branch before starting the next issue.
-6. Refresh the milestone before each issue. Record pull request links, proof, blockers, and final state in the tracker when access permits.
-7. Report completed issues, merged and open pull requests, blockers, checks, and anything not verified.
+5. When merging is allowed, merge only when:
+   - Required checks pass or are confirmed unconfigured.
+   - The pull request is mergeable.
+   - Every current comment has a clear outcome.
+   - No required change remains unresolved.
+   - The description and checklist match the final commit.
+6. Sync the latest remote default branch before starting the next issue.
+7. Refresh the milestone before each issue. Record pull request links, proof, blockers, and final state in the tracker when access permits.
+8. Report completed issues, merged and open pull requests, blockers, checks, and anything not verified.
 
 ## Boundaries
 
@@ -25,5 +31,6 @@ Finish every open issue in a GitHub milestone.
 - Use one branch and pull request per issue unless combining issues is required for a working result. Explain any combination before starting it.
 - Do not batch unrelated issues.
 - Never merge without explicit permission.
-- Do not merge with failing required checks, missing acceptance criteria, a current comment without a disposition, a required change unresolved, or an acceptance criterion or affected failure path left unverified without a user-accepted exception.
+- Do not merge with failing required checks, missing acceptance criteria, a current comment without a clear outcome, or a required change still open.
+- Do not merge when an acceptance criterion or affected failure path is unverified unless the user accepts that exception.
 - Stop when an issue has unresolved product or technical decisions, requires missing secrets or permissions, already has conflicting work, or grows beyond its acceptance criteria.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "Breaks a reviewed design or brief into ordered, agent-ready tasks, tickets, and optional milestones. Use when the user asks to break a feature or project into implementation tasks, create implementation tickets or issues from a design, brief, or project, define milestones, or prepare work for multiple agent runs. Do not use for one ticket or the short execution plan inside one coding task."
+description: "Turns a reviewed design or brief into ordered tasks for separate agent runs. Use for implementation tasks, tracker tickets, or useful milestones. Do not use for one coding task or its short execution outline."
 user-invocable: true
 argument-hint: "<design, brief, issue, or request>"
 ---
@@ -11,9 +11,14 @@ argument-hint: "<design, brief, issue, or request>"
 
 1. Read the source, repository instructions, and relevant code.
 2. Stop and return to design if product or technical choices remain open.
-3. Break the work into vertical, outcome-based tasks. Each task must produce one focused, self-contained pull request whose outcome, behavior, and proof can be reviewed without separating unrelated work, and it must fit one agent run. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review. Order tasks by dependency. Add milestones only when they create a useful delivery or review boundary.
-4. Return the plan in chat by default. Create tracker tickets only when the user asks. Never write a plan document.
-5. Stop after planning. Do not implement.
+3. Break the work into tasks that each deliver working behavior. Each task must:
+   - Fit one agent run.
+   - Produce one focused pull request.
+   - Let a reviewer understand the outcome, behavior, and proof without separating unrelated work.
+4. Separate refactoring when it would hide the behavior change. Small local cleanup may stay when it makes the change easier to review.
+5. Order tasks by dependency. Add milestones only when they create a useful delivery or review boundary.
+6. Return the plan in chat by default. Create tracker tickets only when the user asks. Never write a plan document.
+7. Stop after planning. Do not implement.
 
 Each task must stand alone:
 
@@ -41,6 +46,6 @@ Related work this task must not absorb.
 
 ## Boundaries
 
-- Do not split by file or technical layer when one vertical slice can deliver working behavior.
+- Do not split one piece of working behavior into separate file or technical-layer tasks.
 - Do not create scaffolding or cleanup tasks without a checked outcome.
 - Do not hide unresolved decisions inside implementation tickets.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: "Independently reviews whether a design can satisfy its requirements, plus behavior, security, regressions, complexity, test quality, documentation, and missing evidence. Use when the user asks for a code review, PR review, diff review, security review, second opinion, or pre-merge review. Launches a fresh subagent and never edits the code."
+description: "Uses a fresh agent to review a design or code change without editing it. Checks behavior, security, regressions, complexity, tests, docs, and missing proof. Use for code, PR, diff, security, second-opinion, or pre-merge reviews."
 user-invocable: true
 argument-hint: "[ticket, design, diff, branch, commit, PR, or file path]"
 ---
@@ -11,19 +11,31 @@ The reviewer must be a fresh subagent that did not implement the change. Do not 
 
 ## Standard
 
-Approve only when the change matches its source, behaves as required, and has no known defect or unmitigated risk that could violate the source or repository policy in security, data loss, compatibility, or operations. If the same outcome and proof can be delivered with less state, indirection, duplication, or operational work, request the simpler design. Do not demand perfection or block on personal taste. Cite technical evidence or repository conventions.
+Approve only when:
+
+- The change matches its source and behaves as required.
+- No known defect or unhandled risk could break the source or repository rules for security, data loss, compatibility, or operations.
+- No simpler design has been identified that delivers the same outcome and proof with less state, indirection, duplication, or operational work.
+
+Do not demand perfection or block on personal taste. Cite technical evidence or repository conventions.
 
 The verdict is independent agent evidence. It is not GitHub approval or a replacement for human review.
 
 ## Review order
 
-1. **Set the frame.** Give the reviewer the task, acceptance criteria, repository guidance, complete diff or pull request, and test evidence. Identify the user or developer affected by the change.
-2. **Take the broad view.** Read the available change summary, local execution outline, or pull request description, plus the relevant design or ticket. Confirm the change belongs in the system, matches the intended behavior, and is one reviewable outcome. Report a mismatch with the source or a design that cannot satisfy its requirements before reviewing details.
-3. **Review the main behavior.** Start with the files and flows that implement the outcome. Check functionality for users and developers, failures, security boundaries, interfaces, compatibility, migrations, concurrency, and operations.
-4. **Review every human-written changed line in context.** Inspect enough surrounding code to judge correctness, regressions, complexity, naming, comments, style, and documentation. For generated files or large data, inspect the generator or source and spot-check output. Keep findings within the change's scope.
-5. **Review the proof.** Check that tests cover the changed behavior and failure paths affected by the change or named in its acceptance criteria, assert observable behavior or a documented internal contract, would fail under a broken implementation, and do not duplicate implementation logic or obscure the scenario with setup. Run focused checks that can confirm or falsify a claim that could change a finding or verdict.
-6. **Check specialist coverage.** Identify security, privacy, concurrency, accessibility, internationalization, or domain-specific work. If the reviewer lacks evidence or expertise for a risk that could violate the source or repository policy, mark it unverified. Use `Blocked` when that gap could conceal such a violation and no qualified reviewer covers it.
-7. **Report findings.** Return actionable findings in severity order. For each finding give the location, impact, evidence, and smallest fix direction.
+1. **Set the frame.** Give the reviewer the task, acceptance criteria, repository rules, complete diff or pull request, and test evidence. Name the user or developer affected by the change.
+2. **Take the broad view.** Read the change summary and the relevant design or ticket. Confirm that the change belongs in the system, matches the intended behavior, and delivers one reviewable outcome. Report a mismatch before reviewing details.
+3. **Review the main behavior.** Start with the files and flows that deliver the outcome. Check behavior, failures, security boundaries, interfaces, compatibility, migrations, concurrency, and operations.
+4. **Review every human-written changed line in context.** Read enough surrounding code to judge correctness, regressions, complexity, names, comments, style, and docs. For generated files or large data, inspect the source and spot-check the output. Keep findings within the change's scope.
+5. **Review the proof.** Check that tests:
+   - Cover the changed behavior and affected failure paths.
+   - Prove the acceptance criteria.
+   - Assert behavior a user or caller can observe, or a documented internal contract.
+   - Would fail under a broken implementation.
+   - Do not copy implementation logic or hide the scenario in setup.
+6. Run focused checks that can confirm or disprove a claim that could change a finding or verdict.
+7. **Check specialist coverage.** Identify security, privacy, concurrency, accessibility, internationalization, or domain-specific work. Mark a risk unverified when the reviewer lacks the evidence or skill to judge it. Use `Blocked` when that gap could hide a problem that breaks a rule and no qualified reviewer covers it.
+8. **Report findings.** Return actionable findings in severity order. For each finding give the location, impact, evidence, and smallest fix direction.
 
 - **blocker:** unsafe to merge.
 - **important:** should fix before merge.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-to-pr
-description: "Takes one task, ticket, or existing pull request to a tested, independently reviewed, green pull request ready for human merge. Use when the user asks to implement, build, fix, deliver, or take one task or issue to a pull request."
+description: "Takes one task from its source to a tested and independently reviewed pull request. Use to implement, build, fix, or deliver one task, ticket, or existing pull request."
 user-invocable: true
 argument-hint: "<ticket, task, or pull request>"
 ---
@@ -9,59 +9,83 @@ argument-hint: "<ticket, task, or pull request>"
 
 Follow this workflow for the requested task, ticket, or pull request:
 
-1. **Resolve the source.** Resume an existing pull request and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or durable tracking improves the handoff or proof. Do not duplicate tickets or pull requests.
-2. **Branch.** Resume the branch and worktree for an existing pull request. For new work, fetch the remote and create a dedicated branch and worktree from the latest remote default branch, named with the ticket number or task slug. Follow the repository's location convention and reuse a suitable existing worktree. Remove a manually created worktree after its pull request is merged or closed.
+1. **Resolve the source.** Resume an existing pull request and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or saved tracking would improve the handoff or proof. Do not duplicate tickets or pull requests.
+2. **Branch.** Resume the branch and worktree for an existing pull request. For new work:
+   - Fetch the remote.
+   - Create a branch and worktree from the latest remote default branch.
+   - Name it with the ticket number or task slug.
+   - Follow the repository's location rules and reuse a suitable worktree.
+   - Remove a manually created worktree after its pull request is merged or closed.
 3. **Read the context.** Read the repository instructions and inspect the relevant code.
-4. **Outline the change.** Define one focused, self-contained outcome with its related proof. A reviewer must be able to understand its behavior and proof without first separating unrelated work. If the source requires several such changes, split it or return to planning before coding. Separate refactoring when it would obscure the behavior diff. Small local cleanup may remain when it makes the changed behavior easier to review. This is a local execution outline, not a plan document.
-5. **Implement.** Make the change. Test changed behavior, failure paths affected by the change or named in its acceptance criteria, and behavior a refactor must preserve. If implementation changes documented ownership, dependency direction, protocols, durable data, trust boundaries, deployment topology, or hard limits, update the existing architecture reference in the same change. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, record the concrete reason and substitute evidence.
-6. **Test and self-review.** Run tests and checks that cover the changed behavior and affected interfaces, including a real browser when browser-rendered behavior changes. Inspect the final diff for accidental scope, unclear code, and missing proof before independent review.
-7. **Review.** Review the change with a fresh subagent that did not implement it.
-8. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
-9. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request that meets the pull request standard below.
-10. **Pass CI.** Wait for checks, fix failures caused by the change or required by repository policy, and rerun affected tests and review until required checks pass. If no checks are configured, continue.
-11. **Address feedback.** Inspect every current human and bot comment and review thread. Give each one a disposition: change the code or durable documentation, answer the question, push back with technical evidence, link a tracked follow-up and explain why a non-blocking suggestion is outside this pull request, or mark informational feedback as requiring no action. If a reviewer cannot understand the code, clarify the code or documentation before relying on a thread reply. Resolve a thread only when fully addressed. Rerun affected tests and fresh review after requested changes. Do not wait indefinitely for future feedback.
-12. **Refresh the pull request.** Update the title, description, and checklist to match the final head, verification, CI state, review findings, and feedback disposition.
+4. **Outline the change.** Define one focused outcome and its proof. A reviewer must be able to understand it without separating unrelated work. If the source requires several outcomes, split it or return to planning before coding.
+   - Separate refactoring when it would hide the behavior change.
+   - Keep small local cleanup only when it makes the change easier to review.
+   - Keep this as a local execution outline, not a plan document.
+5. **Implement.** Make the change and test:
+   - Changed behavior.
+   - Affected failure paths and any failure path named in the acceptance criteria.
+   - Behavior that a refactor must preserve.
+6. Update the existing architecture document when code changes documented ownership, dependency direction, protocols, stored data, trust boundaries, deployment topology, or hard limits.
+7. If automated tests cannot exercise the affected behavior, explain why and give other evidence.
+8. **Test and self-review.** Run tests and checks that cover the changed behavior and affected interfaces. Use a real browser when browser-rendered behavior changes. Inspect the final diff for accidental scope, unclear code, and missing proof.
+9. **Review.** Review the change with a fresh subagent that did not implement it.
+10. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
+11. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request that meets the pull request standard below.
+12. **Pass CI.** Wait for checks. Fix failures caused by the change or required by repository policy. Rerun affected tests and review until required checks pass. Continue when no checks are configured.
+13. **Address feedback.** Inspect every current human and bot comment and review thread. Give each one a clear outcome:
+    - Change the code or lasting documentation.
+    - Answer the question.
+    - Push back with technical evidence.
+    - Link a tracked follow-up and explain why the suggestion is outside this pull request.
+    - Mark information that needs no action.
+14. If a reviewer cannot understand the code, clarify the code or documentation before relying on a thread reply. Resolve a thread only when fully addressed.
+15. Rerun affected tests and fresh review after requested changes. Do not wait indefinitely for future feedback.
+16. **Refresh the pull request.** Update the title, description, and checklist to match the final commit, verification, CI state, review findings, and feedback outcomes.
 
 Commit and push every post-PR fix before reassessing checks or feedback.
 
-If the ticket, task, or design is wrong or incomplete, update the source of truth before continuing. Prefer the smallest complete change and no unrelated cleanup.
+If the ticket, task, or design is wrong or incomplete, update it before continuing. Prefer the smallest complete change and no unrelated cleanup.
 
-Stop when the pull request is green, mergeable, every current comment has a disposition, and no required change remains unresolved. Never merge unless the user explicitly asks. Report an exact blocker when required access, checks, or independent review remain unavailable after safe alternatives are exhausted.
+Stop when the pull request is mergeable, all required checks pass, every current comment has a clear outcome, and no required change remains unresolved.
+
+Never merge unless the user explicitly asks. Report the exact blocker when required access, checks, or independent review remain unavailable after safe alternatives are exhausted.
 
 ## Pull request standard
 
-Treat the pull request title and body as durable history for reviewers now and engineers later. Follow a required repository template and add any information or evidence below that it does not cover. If no template exists, use the structure below.
+Treat the pull request title and body as useful history for reviewers now and engineers later. Follow the repository template when one exists. Add information below it only when a reviewer needs it. Otherwise use the structure below.
 
 - Follow the repository's title convention. Otherwise use a short, standalone title that states the delivered outcome.
 - Link the source ticket with the repository's closing syntax when the pull request completes it.
-- Include enough context to understand the change without opening the ticket or reading the entire diff.
-- Answer the reviewer questions with concrete behavior, decisions, risks, shortcomings, and evidence. Do not write an inventory of edited files.
-- For a complex change, say where to start and which parts need the closest scrutiny.
+- Give enough context to understand the change without opening the ticket or reading the whole diff.
+- Start with two to four short sentences. Explain the problem, what changed, and why it matters.
+- Use everyday words. Define any technical term the reader needs.
+- Put technical detail after the summary. Include only behavior, decisions, risks, shortcomings, and evidence that help the review.
+- Do not list edited files.
+- For a complex change, say where to start and what needs the closest review.
 - Answer every checklist item with an explicit status and evidence. Use `Not applicable`, `Not configured`, or `Pending` instead of a checked box that implies success.
 - Treat independent agent review as evidence, not GitHub approval or a replacement for human review.
 - Preserve useful human-written context when updating an existing pull request.
-- Keep the body current when later commits change behavior, risk, or verification.
+- Keep the body short and current when later commits change behavior, risk, or verification.
 
 ```markdown
 Closes #<ticket>
 
-## What is this change?
+## Plain English summary
 
-Summarize the major changes and observable behavior so a reader understands
-what changed without reading the entire diff.
+In two to four short sentences, explain the problem, what changed, and why it
+matters. Use everyday words. Do not list files or use unexplained technical
+terms.
 
-## Why is it important?
+## Details
 
-Explain the problem, who it affects, the context behind the change, and why
-this approach was chosen.
+Add only behavior or decisions that are not clear from the summary. Skip this
+section when the summary is enough.
 
-## What should the reviewer know or consider?
+## Reviewer notes
 
-Call out decisions not obvious from the code, scope boundaries, tradeoffs,
-shortcomings, safety rules, compatibility, migrations, failure behavior,
-operational impact, and known risks. Link relevant designs, benchmarks, or
-related changes while preserving the essential context here. For a complex
-change, tell the reviewer where to start and what needs the closest scrutiny.
+Include only facts that change how this pull request should be reviewed: risk,
+tradeoff, failure behavior, compatibility, migration, or where to start. Write
+`None` when none apply.
 
 ## Checklist
 

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: "Tests a code change against its acceptance criteria using focused automated checks and real-browser verification for browser-facing work. Use when the user asks to test, verify, validate, QA, check acceptance criteria, browser-test, or prove a diff, branch, PR, URL, or user flow works."
+description: "Proves that a code change meets its acceptance criteria. Uses focused automated checks and a real browser for browser-facing work. Use to test or verify a diff, branch, PR, URL, or user flow."
 user-invocable: true
 argument-hint: "<task, acceptance criteria, diff, branch, PR, URL, or flow>"
 ---
@@ -10,11 +10,17 @@ argument-hint: "<task, acceptance criteria, diff, branch, PR, URL, or flow>"
 ## Workflow
 
 1. Read the task, acceptance criteria, changed code, existing tests, and repository instructions.
-2. Map every acceptance criterion and failure path affected by the change to proof. Test changed behavior, those failure paths, and behavior a refactor must preserve. If the change has no executable behavior, or the affected behavior cannot be exercised through available automated interfaces, state the concrete reason and substitute evidence.
-3. Add or update focused tests where proof is missing. Check that assertions would fail when the changed behavior breaks and assert observable behavior rather than incidental implementation unless the internal contract is the target. Keep setup and assertions no more complex than the scenario requires.
-4. Run the narrowest checks that exercise the changed behavior and affected interfaces, then wider checks when shared behavior or interfaces changed.
-5. When browser-rendered behavior changes, start the documented app and verify the acceptance-criteria flows and affected failure states in a real browser. Check desktop and mobile when layout or responsive styles changed, and check keyboard use when interactions changed. Check console errors and failed requests during every browser flow. Capture evidence. Source inspection is not browser proof.
-6. Report each criterion as pass, fail, or unverified with the command, browser flow, or evidence that supports it.
+2. Map every acceptance criterion and affected failure path to proof. Test changed behavior and behavior a refactor must preserve.
+3. If automated tests cannot exercise the affected behavior, explain why and give other evidence.
+4. Add or update focused tests where proof is missing. Assertions should fail when the changed behavior breaks.
+5. Assert behavior a user or caller can observe unless the test targets a documented internal contract. Keep setup and assertions no more complex than the scenario.
+6. Run the narrowest checks that exercise the changed behavior and affected interfaces. Run wider checks when shared behavior or interfaces changed.
+7. When browser-rendered behavior changes, start the documented app and check the required flows and affected failures in a real browser.
+   - Check desktop and mobile when layout or responsive styles changed.
+   - Check keyboard use when interactions changed.
+   - Check console errors and failed requests during every flow.
+   - Capture evidence. Reading source is not browser proof.
+8. Report each criterion as pass, fail, or unverified. Include the command, browser flow, or other evidence.
 
 ## Boundaries
 


### PR DESCRIPTION
## Plain English summary

Blueprint had sound rules, but some skills and examples explained them with dense or abstract language. This change makes every skill easier for a new teammate to understand. Pull requests now start with a short plain English summary, while the technical checks and delivery rules stay the same.

## Details

- Adds one shared writing rule: explain the main idea first, use everyday words, define technical terms, then add detail.
- Makes architecture and design summaries pass a new-teammate readability check.
- Shortens skill descriptions and splits compound workflow rules into clear steps.
- Updates the public guides and examples so they demonstrate the same style.

## Reviewer notes

This changes instructions and examples only. The closest review should check that simpler wording has not weakened any technical contract.

## Checklist

- **Is this one focused, self-contained change?** Yes. It applies one plain-language standard across Blueprint guidance and examples.
- **Did you write or update tests?** Not applicable. There is no executable product behavior.
- **Did you run the relevant tests and checks?** Yes. Skill loading, YAML metadata, numbered sections, example structure, local links, Bash syntax, sentence length, em dash scan, Mermaid rendering, and diff checks passed.
- **Did you independently review the final diff and address valid findings?** Yes. A fresh reviewer approved after its valid wording findings were fixed.
- **Did you update documentation when behavior changed?** Yes. Documentation is the change.
- **Did required CI checks pass?** Not configured. No required checks are reported for this branch.