### PR TITLE
feat(plan): make tasks clear cold handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file records notable changes to Blueprint.
 
 ### Changed
 
+- `/plan` now writes each task as a cold handoff with a plain title, standalone summary, useful user stories, defined project terms, and enough context and proof for a new engineer to complete it.
 - `/task-to-pr` now accepts one or more tasks. It orders dependent work, can run independent tasks at the same time, and creates one pull request for each task.
 - Delivery now has two clear phases: build and review the code, then pass CI and automated code review.
 - Automated review findings require a reply that says what changed or why no change was needed.

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -112,6 +112,8 @@ This task depends on Task 1, which creates the local API and database. It proves
 - Reject uploads over 25 MiB before text extraction.
 - Use fixed-size chunks of about 500 tokens with about 50 tokens of overlap.
 - Store documents, chunks, and embeddings in PostgreSQL with pgvector.
+- Generate an opaque UUID for each uploaded document. Treat the original filename as display metadata, never identity.
+- Identify each chunk by its document UUID and zero-based position. Keep that position stable for the lifetime of the document.
 - Commit the document and all chunks in one database transaction.
 - Use the existing `DATABASE_URL` and `OPENAI_API_KEY` settings.
 - Return API errors as `{error: {code, message}}`.
@@ -121,7 +123,9 @@ This task depends on Task 1, which creates the local API and database. It proves
 #### Acceptance criteria
 
 - `POST /api/v1/documents` accepts a PDF and returns `{id, filename, uploaded_at, chunk_count}`.
+- Uploading two documents with the same filename returns two distinct valid UUIDs and stores both documents.
 - Uploaded PDFs are stored with chunks and embeddings that can be queried later.
+- Stored chunks have unique positions from `0` through `chunk_count - 1` within their document.
 - Non-PDF and empty-text PDF uploads return `400` with `bad_request`.
 - Uploads over 25 MiB return `413` with `payload_too_large` and create no rows.
 - OpenAI embedding failures return `502` with `upstream_error`.
