### PR TITLE
Simplify Blueprint skill workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Blueprint is a small set of instructions for AI coding. It separates deciding wh
 - Update an existing architecture document when code changes ownership, dependency direction, protocols, stored data, trust boundaries, deployment topology, or hard limits.
 - Start with the simplest useful explanation. Use short sentences and everyday words. Define technical terms before using them.
 - Write for a new teammate. Put detail after the main idea. Remove anything that does not help someone decide, build, test, or review the work.
+- Give each skill one numbered workflow. Keep templates and rules separate from the steps.
 - Skip phases that add no value. Small, decided work can go straight to implementation.
 - A task is ready when a new agent can finish it without asking product or technical questions.
 - Each pull request delivers one focused outcome and its proof. A reviewer should not have to separate unrelated work to understand it.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The model has two layers:
 1. **Repository instructions define policy.** `AGENTS.md` says what good work means in a codebase.
 2. **Skills define each kind of work.** Each skill produces one clear result and has a clear stopping point. `/task-to-pr` and `/milestone` join the needed steps.
 
+Each skill uses one numbered workflow. Templates and rules support that workflow instead of creating another path through the work.
+
 ## The six phase skills
 
 | Skill | Owns | Stops when |

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -5,6 +5,7 @@ Review Blueprint as a small set of engineering instructions. Read the issue, com
 - Can a new teammate understand the summary without already knowing Blueprint terms?
 - Does the writing use short sentences, everyday words, and only useful detail?
 - Does each skill represent one meaningful engineering phase or delivery outcome?
+- Does each skill have one numbered workflow, with templates and rules kept outside the steps?
 - Is policy in `AGENTS.md`, with each phase and delivery workflow in its skill?
 - Does `/architecture` describe verified current implementation while `/design` describes a proposed feature or system-part change?
 - Does a read-only architecture explanation, mapping, review, or audit remain in chat unless the user asks for a document?

--- a/examples/rag-chatbot/design.md
+++ b/examples/rag-chatbot/design.md
@@ -181,7 +181,7 @@ Uploads are limited to 25 MiB and rejected before extraction when larger. Chat r
 
 ## 12. Open questions
 
-None block implementation. Authentication, provider selection, and asynchronous ingestion require new designs if the deployment scope expands beyond one trusted user.
+None block task breakdown. Authentication, provider selection, and asynchronous ingestion require new designs if the deployment scope expands beyond one trusted user.
 
 ## 13. Out of scope
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -7,19 +7,45 @@ argument-hint: "[repository, system, subsystem, or existing ARCHITECTURE.md]"
 
 # Architecture
 
+Explain the system that exists now.
+
 ## Workflow
 
-1. Read the request and repository instructions. Then inspect existing architecture docs, manifests, entry points, configuration, schemas, migrations, infrastructure, tests, and a few important flows.
-2. Choose the output:
+1. **Read**
+   - Read the request and repository instructions.
+   - Inspect existing architecture docs, manifests, entry points, configuration, schemas, migrations, infrastructure, tests, and a few important flows.
+
+2. **Choose the output**
    - For a whole repository document, use root `ARCHITECTURE.md`.
    - For a named subsystem, use its existing document or `docs/<subsystem>/architecture.md`.
    - For an explanation, map, review, or audit, answer in chat and do not modify files.
-3. Treat code, schemas, configuration, infrastructure, and executable tests as evidence. Treat existing prose as a claim to verify. Resolve contradictions before repeating them.
-4. Describe the system that exists now. Use the shape below for a document. For a chat report, use only the sections that answer the request. Link proposed changes to their design documents.
-5. Run the review pass. Correct every claim you can verify, identify unresolved evidence gaps, and keep limitations restricted to verified implementation gaps.
-6. Return the document or report for human review. Do not design future behavior, plan work, or change implementation.
 
