### PR TITLE
feat(review): structure code findings

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -7,7 +7,13 @@ argument-hint: "[ticket, design, diff, branch, commit, PR, or file path]"
 
 # Review
 
-The reviewer must be a fresh subagent that did not implement the change. Do not edit files.
+The reviewer must be a fresh subagent that did not implement the change. Do not edit files or post comments.
+
+## Scope
+
+Review the target named by the user. It may be a ticket, design, file, diff, branch, commit, pull request, or other change on GitHub.
+
+If the user does not name a target, review the current repository's complete local change set: commits on the current branch relative to the repository's default branch, staged changes, unstaged changes, and untracked files. Use the repository and immediate surrounding code as context. If there are no local changes, say so instead of substituting a whole-repository audit.
 
 ## Standard
 
@@ -35,17 +41,46 @@ The verdict is independent agent evidence. It is not GitHub approval or a replac
    - Do not copy implementation logic or hide the scenario in setup.
 6. Run focused checks that can confirm or disprove a claim that could change a finding or verdict.
 7. **Check specialist coverage.** Identify security, privacy, concurrency, accessibility, internationalization, or domain-specific work. Mark a risk unverified when the reviewer lacks the evidence or skill to judge it. Use `Blocked` when that gap could hide a problem that breaks a rule and no qualified reviewer covers it.
-8. **Report findings.** Return actionable findings in severity order. For each finding give the location, impact, evidence, and smallest fix direction.
+8. **Report findings.** Return actionable findings in priority order using the format below.
 
-- **blocker:** unsafe to merge.
-- **important:** should fix before merge.
-- **nit:** optional; omit unless asked.
+## Code review findings
+
+For code, commit, branch, and pull request reviews, report only real bugs and customer-impacting issues introduced or exposed by the change. Check security, logic, behavior, reliability, compatibility, regressions, and affected failure paths. Inspect the immediate surrounding code needed to prove each finding.
+
+Use this format for every finding:
+
+```text
+Priority: Must fix / Should fix / Could fix
+Confidence: 0–5
+What I found: Describe the technical problem.
+Why it matters: Explain the impact on customers, callers, or the service.
+ELI5: In one or two short sentences, state the exact condition that triggers the problem and what the customer or service experiences. Use no analogies, jargon, or acronyms.
+Where: File and line.
+Suggested fix: Give a short, practical direction.
+```
+
+Priority means:
+
+- **Must fix:** Unsafe to merge. The change can cause a security failure, data loss, broken required behavior, or a serious service regression.
+- **Should fix:** A real defect or reliability risk that should be corrected before merge.
+- **Could fix:** A proven, limited problem that does not need to block merge. Do not use this for style preferences.
+
+Confidence means:
+
+- **5:** Confirmed by reproduction, test, or direct code evidence.
+- **4:** Strong evidence with no credible alternative explanation.
+- **3:** Probable, but some runtime evidence is unavailable.
+- **0–2:** Do not report. Investigate further or mark the area unverified.
+
+Write so the developer can quickly understand what is broken, who it affects, and why they should care. Be concise. Do not report style preferences, theoretical concerns, or problems outside the changed code and its immediate context.
+
+For design reviews, report each finding with its priority, location, impact, evidence, and smallest fix direction. Do not force the code finding format onto a design.
 
 ## Verdict
 
 If fresh subagents are unavailable, stop and report that independent review is blocked unless the user explicitly accepts a documented self-review.
 
-If there are no findings, say so. End with `Approve`, `Request changes`, or `Blocked`, then state what remains unverified.
+If there are no findings, say so. End with `Approve`, `Request changes`, or `Blocked`, then state what remains unverified. A Must fix or Should fix finding requires `Request changes`. Could fix findings do not prevent `Approve`.
 
 ## Boundaries
 


### PR DESCRIPTION
## Plain English summary

Review requests now use the target named by the user. Without a target, the reviewer checks all current local changes, including branch commits and staged, unstaged, and untracked work. Code reviews now report proven bugs and customer impact in a consistent format with clear priority and confidence.

## Details

Design reviews keep their existing evidence-based finding format. Every review remains read-only and ends with the existing verdict and unverified-risk statement.

## Reviewer notes

This changes skill instructions only. Live execution against sample local, GitHub, and design targets is not automated.

## Checklist

- **Is this one focused, self-contained change?** Yes
  - It changes only review scope resolution and finding output.
- **Did you write or update tests?** Not applicable
  - The repository has no runtime test harness for skill prose.
- **Did you run the relevant tests and checks?** Yes
  - `git diff --check`, frontmatter delimiter checks, and the repository writing rule check passed. Live target execution remains unverified.
- **Did you independently review the final diff and address valid findings?** Yes
  - A fresh read-only subagent approved the final diff with no actionable findings.
- **Did you update documentation when behavior changed?** Yes
  - The review skill is the user-facing instruction being changed.
- **Did required CI checks pass?** Not configured
  - GitHub reported no status checks or pull-request workflow runs for the latest commit.