@@ -144,6 +148,8 @@ curl -F "file=@tests/fixtures/test.pdf" http://localhost:8000/api/v1/documents
 ```
 
 Also run focused tests for a non-PDF, an empty-text PDF, and an oversized upload. Test embedding failure and a forced database failure that returns `500` with `internal_error`. Cover shutdown completion and cancellation during slow uploads. Test each shutdown setting boundary.
+
+Upload the same fixture twice with the same filename. Prove that the returned IDs are distinct UUIDs and query each document's chunks to confirm unique zero-based positions.
 
 For every failed upload, query PostgreSQL in the test fixture and prove that document and chunk row counts did not change.
 
@@ -172,6 +178,7 @@ This task depends on Task 2. Task 2 stores each uploaded document as small text 
 #### Constraints
 
 - Add the endpoints to the existing FastAPI service and use the PostgreSQL document and chunk records created by Task 2.
+- Use the opaque document UUID as API identity. Treat the filename as display metadata only.
 - Do not change upload behavior from Task 2.
 - Deleted chunks must not remain retrievable.
 - Return API errors as `{error: {code, message}}`.
@@ -229,6 +236,7 @@ This task depends on Tasks 2 and 3. Task 2 stores each PDF as small text section
 #### Constraints
 
 - Add the endpoint to the existing FastAPI service and query PostgreSQL with pgvector.
+- Return each source's opaque document UUID and stable zero-based chunk position as `document_id` and `chunk_index`.
 - Use the existing `DATABASE_URL` and `OPENAI_API_KEY` settings.
 - Return API errors as `{error: {code, message}}`.
 - Mock OpenAI calls in tests.

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -47,10 +47,12 @@ This task creates the base service shape for every later endpoint. It should est
 
 #### Constraints
 
+- Build the API with FastAPI and use PostgreSQL with pgvector.
 - Use `uv` for Python package management.
 - Use Docker Compose for the API and PostgreSQL with pgvector.
 - Keep configuration in environment variables.
 - Require `DATABASE_URL` and `OPENAI_API_KEY`.
+- Return API errors as `{error: {code, message}}`.
 
 #### Acceptance criteria
 
@@ -105,10 +107,14 @@ This task proves the path from upload to stored search data. It validates the fi
 
 #### Constraints
 
+- Add the endpoint to the existing FastAPI service.
 - Accept PDFs only.
 - Reject uploads over 25 MiB before text extraction.
 - Use fixed-size chunks of about 500 tokens with about 50 tokens of overlap.
+- Store documents, chunks, and embeddings in PostgreSQL with pgvector.
 - Commit the document and all chunks in one database transaction.
+- Use the existing `DATABASE_URL` and `OPENAI_API_KEY` settings.
+- Return API errors as `{error: {code, message}}`.
 - Mock OpenAI calls in tests.
 - Read the shutdown deadline from `SERVER_GRACEFUL_SHUTDOWN_SECONDS`, defaulting to `10`, and fail startup unless it is an integer from `1` through `60`.
 
@@ -165,8 +171,10 @@ Task 2 stores each uploaded document as small text sections, called chunks, with
 
 #### Constraints
 
+- Add the endpoints to the existing FastAPI service and use the PostgreSQL document and chunk records created by Task 2.
 - Do not change upload behavior from Task 2.
 - Deleted chunks must not remain retrievable.
+- Return API errors as `{error: {code, message}}`.
 
 #### Acceptance criteria
 
@@ -220,6 +228,10 @@ Task 2 stores each PDF as small text sections, called chunks, and creates a nume
 
 #### Constraints
 
+- Add the endpoint to the existing FastAPI service and query PostgreSQL with pgvector.
+- Use the existing `DATABASE_URL` and `OPENAI_API_KEY` settings.
+- Return API errors as `{error: {code, message}}`.
+- Mock OpenAI calls in tests.
 - Retrieve at most 5 chunks for each question.
 - Calculate cosine similarity as `1 - (embedding <=> query_embedding)`.
 - Read the inclusive threshold from `RAG_RELEVANCE_THRESHOLD`, defaulting to `0.75`, accept `0` and `1`, and fail startup unless it is numeric and satisfies `0 <= value <= 1`.

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -48,16 +48,19 @@ This task creates the base service shape for every later endpoint. It should est
 #### Constraints
 
 - Build the API with FastAPI and use PostgreSQL with pgvector.
+- Keep HTTP validation and response formatting in FastAPI routes. Put health-check ordering in an application service and PostgreSQL access in a repository.
 - Use `uv` for Python package management.
 - Use Docker Compose for the API and PostgreSQL with pgvector.
 - Keep configuration in environment variables.
 - Require `DATABASE_URL` and `OPENAI_API_KEY`.
+- Make `/health` check PostgreSQL only. It must not call OpenAI.
 - Return API errors as `{error: {code, message}}`.
 
 #### Acceptance criteria
 
 - The API and database start with Docker Compose.
 - `GET /health` returns `200` with `{"status":"ok"}` when the API can reach the database and `503` with `service_unavailable` when it cannot.
+- With PostgreSQL reachable and OpenAI unavailable, `GET /health` returns `200` and makes no OpenAI request.
 - The app fails before serving traffic when `DATABASE_URL` or `OPENAI_API_KEY` is missing.
 - The README states that V1 is for one trusted user and sends document text to OpenAI.
 - A baseline `uv run pytest` succeeds for later tasks.
@@ -75,7 +78,7 @@ uv sync --frozen
 uv run pytest
 ```
 
-Also make PostgreSQL unavailable and verify that `/health` returns the documented `503`. Cover each missing required setting.
+Also make PostgreSQL unavailable and verify that `/health` returns the documented `503`. Make the OpenAI test adapter fail while PostgreSQL remains reachable, then verify that `/health` still returns `200` without calling the adapter. Cover each missing required setting.
 
 #### Out of scope
 
