### PR TITLE
docs: simplify task-to-pr workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ flowchart TB
     end
 
     subgraph Deliver["Deliver with /task-to-pr"]
-        Task --> Isolate["isolate"] --> Code["code"] --> Test["/test"] --> Review["/review"]
-        Review -->|findings| Fix["fix"] --> Test
-        Review -->|clean| Publish["publish PR"] --> Validate["CI + current feedback"]
+        Task --> Isolate["isolate"] --> Code["code"] --> Review["/review"] --> Test["/test"]
+        Review -->|findings| Fix["fix"] --> Review
+        Test -->|failure| Fix
+        Test -->|pass| Publish["publish PR"] --> Validate["CI + current feedback"]
         Validate -->|failure or finding| Fix
         Validate -->|clean| PR["ready PR"]
     end
@@ -75,14 +76,13 @@ Writing code is a basic agent ability, not a separate skill. Branching, committi
 
 [`skills/task-to-pr/SKILL.md`](skills/task-to-pr/SKILL.md) is the single authority for delivery. Given a ticket, task, or existing PR, it:
 
-1. resolves the source and isolates work before editing;
-2. implements the smallest complete change;
-3. runs `/test` and independent `/review` loops;
-4. creates Conventional Commits and opens or updates a PR with a plain summary, review notes, and an evidence checklist;
-5. waits for CI, handles feedback that exists, and records evidence;
-6. stops at a mergeable PR whose required checks pass.
+1. codes one focused change in an isolated worktree;
+2. gets a fresh independent review;
+3. proves the change with tests;
+4. opens a pull request;
+5. waits for CI and feedback, then repeats review and tests after code changes.
 
-It does not wait forever for future human feedback, manufacture tracker artifacts for trivial work, or merge without explicit permission.
+It stops when the pull request is ready for human merge. It never merges without explicit permission.
 
 ## One milestone to completed issues
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ flowchart TB
     end
 
     subgraph Deliver["Deliver with /task-to-pr"]
-        Task --> Isolate["isolate"] --> Code["code"] --> Review["/review"] --> Test["/test"]
+        Task --> Isolate["isolate"] --> Code["code"] --> Review["review code"] --> Test["/test"]
         Review -->|findings| Fix["fix"] --> Review
         Test -->|failure| Fix
-        Test -->|pass| Publish["publish PR"] --> Validate["CI + current feedback"]
+        Test -->|pass| ProofReview["review proof"] --> Publish["publish PR"] --> Validate["latest commit checks"]
+        ProofReview -->|findings| Fix
         Validate -->|failure or finding| Fix
-        Validate -->|clean| PR["ready PR"]
+        Validate -->|clean| Human["check current comments once"]
+        Human -->|finding| Fix
+        Human -->|clean| PR["ready PR"]
     end
 
     PR --> Merge([Human merge])
@@ -77,10 +80,10 @@ Writing code is a basic agent ability, not a separate skill. Branching, committi
 [`skills/task-to-pr/SKILL.md`](skills/task-to-pr/SKILL.md) is the single authority for delivery. Given a ticket, task, or existing PR, it:
 
 1. codes one focused change in an isolated worktree;
-2. gets a fresh independent review;
-3. proves the change with tests;
+2. reviews the code before testing;
+3. proves the change with tests, then gets a fresh independent review;
 4. opens a pull request;
-5. waits for CI and feedback, then repeats review and tests after code changes.
+5. passes configured CI and automated review for the latest commit, then checks current human comments once.
 
 It stops when the pull request is ready for human merge. It never merges without explicit permission.
 

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -7,98 +7,39 @@ argument-hint: "<ticket, task, or pull request>"
 
 # Task to PR
 
-Follow this workflow for the requested task, ticket, or pull request:
+Take one task to a pull request that is ready for human merge.
 