-## Document shape
+3. **Verify the current system**
+   - Treat code, schemas, configuration, infrastructure, and executable tests as evidence.
+   - Treat existing prose as a claim to check.
+   - Resolve contradictions before repeating a claim.
+   - Check facts that change often, such as counts, limits, ports, timeouts, and dependency versions.
+
+4. **Write**
+   - Describe what is implemented now.
+   - For a document, use the template below.
+   - For chat, use only the sections that answer the request.
+   - Link proposed changes to their design documents.
+
+5. **Review**
+   - Check that a new teammate can explain the system, its main parts, where data lives, and the main rule to preserve.
+   - Check ownership, dependency direction, public contracts, critical flow order, side effects, cleanup, and failure paths against current evidence.
+   - Check authentication, authorization, isolation, untrusted input, secret access, and fail-open or fail-closed behavior.
+   - Check limited resources, concurrency, retries, startup, shutdown, monitoring, recovery, and how the system slows incoming work when full.
+   - Check repeated claims against repository instructions, README files, schemas, configuration, and tests.
+   - Fix verified errors. Put unresolved evidence gaps under Verification.
+   - Keep Known limitations to present gaps proved by current evidence.
+
+6. **Stop**
+   - Return the document or report for human review.
+   - Do not design future behavior, plan work, or change implementation.
+
+## Document template
 
 ```markdown
 # <System> architecture
@@ -62,36 +88,17 @@ List gaps that current evidence confirms. Do not mix in goals, roadmap items, or
 Link the small set of files that define entry points, boundaries, schemas, configuration, and critical flows.
 ```
 
-## Writing rules
+## Rules
 
 - Keep explanation, mapping, review, and audit requests read-only. Create or update a file only when the user asks for an architecture document.
-- Describe implemented reality, not intended architecture. Use a design document for future behavior.
 - Use `working tree based on <commit>` when the document and code change together before commit. Do not claim that uncommitted code was verified at the base commit.
-- Start with the simplest useful explanation. Write for a new teammate, not someone who already knows the project.
 - Use short sentences and everyday words. Define technical terms before using them.
-- Put detail after the reader understands the main idea. Do not turn the document into a file inventory.
-- Keep the length proportional to the system. A small repository may satisfy a section with one paragraph; do not pad it to resemble a large platform.
+- Start with the main idea. Put detail later. Do not turn the document into a file inventory.
+- Keep the length proportional to the system. Do not pad a small system.
 - Prefer exact execution order, ownership, and failure behavior over broad labels such as "service layer" or "robust".
 - Give every component a positive and negative boundary: what it owns and what it does not own.
 - Use diagrams for system context, dependencies, or flows only when they make a relationship materially clearer.
-- Check facts that can change immediately before writing them. Examples include counts, limits, ports, timeouts, and dependency versions.
 - Omit facts that add maintenance work without helping a contributor make a decision.
 - Link to detailed protocol, operations, or testing documents instead of duplicating them.
 - Keep proposed work in linked designs. Known limitations describe present gaps only.
-- Use plain words, define project-specific terms, and do not use em dashes.
-
-## Review pass
-
-Reread the draft and check each category against current evidence.
-
-1. **Clear summary.** Can a new teammate explain what the system does, how its main parts work together, where the real data lives, and the main rule to preserve?
-2. **Current state.** Does every statement describe code and configuration that exist at the stated verification basis?
-3. **Ownership.** Is each stored value, identifier, policy, and public contract owned in one named place?
-4. **Boundaries.** Does every component say what it owns, depends on, and does not own? Does the dependency direction match imports and runtime calls?
-5. **Flows.** Do the critical paths include their real ordering, response point, side effects, cleanup, and failure branches?
-6. **Security.** Are authentication, authorization, tenant or user isolation, untrusted input, secret access, and fail-open or fail-closed behavior explicit?
-7. **Operations.** Does the document cover limited resources, concurrency, retries, startup, shutdown, monitoring, and recovery? Does it say how the system slows incoming work when full?
-8. **Consistency.** Do repeated claims agree with README, repository instructions, contributor docs, schemas, config, and tests? Remove duplication or name the source when they do not.
-9. **Limitations.** Are gaps verified and current, with planned changes kept out of the current-system explanation?
-
-Put unresolved evidence gaps under Verification and state what would verify them.
+- Do not use em dashes.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -7,16 +7,39 @@ argument-hint: "<feature, problem, or brief>"
 
 # Design
 
+Write a spec for a proposed feature or system change.
+
 ## Workflow
 
-1. Read the request, repository instructions, relevant code, and linked material.
-2. Resolve choices that would change behavior, interfaces, data, errors, security, operations, or tests.
-3. Ask only questions whose answers would change the design. Recommend an answer when asking.
-4. Write `docs/<feature-slug>/design.md` using the numbered shape below. Keep it short and in order. Omit only sections that do not apply.
-5. Run the review pass. Fix what you can. List the rest under Open questions.
-6. Stop for human review. Do not plan or implement.
+1. **Read**
+   - Read the request, repository instructions, relevant code, current architecture, and linked material.
 