@@ -108,16 +111,20 @@ This task depends on Task 1, which creates the local API and database. It proves
 #### Constraints
 
 - Add the endpoint to the existing FastAPI service.
+- Keep HTTP validation and response formatting in the FastAPI route. Put upload ordering in an application service, PostgreSQL access in a repository, and provider request translation in an OpenAI adapter.
 - Accept PDFs only.
 - Reject uploads over 25 MiB before text extraction.
 - Use fixed-size chunks of about 500 tokens with about 50 tokens of overlap.
 - Store documents, chunks, and embeddings in PostgreSQL with pgvector.
 - Generate an opaque UUID for each uploaded document. Treat the original filename as display metadata, never identity.
 - Identify each chunk by its document UUID and zero-based position. Keep that position stable for the lifetime of the document.
+- Make each chunk's document foreign key cascade on delete.
 - Commit the document and all chunks in one database transaction.
+- Send document chunks to OpenAI for embeddings. Keep durable application data in PostgreSQL.
 - Use the existing `DATABASE_URL` and `OPENAI_API_KEY` settings.
 - Return API errors as `{error: {code, message}}`.
 - Mock OpenAI calls in tests.
+- On shutdown, stop accepting new requests. Let active requests finish until the configured deadline, then cancel them and roll back open database transactions.
 - Read the shutdown deadline from `SERVER_GRACEFUL_SHUTDOWN_SECONDS`, defaulting to `10`, and fail startup unless it is an integer from `1` through `60`.
 
 #### Acceptance criteria
@@ -126,12 +133,14 @@ This task depends on Task 1, which creates the local API and database. It proves
 - Uploading two documents with the same filename returns two distinct valid UUIDs and stores both documents.
 - Uploaded PDFs are stored with chunks and embeddings that can be queried later.
 - Stored chunks have unique positions from `0` through `chunk_count - 1` within their document.
+- Deleting a document row through PostgreSQL also deletes all of its chunks through the foreign-key cascade.
 - Non-PDF and empty-text PDF uploads return `400` with `bad_request`.
 - Uploads over 25 MiB return `413` with `payload_too_large` and create no rows.
 - OpenAI embedding failures return `502` with `upstream_error`.
 - A persistence failure returns `500` with `internal_error`.
 - Embedding and persistence failures leave no document or chunk rows behind.
 - A slow upload that finishes before the graceful shutdown deadline commits normally.
+- After shutdown begins, a new upload is not accepted and creates no rows.
 - Cancelling a deliberately slow upload at the graceful shutdown deadline leaves no document or chunk rows behind.
 - Startup accepts shutdown values from `1` through `60` and rejects zero, negative, greater values, and non-integers.
 - A PDF fixture contains the sentence "PostgreSQL with pgvector stores the embeddings." for later retrieval tests.