-1. **Resolve the source.** Resume an existing pull request and its linked ticket when one exists. Otherwise fetch the ticket or use the task as the source. Create a ticket only when the user asks or saved tracking would improve the handoff or proof. Do not duplicate tickets or pull requests.
-2. **Branch.** Resume the branch and worktree for an existing pull request. For new work:
-   - Fetch the remote.
-   - Create a branch and worktree from the latest remote default branch.
-   - Name it with the ticket number or task slug.
-   - Follow the repository's location rules and reuse a suitable worktree.
-   - Remove a manually created worktree after its pull request is merged or closed.
-3. **Read the context.** Read the repository instructions and inspect the relevant code.
-4. **Outline the change.** Define one focused outcome and its proof. A reviewer must be able to understand it without separating unrelated work. If the source requires several outcomes, split it or return to planning before coding.
-   - Separate refactoring when it would hide the behavior change.
-   - Keep small local cleanup only when it makes the change easier to review.
-   - Keep this as a local execution outline, not a plan document.
-5. **Implement.** Make the change and test:
-   - Changed behavior.
-   - Affected failure paths and any failure path named in the acceptance criteria.
-   - Behavior that a refactor must preserve.
-6. Update the existing architecture document when code changes documented ownership, dependency direction, protocols, stored data, trust boundaries, deployment topology, or hard limits.
-7. If automated tests cannot exercise the affected behavior, explain why and give other evidence.
-8. **Test and self-review.** Run tests and checks that cover the changed behavior and affected interfaces. Use a real browser when browser-rendered behavior changes. Inspect the final diff for accidental scope, unclear code, and missing proof.
-9. **Review.** Review the change with a fresh subagent that did not implement it.
-10. **Address findings.** Fix valid review findings, then rerun affected tests and fresh review.
-11. **Publish.** Create a Conventional Commit, push the branch, and open or update a ready pull request that meets the pull request standard below.
-12. **Pass CI.** Wait for checks. Fix failures caused by the change or required by repository policy. Rerun affected tests and review until required checks pass. Continue when no checks are configured.
-13. **Address feedback.** Inspect every current human and bot comment and review thread. Give each one a clear outcome:
-    - Change the code or lasting documentation.
-    - Answer the question.
-    - Push back with technical evidence.
-    - Link a tracked follow-up and explain why the suggestion is outside this pull request.
-    - Mark information that needs no action.
-14. If a reviewer cannot understand the code, clarify the code or documentation before relying on a thread reply. Resolve a thread only when fully addressed.
-15. Rerun affected tests and fresh review after requested changes. Do not wait indefinitely for future feedback.
-16. **Refresh the pull request.** Update the title, description, and checklist to match the final commit, verification, CI state, review findings, and feedback outcomes.
+## Workflow
 
-Commit and push every post-PR fix before reassessing checks or feedback.
+1. **Code**
+   - Read the task, repository instructions, and relevant code.
+   - Resume an existing pull request and worktree. Otherwise fetch the remote and create a branch and worktree from the latest default branch.
+   - Define one focused outcome and its proof. If the task is wrong, unclear, or too large, update it or return to design or planning.
+   - Implement the smallest complete change. Update the architecture document when system boundaries or contracts change.
 
-If the ticket, task, or design is wrong or incomplete, update it before continuing. Prefer the smallest complete change and no unrelated cleanup.
+2. **Review**
+   - Inspect the complete diff for mistakes, unrelated changes, unclear code, and missing proof.
+   - Ask a fresh subagent to review it.
+   - Fix valid findings and repeat until the reviewer approves.
 
-Stop when the pull request is mergeable, all required checks pass, every current comment has a clear outcome, and no required change remains unresolved.
+3. **Test**
+   - Prove the acceptance criteria, changed behavior, affected failure paths, and behavior a refactor must preserve.
+   - Run focused automated checks. Run wider checks when shared behavior changed.
+   - Use a real browser when browser-rendered behavior changed.
+   - If automated tests cannot cover something, explain why and give other evidence.
+   - If testing changes the code, repeat Review and Test.
 