-## Document shape
+2. **Decide**
+   - Resolve choices that change behavior, interfaces, data, errors, security, operations, or tests.
+   - Ask only questions whose answers would change the design.
+   - Recommend one answer when asking.
+
+3. **Write**
+   - Write `docs/<feature-slug>/design.md` using the template below.
+   - Keep sections short and in order.
+   - Omit only sections that do not apply.
+
+4. **Review**
+   - Check that a new teammate can understand the problem, outcome, approach, and main downside from the executive summary.
+   - Check the current boundary, the boundary being changed, and the owner of each new responsibility.
+   - Check where every stored name and identifier comes from, and what happens when it is missing or later changes.
+   - Check failure, retry timing, recovery without restart, config and enable or disable changes, work in flight, and shutdown.
+   - Check what happens when every dependency is unavailable at startup.
+   - Check identity, authorization, untrusted input, sensitive data, limited resources, and behavior at each limit.
+   - Replace words such as "eventually" and "will not starve" with a bound that can be tested.
+   - Make every acceptance criterion choose one observable result.
+   - Fix gaps supported by current evidence. Put the rest under Open questions and say whether each one blocks task breakdown.
+
+5. **Stop**
+   - Return the design for human review.
+   - Do not plan or implement.
+
+## Document template
 
 ```markdown
 # <Title>
@@ -73,18 +96,18 @@ How each invariant and each important requirement will be proved.
 - Risk and mitigation.
 
 ## 12. Open questions
-- Question, and whether it blocks starting work.
+- Question, and whether it blocks task breakdown.
 
 ## 13. Out of scope
 - Related work this design does not include.
 ```
 
-## Writing rules
+## Rules
 
-- Start with the simplest useful explanation. Write for a new teammate, not someone who already knows the project.
+- Write for a new teammate. Start with the simplest useful explanation.
 - Prose is the default. Use bullets only for real lists, such as config fields, acceptance criteria, risks, and out of scope.
-- A bullet cannot carry a decision by itself. Write the reason next to it in a sentence.
-- Use plain words. Say "the process crashed" instead of "an availability event occurred". Prefer short sentences.
+- Put the reason for a decision in a sentence, not a bare bullet.
+- Use plain words and short sentences. Say "the process crashed" instead of "an availability event occurred".
 - Define a term the first time you use it, or do not use it.
 - Keep current architecture and proposed behavior distinct. Link to `ARCHITECTURE.md` when it exists and say exactly which current boundary changes.
 - Give each changed component a positive and negative boundary: what it owns and what it does not own.
@@ -94,20 +117,3 @@ How each invariant and each important requirement will be proved.
 - Record rejected options only when the tradeoff matters later.
 - Do not repeat the same fact in several sections with different wording.
 - Do not use em dashes.
-
-## Review pass
-
-Reread the draft once and check each category. Fix any gap you can resolve from the available evidence.
-
-1. **Executive summary.** Can a new teammate understand the problem, outcome, approach, and main downside without reading the rest of the document?
-2. **Architecture fit.** Does the design show the current system boundary, the boundary being changed, and the owner of each new responsibility?
-3. **Names and identity.** Where does every stored identifier come from? What happens when it is missing, unclear, or changes after data exists?
-4. **Failure and recovery.** What creates a bad state? Does the system retry, how long does it wait between attempts, and can it recover without a restart? What happens when everything is bad at startup?
-5. **Security and privacy.** Where is identity established, authorization enforced, untrusted input validated, and sensitive data exposed or retained?
-6. **Shared resources.** What limited resource does the feature use? State the budget and what happens at the limit.
-7. **Timing and fairness.** Replace words such as "eventually" and "will not starve" with a bound someone can test.
-8. **Lifecycle.** Cover config reload, enable and disable behavior, work already in flight, and shutdown.
-9. **Undefined terms.** Define words that carry a specific meaning in the design.
-10. **Either/or acceptance criteria.** Do not allow both sides of "recovers or retains" to pass. Choose one observable behavior.
-
-Put anything you cannot resolve under Open questions and state whether it blocks task breakdown.

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -7,18 +7,34 @@ argument-hint: "[code, files, diff, branch, or improvement focus]"
 
 # Improve
 
+Make existing code easier to understand without changing what it does.
+
 ## Workflow
 