@@ -147,9 +156,11 @@ uv run pytest
 curl -F "file=@tests/fixtures/test.pdf" http://localhost:8000/api/v1/documents
 ```
 
-Also run focused tests for a non-PDF, an empty-text PDF, and an oversized upload. Test embedding failure and a forced database failure that returns `500` with `internal_error`. Cover shutdown completion and cancellation during slow uploads. Test each shutdown setting boundary.
+Also run focused tests for a non-PDF, an empty-text PDF, and an oversized upload. Test embedding failure and a forced database failure that returns `500` with `internal_error`. During shutdown, prove that an active upload can finish before the deadline, a new upload is not accepted or stored, and an upload still running at the deadline is cancelled and rolled back. Test each shutdown setting boundary.
 
 Upload the same fixture twice with the same filename. Prove that the returned IDs are distinct UUIDs and query each document's chunks to confirm unique zero-based positions.
+
+Inspect the schema migration for the cascading foreign key. In a focused database test, delete a document row and prove that PostgreSQL removes its chunks without a separate chunk delete.
 
 For every failed upload, query PostgreSQL in the test fixture and prove that document and chunk row counts did not change.
 
@@ -178,15 +189,17 @@ This task depends on Task 2. Task 2 stores each uploaded document as small text 
 #### Constraints
 
 - Add the endpoints to the existing FastAPI service and use the PostgreSQL document and chunk records created by Task 2.
+- Keep HTTP validation and response formatting in FastAPI routes. Put list and delete ordering in an application service and PostgreSQL access in a repository.
 - Use the opaque document UUID as API identity. Treat the filename as display metadata only.
 - Do not change upload behavior from Task 2.
+- Delete the document row and rely on its database foreign-key cascade to remove chunks and embeddings.
 - Deleted chunks must not remain retrievable.
 - Return API errors as `{error: {code, message}}`.
 
 #### Acceptance criteria
 
-- `GET /api/v1/documents` returns documents with `id`, `filename`, `uploaded_at`, and `chunk_count`.
-- `DELETE /api/v1/documents/{id}` removes the document and its related chunks.
+- `GET /api/v1/documents` returns a bare JSON array of documents with `id`, `filename`, `uploaded_at`, and `chunk_count`.
+- `DELETE /api/v1/documents/{id}` returns `200` with `{"deleted":true}` and removes the document and its related chunks.
 - Deleting a missing document returns `404` with `not_found`.
 - Database failures during listing or deletion return `500` with `internal_error`; a failed deletion leaves the document and chunks intact.
 - After deletion, the document no longer appears in the list and its chunks are gone.
@@ -201,9 +214,9 @@ The [RAG chatbot design](design.md) defines the document listing/deletion API sh
 uv run pytest
 ```
 
-Focused tests force database failures during listing and deletion and assert `500` with `internal_error`. After a failed deletion, query PostgreSQL and prove the document and chunks remain.
+Focused tests assert that listing returns a top-level JSON array without a wrapper object. Force database failures during listing and deletion and assert `500` with `internal_error`. After a failed deletion, query PostgreSQL and prove the document and chunks remain.
 
-Manual smoke check: upload `tests/fixtures/test.pdf`, list documents, delete the returned ID, then confirm the ID no longer appears in `GET /api/v1/documents`.
+Manual smoke check: upload `tests/fixtures/test.pdf`, list documents, delete the returned ID, confirm the response is `200` with `{"deleted":true}`, then confirm the ID no longer appears in `GET /api/v1/documents`.
 
 #### Out of scope
 
@@ -236,8 +249,10 @@ This task depends on Tasks 2 and 3. Task 2 stores each PDF as small text section
 #### Constraints
 
 - Add the endpoint to the existing FastAPI service and query PostgreSQL with pgvector.
+- Keep HTTP validation and response formatting in the FastAPI route. Put retrieval and answer ordering in an application service, PostgreSQL vector queries in a repository, and provider request translation in an OpenAI adapter.
 - Return each source's opaque document UUID and stable zero-based chunk position as `document_id` and `chunk_index`.
 - Use the existing `DATABASE_URL` and `OPENAI_API_KEY` settings.
+- Send only the chunks returned in `sources` to OpenAI for answer generation. Keep durable application data in PostgreSQL.
 - Return API errors as `{error: {code, message}}`.
 - Mock OpenAI calls in tests.
 - Retrieve at most 5 chunks for each question.
@@ -248,7 +263,7 @@ This task depends on Tasks 2 and 3. Task 2 stores each PDF as small text section
 
 #### Acceptance criteria
 
-- `POST /api/v1/chat` accepts a message and returns `{answer, sources}`.
+- `POST /api/v1/chat` accepts a JSON body shaped as `{"message":"..."}` and returns `{answer, sources}`.
 - A missing or empty message returns `400` with `bad_request`.
 - Sources include `document_id`, `filename`, `chunk_index`, and `content`.
 - A question answerable from the fixture returns an answer based on that fixture and at least one source.