-Never merge unless the user explicitly asks. Report the exact blocker when required access, checks, or independent review remain unavailable after safe alternatives are exhausted.
+4. **Open the PR**
+   - Create a Conventional Commit, push the branch, and open or update a ready pull request.
+   - Use the repository template. If none exists, use `Plain English summary`, `Reviewer notes`, and `Proof`.
+   - Link the source task. Explain the change without requiring the ticket or diff. Do not list files.
+   - Keep the summary to two to four short sentences. Give the status and evidence for tests, checks, review findings, documentation, CI, and anything unverified.
 
-## Pull request standard
+5. **Wait for feedback**
+   - Wait for CI and current human or bot feedback.
+   - Fix CI failures caused by the change and valid feedback requests. Answer or push back with evidence when no code change is needed.
+   - After a code change, repeat Review and Test. Commit, push, and update the pull request.
+   - Recheck CI and comments after the last push.
+   - Stop when the pull request is mergeable, required checks pass or are not configured, every current comment is handled, and no required change remains.
 
-Treat the pull request title and body as useful history for reviewers now and engineers later. Follow the repository template when one exists. Add information below it only when a reviewer needs it. Otherwise use the structure below.
-
-- Follow the repository's title convention. Otherwise use a short, standalone title that states the delivered outcome.
-- Link the source ticket with the repository's closing syntax when the pull request completes it.
-- Give enough context to understand the change without opening the ticket or reading the whole diff.
-- Start with two to four short sentences. Explain the problem, what changed, and why it matters.
-- Use everyday words. Define any technical term the reader needs.
-- Put technical detail after the summary. Include only behavior, decisions, risks, shortcomings, and evidence that help the review.
-- Do not list edited files.
-- For a complex change, say where to start and what needs the closest review.
-- Answer every checklist item with an explicit status and evidence. Use `Not applicable`, `Not configured`, or `Pending` instead of a checked box that implies success.
-- Treat independent agent review as evidence, not GitHub approval or a replacement for human review.
-- Preserve useful human-written context when updating an existing pull request.
-- Keep the body short and current when later commits change behavior, risk, or verification.
-
-```markdown
-Closes #<ticket>
-
-## Plain English summary
-
-In two to four short sentences, explain the problem, what changed, and why it
-matters. Use everyday words. Do not list files or use unexplained technical
-terms.
-
-## Details
-
-Add only behavior or decisions that are not clear from the summary. Skip this
-section when the summary is enough.
-
-## Reviewer notes
-
-Include only facts that change how this pull request should be reviewed: risk,
-tradeoff, failure behavior, compatibility, migration, or where to start. Write
-`None` when none apply.
-
-## Checklist
-
-- **Is this one focused, self-contained change?** <Yes | No>
-  Evidence or why the size and scope are necessary.
-- **Did you write or update tests?** <Yes | No | Not applicable>
-  Evidence or why tests do not apply.
-- **Did you run the relevant tests and checks?** <Yes | No>
-  Commands, browser or manual checks, results, and any unverified criteria or affected failure paths.
-- **Did you independently review the final diff and address valid findings?** <Yes | No>
-  Review evidence, findings fixed, and anything unresolved.
-- **Did you update documentation when behavior changed?** <Yes | No | Not applicable>
-  User, contributor, and architecture documentation changed or why each was not needed.
-- **Did required CI checks pass?** <Yes | No | Pending | Not configured>
-  Check names and results.
-```
+Never merge unless the user explicitly asks.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -13,21 +13,21 @@ Take one task to a pull request that is ready for human merge.
 
 1. **Code**
    - Read the task, repository instructions, and relevant code.