-1. Identify the target from the request, current diff, or recently changed code.
-2. Read the target, its tests, and relevant surrounding code. State the behavior that must not change.
-3. If that behavior lacks tests, add focused coverage before refactoring. If automated tests cannot exercise it, explain why and give other evidence.
-4. Find unnecessary complexity, duplication, dead code, weak names, awkward boundaries, and abstractions that cost more than they help.
-5. Make focused improvements by deleting, deduplicating, renaming, simplifying, extracting, or inlining.
-6. Preserve public interfaces, data shapes, errors, and user-visible behavior unless the user explicitly asks to change them.
-7. Run tests and checks that cover behavior the refactor can affect. Report what improved, what behavior was preserved, and the evidence.
+1. **Choose the target**
+   - Use the request, current diff, or recently changed code.
+   - Read the target, its tests, and the surrounding code needed to understand it.
 
-## Boundaries
+2. **Protect existing behavior**
+   - State what must not change.
+   - Add focused tests first when that behavior lacks proof.
+   - If automated tests cannot cover it, explain why and name other evidence.
+
+3. **Simplify**
+   - Find duplication, dead code, weak names, awkward boundaries, and abstractions that cost more than they help.
+   - Delete, combine, rename, extract, inline, or reorder code where it makes the target clearer.
+   - Prefer a few focused edits over a broad rewrite.
+
+4. **Verify**
+   - Run checks that cover every behavior the refactor could affect.
+   - Confirm that public interfaces, data shapes, errors, and user-visible behavior did not change.
+
+5. **Report**
+   - Say what became simpler.
+   - Say what behavior stayed the same.
+   - Give the test or other evidence.
+
+## Rules
 
 - Do not add product scope or absorb unrelated cleanup.
-- Prefer a few clear edits over a broad rewrite.
-- Preserve behavior even when a redesign would be easier.
+- Preserve behavior unless the user explicitly asks to change it.

--- a/skills/milestone/SKILL.md
+++ b/skills/milestone/SKILL.md
@@ -11,26 +11,36 @@ Finish every open issue in a GitHub milestone.
 
 ## Workflow
 
-1. Resolve the milestone and repository. Inspect its open issues, dependencies, linked pull requests, checks, and current project state.
-2. Order the remaining issues by dependency, risk, and how easy each change will be to review. Put blockers, bugs, and shared foundations before features that depend on them.
-3. Take one issue at a time to a ready pull request. Create the branch and worktree, implement the smallest complete change, test it, review it with a fresh agent, then open the PR. Resume a matching pull request instead of creating duplicate work.
-4. After each pull request is ready, stop for human merge unless the user explicitly allowed merging for this run.
-5. When merging is allowed, merge only when:
-   - Required checks pass or are confirmed unconfigured.
-   - The pull request is mergeable.
-   - Every current comment has a clear outcome.
-   - No required change remains unresolved.
-   - The description and checklist match the final commit.
-6. Sync the latest remote default branch before starting the next issue.
-7. Refresh the milestone before each issue. Record pull request links, proof, blockers, and final state in the tracker when access permits.
-8. Report completed issues, merged and open pull requests, blockers, checks, and anything not verified.
+1. **Read the milestone**
+   - Resolve the repository and milestone.
+   - Inspect its open issues, dependencies, linked pull requests, checks, and current project state.
 
-## Boundaries
+2. **Order the work**
+   - Order open issues by dependency, risk, and review cost.
+   - Put blockers, bugs, and shared foundations before work that depends on them.
+
+3. **Deliver one issue**
+   - Use `/task-to-pr` to take one issue to a ready pull request.
+   - Resume a matching pull request instead of creating another one.
+   - Keep one branch and pull request per issue unless separate issues must ship together to work.
+
+4. **Stop for merge**
+   - Stop after each ready pull request unless the user allowed merging for this run.
+   - When merging is allowed, merge only when the pull request is mergeable, required checks pass or are unconfigured, current comments are handled, no required change remains, and the description and checklist match the final commit.
+
+5. **Refresh and repeat**
+   - Sync the latest remote default branch.
+   - Refresh the milestone before choosing the next issue.
+   - Record pull request links, proof, blockers, and final state in the tracker when access permits.
+
+6. **Report**
+   - List completed issues, merged and open pull requests, blockers, checks, and anything not verified.
+
+## Rules
 
 - Work only on issues in the milestone.