@@ -271,7 +286,7 @@ The [RAG chatbot design](design.md) covers retrieval defaults, chat response sha
 uv run pytest
 ```
 
-Run focused tests for a missing or empty message and for a database failure during retrieval. Use fixed vectors with scores equal to, just below, and just above the threshold.
+Run focused tests that send the documented JSON request body, omit `message`, and send an empty `message`. Cover a database failure during retrieval. Use fixed vectors with scores equal to, just below, and just above the threshold.
 
 Create more than five matching chunks. Check that the mocked answer generator receives the same first five chunks returned in the sources.
 

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -103,7 +103,7 @@ Users can upload a PDF and receive a stored document record with the number of t
 
 #### Context
 
-This task proves the path from upload to stored search data. It validates the file, extracts its text, and divides that text into small sections called chunks. It turns each chunk into a numeric representation called an embedding, which the service uses to find text with similar meaning. It then stores the document and its chunks for later document and chat tasks.
+This task depends on Task 1, which creates the local API and database. It proves the path from upload to stored search data. It validates the file, extracts its text, and divides that text into small sections called chunks. It turns each chunk into a numeric representation called an embedding, which the service uses to find text with similar meaning. It then stores the document and its chunks for later document and chat tasks.
 
 #### Constraints
 
@@ -167,7 +167,7 @@ Users can list uploaded documents and delete a document with all searchable data
 
 #### Context
 
-Task 2 stores each uploaded document as small text sections, called chunks, with numeric embeddings used to find text with similar meaning. Those documents form the collection that chat will search. This task lets users manage that collection before chat relies on it.
+This task depends on Task 2. Task 2 stores each uploaded document as small text sections, called chunks, with numeric embeddings used to find text with similar meaning. Those documents form the collection that chat will search. This task lets users manage that collection before chat relies on it.
 
 #### Constraints
 
@@ -224,7 +224,7 @@ Users can ask a question and receive an answer based on uploaded PDFs, with refe
 
 #### Context
 
-Task 2 stores each PDF as small text sections, called chunks, and creates a numeric embedding for each chunk. This task creates the same kind of embedding for a question and compares the numbers to find text with similar meaning. It gives the matching text to OpenAI, formats the answer and source references, and handles questions that have no useful match.
+This task depends on Tasks 2 and 3. Task 2 stores each PDF as small text sections, called chunks, and creates a numeric embedding for each chunk. Task 3 adds the deletion endpoint used to prove that removed documents no longer affect answers. This task creates the same kind of embedding for a question and compares the numbers to find text with similar meaning. It gives the matching text to OpenAI, formats the answer and source references, and handles questions that have no useful match.
 
 #### Constraints
 

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-A FastAPI service for uploading PDFs and answering questions from their contents using PostgreSQL with pgvector and OpenAI.
+A FastAPI service for uploading PDFs and answering questions from their contents. It uses retrieval-augmented generation (RAG): the service finds relevant text in PostgreSQL with pgvector, then gives that text to OpenAI to answer the question.
 
 Source design: [RAG chatbot design](design.md)
 
@@ -18,16 +18,24 @@ Source design: [RAG chatbot design](design.md)
 - Mock OpenAI in tests.
 - Add focused tests with each task and run them against PostgreSQL with pgvector.
 - Keep API errors shaped as `{error: {code, message}}`, including `payload_too_large` for a PDF over 25 MiB.
-- Return a fixed no-information answer instead of hallucinating when retrieval has no relevant chunks.
+- Return a fixed no-information answer instead of inventing an answer when the search finds no relevant text.
 - Require `DATABASE_URL` and `OPENAI_API_KEY`.
 
 ---
 
-## Milestone 1: Foundation
+## Milestone 1: Run the service locally
 
 Goal: the app starts, connects to the database, and exposes a healthy API shell.
 
-### Task 1: Local API foundation
+### Task 1: Start and check the API locally
+
+#### Summary
+
+Developers cannot build later features until they can start the API and its database in a repeatable way. This task adds local startup, required configuration, and a health check so a developer can tell whether the base service is ready.
+
+#### User stories
+
+- As a developer, I want to start the API and database locally and check their health so that I can build and test features on a known working service.
 
 #### Outcome
 
@@ -73,19 +81,27 @@ Document upload, embeddings, retrieval, chat, auth, and deployment beyond local 
 
 ---
 
-## Milestone 2: Document ingestion
+## Milestone 2: Store uploaded documents
 
 Goal: PDFs can be uploaded, processed, and stored for later retrieval.
 
-### Task 2: PDF upload and ingestion
+### Task 2: Upload and store PDFs
+
+#### Summary
+
+Users cannot ask questions about their documents until the service can turn an uploaded PDF into searchable text. This task validates each upload and stores its text for later searching without leaving partial data after a failure.
+
+#### User stories
+
+- As a user, I want to upload a PDF so that the service can use its contents when answering my questions.
 
 #### Outcome
 
-Users can upload a PDF and receive a stored document record with chunk count.
+Users can upload a PDF and receive a stored document record with the number of text sections created from it.
 
 #### Context
 
-This task proves the ingestion path: validation, text extraction, chunking, embeddings, and persistence. Later document and chat tasks depend on the stored document and chunk data.
+This task proves the path from upload to stored search data. It validates the file, extracts its text, and divides that text into small sections called chunks. It turns each chunk into a numeric representation called an embedding, which the service uses to find text with similar meaning. It then stores the document and its chunks for later document and chat tasks.
 
 #### Constraints
 
@@ -129,15 +145,23 @@ For every failed upload, query PostgreSQL in the test fixture and prove that doc
 
 Document listing, deletion, retrieval, chat, auth, and non-PDF formats.
 
-### Task 3: Document listing and deletion
+### Task 3: List and delete uploaded documents
+
+#### Summary
+
+After uploading documents, users need to see what the service holds and remove material they no longer want searched. This task adds listing and deletion while ensuring removed text cannot appear in later answers.
+
+#### User stories
+
+- As a user, I want to list and delete uploaded documents so that I can control which material the service searches.
 
 #### Outcome
 
-Users can list uploaded documents and delete a document with all of its chunks and embeddings.
+Users can list uploaded documents and delete a document with all searchable data created from it.
 
 #### Context
 
-Documents and chunks exist after Task 2. This task adds the document management behavior needed before chat can rely on the stored corpus.
+Task 2 stores each uploaded document as small text sections, called chunks, with numeric embeddings used to find text with similar meaning. Those documents form the collection that chat will search. This task lets users manage that collection before chat relies on it.
 
 #### Constraints
 
@@ -172,19 +196,27 @@ Search, chat, cross-user permissions, and soft delete.
 
 ---
 
-## Milestone 3: Grounded chat
+## Milestone 3: Answer questions from documents
 
-Goal: users can ask questions and get grounded answers from uploaded documents.
+Goal: users can ask questions and get answers based on uploaded documents.
 
-### Task 4: Retrieval-backed chat endpoint
+### Task 4: Answer questions from uploaded PDFs
+
+#### Summary
+
+Stored PDFs are not useful until users can ask questions and receive answers based on their contents. This task finds the most relevant stored text, gives it to OpenAI, cites the source passages, and says clearly when the documents do not contain an answer.
+
+#### User stories
+
+- As a user, I want answers based on my uploaded PDFs so that I can use the documents without searching them by hand.
 
 #### Outcome
 
-Users can ask a question and receive a grounded answer with source references from uploaded PDFs.
+Users can ask a question and receive an answer based on uploaded PDFs, with references to the source text.
 
 #### Context
 
-This task combines vector retrieval, prompt construction, OpenAI chat completion, source formatting, and no-result behavior.
+Task 2 stores each PDF as small text sections, called chunks, and creates a numeric embedding for each chunk. This task creates the same kind of embedding for a question and compares the numbers to find text with similar meaning. It gives the matching text to OpenAI, formats the answer and source references, and handles questions that have no useful match.
 
 #### Constraints
 
@@ -199,7 +231,7 @@ This task combines vector retrieval, prompt construction, OpenAI chat completion
 - `POST /api/v1/chat` accepts a message and returns `{answer, sources}`.
 - A missing or empty message returns `400` with `bad_request`.
 - Sources include `document_id`, `filename`, `chunk_index`, and `content`.
-- A question answerable from the fixture returns an answer grounded in that fixture and at least one source.
+- A question answerable from the fixture returns an answer based on that fixture and at least one source.
 - With more than five qualifying chunks, retrieval returns five and the mocked generator receives exactly the same ordered content returned in `sources`.
 - A chunk scoring exactly `RAG_RELEVANCE_THRESHOLD` qualifies, while a lower score does not.
 - Chunks with equal similarity are ordered by document ID and then chunk index.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -10,8 +10,8 @@ argument-hint: "<design, brief, issue, or request>"
 ## Workflow
 
 1. Read the source, repository instructions, and relevant code.
-2. Stop and return to design if product or technical choices remain open.
-3. Break the work into tasks that each deliver working behavior. Each task must:
+2. Stop and return to design if unresolved product or technical choices would change behavior, interfaces, data, security, scale, performance, compatibility, operations, cost, or proof.
+3. Choose task boundaries and break the work into tasks that each deliver working behavior. Do not require two tasks to answer the same open question or define the same shared contract independently. Each task must:
    - Fit one agent run.
    - Produce one focused pull request.
    - Let a reviewer understand the outcome, behavior, and proof without separating unrelated work.
@@ -42,6 +42,7 @@ Each task must stand alone:
 ### Summary
 In two to four sentences, explain the current behavior, who it affects, what will change, and why that change matters.
 
+<!-- Optional: include this section only when the task serves an honest user goal. -->
 ### User stories
 - As a <role>, I want <capability> so that <benefit>.
 
@@ -71,6 +72,8 @@ Related work this task must not absorb.
 - Do not hide unresolved decisions inside implementation tickets.
 - Use a short title that names the action and result in plain words, such as `Remove expired event details automatically`. Do not use only component names or an internal project label.
 - Use plain words in the title, Summary, User stories, and Outcome. Define any project term needed there.
-- Keep implementation steps out of user stories and acceptance criteria. State observable behavior and proof instead.
+- Keep implementation mechanics out of user stories.
+- In Acceptance criteria, state observable behavior and any internal contract that must hold.
+- Put decided technical choices and non-negotiable implementation constraints in Constraints. Leave interchangeable local mechanics to the implementing agent.
 - Give each section one job. Summary orients the reader. User stories state people's goals. Outcome states the working result. Context explains the system and dependencies. Some meaning will overlap, but do not copy sentences or add repetition that does not help the reader.
 - Reread each task alone. A cold reader must be able to explain why it exists, identify the relevant system boundary, implement the decided behavior, and prove it works. Add anything missing before returning the plan.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -17,19 +17,39 @@ argument-hint: "<design, brief, issue, or request>"
    - Let a reviewer understand the outcome, behavior, and proof without separating unrelated work.
 4. Separate refactoring when it would hide the behavior change. Small local cleanup may stay when it makes the change easier to review.
 5. Order tasks by dependency. Add milestones only when they create a useful delivery or review boundary.
-6. Return the plan in chat by default. Create tracker tickets only when the user asks. Never write a plan document.
+6. Return the plan in chat by default. Create tracker tickets only when the user asks. When tickets are separate, copy every needed decision and definition into each ticket. Do not rely on a plan introduction or sibling ticket. Never write a plan document.
 7. Stop after planning. Do not implement.
+
+## Task writing
+
+Treat each task as a cold handoff to a junior engineer with repository access. Assume they have not seen the conversation, design process, or other tickets. Give them enough purpose, system context, decisions, and proof to complete the work without asking for missing product or technical context. Link the source design for detail, not as a substitute for orientation.
+
+Name the current behavior, the affected person, the change, and its value before implementation detail. Define project-specific roles, records, states, and acronyms the first time they appear. Put database, framework, and code details in Context or Constraints.
+
+Use short, concrete sentences. Prefer familiar words and specific verbs. Do not use slogans, metaphors, filler, marketing language, or vague claims such as "robust", "seamless", "comprehensive", and "future-proof".
+
+Use one user story for each distinct goal that the task serves. Operators, maintainers, and developers are valid users when they experience the problem. Omit the section when no honest user goal exists. Do not invent a story for every technical requirement.
+
+For example, explain that completed tasks currently keep every diagnostic event forever and can make the database grow without limit. Then use the story: `As an operator, I want old diagnostic events removed automatically so that storage stays bounded without losing task results.` Put retention timing, batch deletion, and database rules in Constraints.
+
+For a migration, explain the old model, the new model, how records map between them, and why existing users need the move. Define names such as `Definition`, `Run`, `Job`, and `Runner` from the source material. Never use a list of new names as the explanation. Then state the user goal plainly: `As an operator, I want my existing schedules and audit history to keep working after the new scheduling model replaces the old one.` Put cutover, restart, compatibility, and legacy-data rules in Constraints.
 
 Each task must stand alone:
 
 ```markdown
 ## <Task title>
 