-   - Resume an existing pull request and worktree. Otherwise fetch the remote and create a branch and worktree from the latest default branch.
+   - For an existing pull request, use its branch in a worktree. Otherwise fetch the remote and create both from the latest default branch.
    - Define one focused outcome and its proof. If the task is wrong, unclear, or too large, update it or return to design or planning.
    - Implement the smallest complete change. Update the architecture document when system boundaries or contracts change.
 
 2. **Review**
    - Inspect the complete diff for mistakes, unrelated changes, unclear code, and missing proof.
-   - Ask a fresh subagent to review it.
-   - Fix valid findings and repeat until the reviewer approves.
+   - Fix problems before testing.
 
 3. **Test**
    - Prove the acceptance criteria, changed behavior, affected failure paths, and behavior a refactor must preserve.
    - Run focused automated checks. Run wider checks when shared behavior changed.
    - Use a real browser when browser-rendered behavior changed.
    - If automated tests cannot cover something, explain why and give other evidence.
-   - If testing changes the code, repeat Review and Test.
+   - Give the task, repository instructions, complete diff, and final evidence to a fresh subagent.
+   - Fix valid findings. After any code change, repeat Test and this final Review until approved.
 
 4. **Open the PR**
    - Create a Conventional Commit, push the branch, and open or update a ready pull request.
@@ -35,11 +35,14 @@ Take one task to a pull request that is ready for human merge.
    - Link the source task. Explain the change without requiring the ticket or diff. Do not list files.
    - Keep the summary to two to four short sentences. Give the status and evidence for tests, checks, review findings, documentation, CI, and anything unverified.
 
-5. **Wait for feedback**
-   - Wait for CI and current human or bot feedback.
-   - Fix CI failures caused by the change and valid feedback requests. Answer or push back with evidence when no code change is needed.
-   - After a code change, repeat Review and Test. Commit, push, and update the pull request.
-   - Recheck CI and comments after the last push.
-   - Stop when the pull request is mergeable, required checks pass or are not configured, every current comment is handled, and no required change remains.
+5. **Pass checks**
+   - Wait for configured CI and automated review of the latest commit. Request a new automated review after a push when needed.
+   - Continue when CI or automated review is not configured.
+   - Fix CI failures caused by the change and valid automated feedback.
+   - After a code change, repeat Review and Test. Commit, push, and start Pass checks again.
+   - When automated checks pass, inspect human comments once. Address those present, but do not wait for future comments.
+   - If a human comment changes the code, repeat Review and Test, commit, push, and start Pass checks again.
+   - Update the pull request with the final check state, feedback outcome, and proof.
+   - Stop when the pull request is mergeable, required CI passes or is not configured, automated review covers the latest commit or is not configured, every current comment is handled, and no required change remains.
 
 Never merge unless the user explicitly asks.


### PR DESCRIPTION
## Plain English summary

`/task-to-pr` had 16 workflow steps and a second long PR standard. It now has five steps: Code, Review, Test, Open PR, and Pass checks. The final step waits for automation on the latest commit, checks current human comments once, and never waits for comments that may arrive later.

## Details

The skill is 476 words, down from 1,103. The README shows the same five-step order and finite feedback loop.

## Reviewer notes

Check that the shorter workflow still keeps existing PR branches and worktrees, final independent review with test evidence, browser proof, latest-commit automation, one current-comment check, and the no-merge rule.

## Checklist

- **Is this one focused, self-contained change?** Yes. It only simplifies `/task-to-pr` and its README summary.
- **Did you write or update tests?** Not applicable. This changes instructions, not executable behavior.
- **Did you run the relevant tests and checks?** Yes. Skill loading, YAML metadata, required-rule checks, local links, Mermaid rendering, word count, and diff checks passed.
- **Did you independently review the final diff and address valid findings?** Yes. Fresh independent review approved. Both original automated review threads were fixed, answered with commit evidence, and resolved. Codex reviewed latest commit `c8f641f` and found no major issues.
- **Did you update documentation when behavior changed?** Yes. The README text and diagram match the skill.
- **Did required CI checks pass?** Not configured. No CI checks are reported for this branch.