-- Use one branch and pull request per issue unless combining issues is required for a working result. Explain any combination before starting it.
 - Do not batch unrelated issues.
+- Explain why issues must be combined before starting combined work.
 - Never merge without explicit permission.
-- Do not merge with failing required checks, missing acceptance criteria, a current comment without a clear outcome, or a required change still open.
-- Do not merge when an acceptance criterion or affected failure path is unverified unless the user accepts that exception.
+- Do not merge with missing acceptance criteria or unverified affected failure paths unless the user accepts the gap.
 - Stop when an issue has unresolved product or technical decisions, requires missing secrets or permissions, already has conflicting work, or grows beyond its acceptance criteria.

--- a/skills/milestone/SKILL.md
+++ b/skills/milestone/SKILL.md
@@ -42,5 +42,6 @@ Finish every open issue in a GitHub milestone.
 - Do not batch unrelated issues.
 - Explain why issues must be combined before starting combined work.
 - Never merge without explicit permission.
-- Do not merge with missing acceptance criteria or unverified affected failure paths unless the user accepts the gap.
+- Do not merge with missing acceptance criteria.
+- Do not merge with unverified acceptance criteria or affected failure paths unless the user accepts the evidence gap.
 - Stop when an issue has unresolved product or technical decisions, requires missing secrets or permissions, already has conflicting work, or grows beyond its acceptance criteria.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -7,20 +7,34 @@ argument-hint: "<design, brief, issue, or request>"
 
 # Plan
 
+Turn decided work into ordered tasks for separate agent runs.
+
 ## Workflow
 
-1. Read the source, repository instructions, and relevant code.
-2. Stop and return to design if product or technical choices remain open.
-3. Break the work into tasks that each deliver working behavior. Each task must:
-   - Fit one agent run.
-   - Produce one focused pull request.
-   - Let a reviewer understand the outcome, behavior, and proof without separating unrelated work.
-4. Separate refactoring when it would hide the behavior change. Small local cleanup may stay when it makes the change easier to review.
-5. Order tasks by dependency. Add milestones only when they create a useful delivery or review boundary.
-6. Return the plan in chat by default. Create tracker tickets only when the user asks. Never write a plan document.
-7. Stop after planning. Do not implement.
+1. **Read**
+   - Read the source, repository instructions, and relevant code.
+   - Identify the outcome, fixed decisions, constraints, and proof.
 
-Each task must stand alone:
+2. **Check readiness**
+   - Stop and return to design if a product or technical choice remains open.
+   - Continue only when a new agent could complete each task without asking those questions.
+
+3. **Create tasks**
+   - Make each task fit one agent run and one focused pull request.
+   - Make each task deliver working behavior and its proof.
+   - Separate refactoring when it would hide a behavior change. Keep small local cleanup only when it makes that change easier to review.
+   - Use the task template below.
+
+4. **Order tasks**
+   - Put dependencies before the work that needs them.
+   - Add a milestone only when it creates a useful delivery or review point.
+
+5. **Publish and stop**
+   - Return the plan in chat by default.
+   - Create tracker tickets only when the user asks.
+   - Do not write a plan document or implement the work.
+
+## Task template
 
 ```markdown
 ## <Task title>
@@ -44,8 +58,9 @@ Exact commands and any required manual verification.
 Related work this task must not absorb.
 ```
 
-## Boundaries
+## Rules
 
 - Do not split one piece of working behavior into separate file or technical-layer tasks.
 - Do not create scaffolding or cleanup tasks without a checked outcome.
 - Do not hide unresolved decisions inside implementation tickets.
+- Give each task enough context to stand alone.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -43,7 +43,7 @@ Use a fresh subagent that did not implement the change. Review without editing f
 
 ## Rules
 
-- Approve only when the change matches its source, no known defect or unhandled risk threatens security, data, compatibility, or operations, and no simpler design delivers the same outcome and proof.
+- Approve only when the change matches its source and repository rules, no known defect or unhandled risk threatens security, data, compatibility, or operations, and no simpler design delivers the same outcome and proof.
 - Keep findings within the change, but inspect enough context to judge its system effect.
 - Cite technical evidence or repository conventions. Do not block on personal taste.
 - Do not approve only because checks pass.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -7,48 +7,46 @@ argument-hint: "[ticket, design, diff, branch, commit, PR, or file path]"
 
 # Review
 