+### Summary
+In two to four sentences, explain the current behavior, who it affects, what will change, and why that change matters.
+
+### User stories
+- As a <role>, I want <capability> so that <benefit>.
+
 ### Outcome
-The working result.
+The useful behavior that will work when the task is complete.
 
 ### Context
-What a new agent needs with no session history.
+Define the relevant parts of the system, prior work, dependencies, and source decisions that a new agent needs with no session history.
 
 ### Constraints
 Decisions and behavior that must not change.
@@ -49,3 +69,8 @@ Related work this task must not absorb.
 - Do not split one piece of working behavior into separate file or technical-layer tasks.
 - Do not create scaffolding or cleanup tasks without a checked outcome.
 - Do not hide unresolved decisions inside implementation tickets.
+- Use a short title that names the action and result in plain words, such as `Remove expired event details automatically`. Do not use only component names or an internal project label.
+- Use plain words in the title, Summary, User stories, and Outcome. Define any project term needed there.
+- Keep implementation steps out of user stories and acceptance criteria. State observable behavior and proof instead.
+- Give each section one job. Summary orients the reader. User stories state people's goals. Outcome states the working result. Context explains the system and dependencies. Some meaning will overlap, but do not copy sentences or add repetition that does not help the reader.
+- Reread each task alone. A cold reader must be able to explain why it exists, identify the relevant system boundary, implement the decided behavior, and prove it works. Add anything missing before returning the plan.


