### PR TITLE
docs: add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+This file records notable changes to Blueprint.
+
+## Unreleased
+
+### Changed
+
+- `/task-to-pr` now accepts one or more tasks. It orders dependent work, can run independent tasks at the same time, and creates one pull request for each task.
+- Delivery now has two clear phases: build and review the code, then pass CI and automated code review.
+- Automated review findings require a reply that says what changed or why no change was needed.
+- Pull requests stay open unless the user asks the agent to merge them.
+
+### Removed
+
+- Removed the `/milestone` skill. Pass a GitHub milestone to `/task-to-pr` instead.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ npx skills add owainlewis/blueprint
 
 Upgrading from the older set of skills? Follow the [migration guide](MIGRATION.md). A normal update may leave removed skills installed, so the cleanup step matters.
 
+Read the [changelog](CHANGELOG.md) for notable changes.
+
 ## Repository map
 
 ```text

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ AGENTS.md                portable repository policy
 CLAUDE.md                Claude Code adapter
 REVIEW.md                review standard for Blueprint itself
 MIGRATION.md             clean upgrade from the old skill set
+CHANGELOG.md             notable changes to Blueprint
 examples/                reviewed design and planning examples
 ```
 


### PR DESCRIPTION
## Summary

- add a changelog for notable Blueprint changes
- record that `/task-to-pr` replaces `/milestone`
- link the changelog from the README and add it to the repository map

## Proof

- `git diff --check`
- local Markdown links checked
- eight skill files and frontmatter checked
- `./examples/regenerate.sh`
- fresh independent review: approved with no findings
- GitHub automated review of `40b1273`: no major issues