-The reviewer must be a fresh subagent that did not implement the change. Do not edit files.
+Use a fresh subagent that did not implement the change. Review without editing files.
 
-## Standard
+## Workflow
 
-Approve only when:
+1. **Set the frame**
+   - Give the reviewer the task, acceptance criteria, repository rules, complete diff or pull request, and test evidence.
+   - Name the user or developer affected by the change.
 
-- The change matches its source and behaves as required.
-- No known defect or unhandled risk could break the source or repository rules for security, data loss, compatibility, or operations.
-- No simpler design has been identified that delivers the same outcome and proof with less state, indirection, duplication, or operational work.
+2. **Check the outcome**
+   - Read the source design, ticket, or request.
+   - Confirm that the change belongs in the system, matches the requested behavior, and delivers one focused outcome.
+   - Report a mismatch before reviewing details.
 
-Do not demand perfection or block on personal taste. Cite technical evidence or repository conventions.
+3. **Check the change**
+   - Start with the files and flows that deliver the outcome.
+   - Check behavior, failures, security boundaries, interfaces, compatibility, migrations, concurrency, and operations.
+   - Review every human-written changed line in context for correctness, regressions, complexity, names, comments, style, and documentation.
+   - For generated files or large data, inspect the source and spot-check the result.
+   - Run focused checks when they can change a finding or verdict.
 
-The verdict is independent agent evidence. It is not GitHub approval or a replacement for human review.
+4. **Check the proof**
+   - Confirm that tests cover the acceptance criteria, changed behavior, and affected failure paths.
+   - Confirm that assertions would fail for a broken change.
+   - Prefer user-visible behavior or a documented internal contract over copied implementation logic.
+   - Confirm that test setup does not hide the scenario.
+   - Check whether security, privacy, concurrency, accessibility, internationalization, or domain work needs specialist evidence.
+   - Mark a risk unverified when the reviewer lacks the evidence or skill to judge it.
 
-## Review order
+5. **Give the verdict**
+   - Report findings in severity order. For each one, give the location, impact, evidence, and smallest fix direction.
+   - Use `blocker` for unsafe to merge and `important` for should fix before merge. Omit optional nits unless asked.
+   - End with `Approve`, `Request changes`, or `Blocked`.
+   - State anything that remains unverified.
 
-1. **Set the frame.** Give the reviewer the task, acceptance criteria, repository rules, complete diff or pull request, and test evidence. Name the user or developer affected by the change.
-2. **Take the broad view.** Read the change summary and the relevant design or ticket. Confirm that the change belongs in the system, matches the intended behavior, and delivers one reviewable outcome. Report a mismatch before reviewing details.
-3. **Review the main behavior.** Start with the files and flows that deliver the outcome. Check behavior, failures, security boundaries, interfaces, compatibility, migrations, concurrency, and operations.
-4. **Review every human-written changed line in context.** Read enough surrounding code to judge correctness, regressions, complexity, names, comments, style, and docs. For generated files or large data, inspect the source and spot-check the output. Keep findings within the change's scope.
-5. **Review the proof.** Check that tests:
-   - Cover the changed behavior and affected failure paths.
-   - Prove the acceptance criteria.
-   - Assert behavior a user or caller can observe, or a documented internal contract.
-   - Would fail under a broken implementation.
-   - Do not copy implementation logic or hide the scenario in setup.
-6. Run focused checks that can confirm or disprove a claim that could change a finding or verdict.
-7. **Check specialist coverage.** Identify security, privacy, concurrency, accessibility, internationalization, or domain-specific work. Mark a risk unverified when the reviewer lacks the evidence or skill to judge it. Use `Blocked` when that gap could hide a problem that breaks a rule and no qualified reviewer covers it.
-8. **Report findings.** Return actionable findings in severity order. For each finding give the location, impact, evidence, and smallest fix direction.
+## Rules
 