### PR DESCRIPTION
## Plain English summary

Planning tickets can be hard to understand when they assume prior context or lead with internal terms. This change makes every planned task a cold handoff with a clear title, short summary, useful user stories, defined terms, and enough context and proof for a new engineer to complete it. The reviewed example now follows the same rules.

## Details

- Separate user value and working outcomes from decided technical constraints.
- Leave interchangeable coding mechanics to the implementing agent.
- Add direct guidance for event retention and scheduling-model migrations.
- Require separate tracker tickets to carry their own decisions, dependencies, interfaces, and definitions.

## Reviewer notes

This changes instructions and documentation only. There is no runtime code.

## Checklist

- **Is this one focused, self-contained change?** Yes
  - The skill, reviewed example, and changelog all describe the same planning output change.
- **Did you write or update tests?** Not applicable
  - The repository has no automated test suite for instruction files.
- **Did you run the relevant tests and checks?** Yes
  - git diff --check and Pandoc parsing passed. A full design-to-ticket audit checked API, identity, storage, shutdown, dependency, ownership, privacy, and provider contracts.
- **Did you independently review the final diff and address valid findings?** Yes
  - A fresh independent review approved with no findings. All six automated review threads were fixed, replied to, and resolved. The final Codex review reacted with approval.
- **Did you update documentation when behavior changed?** Yes
  - Updated the reviewed planning example and Unreleased changelog.
- **Did required CI checks pass?** Not configured
  - This repository has no workflow files, no reported checks, and no branch protection on main.