-- **blocker:** unsafe to merge.
-- **important:** should fix before merge.
-- **nit:** optional; omit unless asked.
-
-## Verdict
-
-If fresh subagents are unavailable, stop and report that independent review is blocked unless the user explicitly accepts a documented self-review.
-
-If there are no findings, say so. End with `Approve`, `Request changes`, or `Blocked`, then state what remains unverified.
-
-## Boundaries
-
-- Keep findings within the change, but inspect enough surrounding code to judge each changed line and its system effect.
-- Do not turn preferences into findings. Use technical evidence and repository conventions.
-- Do not approve solely because checks pass.
+- Approve only when the change matches its source, no known defect or unhandled risk threatens security, data, compatibility, or operations, and no simpler design delivers the same outcome and proof.
+- Keep findings within the change, but inspect enough context to judge its system effect.
+- Cite technical evidence or repository conventions. Do not block on personal taste.
+- Do not approve only because checks pass.
+- Use `Blocked` when missing specialist evidence could hide a rule-breaking problem.
+- If a fresh subagent is unavailable, report that independent review is blocked unless the user accepts a documented self-review.
+- Treat the verdict as independent evidence, not GitHub approval or a replacement for human review.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -7,22 +7,38 @@ argument-hint: "<task, acceptance criteria, diff, branch, PR, URL, or flow>"
 
 # Test
 
+Prove that a change meets its acceptance criteria.
+
 ## Workflow
 
-1. Read the task, acceptance criteria, changed code, existing tests, and repository instructions.
-2. Map every acceptance criterion and affected failure path to proof. Test changed behavior and behavior a refactor must preserve.
-3. If automated tests cannot exercise the affected behavior, explain why and give other evidence.
-4. Add or update focused tests where proof is missing. Assertions should fail when the changed behavior breaks.
-5. Assert behavior a user or caller can observe unless the test targets a documented internal contract. Keep setup and assertions no more complex than the scenario.
-6. Run the narrowest checks that exercise the changed behavior and affected interfaces. Run wider checks when shared behavior or interfaces changed.
-7. When browser-rendered behavior changes, start the documented app and check the required flows and affected failures in a real browser.
+1. **Read**
+   - Read the task, acceptance criteria, changed code, existing tests, and repository instructions.
+
+2. **Map the proof**
+   - Map every acceptance criterion and affected failure path to a check.
+   - Include changed behavior and behavior a refactor must preserve.
+   - If automated tests cannot cover something, explain why and name other evidence.
+
+3. **Add missing tests**
+   - Add or update focused tests where proof is missing.
+   - Assert behavior a user or caller can observe, or a documented internal contract.
+   - Make each assertion fail when the changed behavior breaks.
+   - Keep setup and assertions no more complex than the scenario.
+
+4. **Run the checks**
+   - Start with the narrowest checks that exercise the changed behavior and affected interfaces.
+   - Run wider checks when shared behavior or interfaces changed.
+   - When browser-rendered behavior changes, start the documented app and check the required flows and affected failures in a real browser.
    - Check desktop and mobile when layout or responsive styles changed.
    - Check keyboard use when interactions changed.
    - Check console errors and failed requests during every flow.
    - Capture evidence. Reading source is not browser proof.
-8. Report each criterion as pass, fail, or unverified. Include the command, browser flow, or other evidence.
 
-## Boundaries
+5. **Report**
+   - Mark every criterion as pass, fail, or unverified.
+   - Include the command, browser flow, or other evidence.
+
+## Rules
 
 - Do not weaken assertions to make a change pass.
 - Do not fix unrelated failures.


### PR DESCRIPTION
## Plain English summary

Most Blueprint skills had numbered steps followed by extra process sections. That made readers piece together the real order. This change gives every skill one clear workflow, followed only by templates and rules. It keeps what each skill does and where it stops the same.

## Reviewer notes

The architecture and design templates keep the same purpose. Review the rewritten workflows for missing rules or changed stop points.

## Checklist

- **Is this one focused, self-contained change?** Yes
  - It applies one structure to the seven skills that had not yet been simplified.
- **Did you write or update tests?** Not applicable
  - This repository contains Markdown instructions, not executable product code.
- **Did you run the relevant tests and checks?** Yes
  - All eight skill metadata blocks parse.
  - Every skill has one ordered numbered workflow.
  - `npx skills add . --list` finds all eight skills.
  - All local Markdown links resolve.
  - The Markdown contains no em dashes.
  - `git diff --check` passes.
- **Did you independently review the final diff and address valid findings?** Yes
  - A fresh agent reviewed each final diff. All findings were fixed, and the final review approved the change with no findings.
  - Both automated review threads were fixed, replied to, and resolved.
  - Codex reviewed final commit `a9112e8680` and found no issues.
- **Did you update documentation when behavior changed?** Yes
  - The skills, golden example, repository policy, README, and review standard now describe the same structure.
- **Did required CI checks pass?** Not configured
  - This repository has no configured CI jobs for the pull request.
