### PR TITLE
feat(skills): add HTML document renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/skills/html-doc/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file records notable changes to Blueprint.
 
 ## Unreleased
 
+### Added
+
+- Added `/html-doc` to turn an existing Markdown PRD or technical design into a verified static HTML reading view with offline Mermaid diagrams, responsive layout, and print styles.
+
 ### Changed
 
 - `/plan` now writes each task as a cold handoff with a plain title, standalone summary, useful user stories, defined project terms, and enough context and proof for a new engineer to complete it.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,12 +1,13 @@
 # Migrate from older Blueprint skills
 
-> **Breaking change:** Blueprint now ships eight skills. You must remove old Blueprint skill folders and copied commands by hand.
+> **Breaking change:** Blueprint now ships nine skills. You must remove old Blueprint skill folders and copied commands by hand.
 
 ## What changed
 
 | Before | Now |
 | --- | --- |
 | No previous equivalent | `/architecture` |
+| No previous equivalent | `/html-doc` |
 | Design review through `/review` | `/architecture-review` |
 | `design-doc`, `spec` | `/design` |
 | `browser-verify` | Browser proof inside `/test` |
@@ -18,23 +19,23 @@
 | `milestone` | `/task-to-pr` with the milestone as input |
 | `code-reviewer` agent definition | A fresh generic subagent launched by `/review` |
 
-These are the eight skills you can call:
+These are the nine skills you can call:
 
 ```text
-/architecture · /design · /architecture-review · /plan · /test · /review · /improve · /task-to-pr
+/architecture · /design · /architecture-review · /plan · /test · /review · /improve · /task-to-pr · /html-doc
 ```
 
 ## Clean upgrade
 
 1. **Remove old Blueprint skills and commands.** In the skill directory used by your coding tool, remove the old `milestone` skill and the other old Blueprint skill folders listed above. Also remove copied Blueprint `implement.md` and `task-to-pr.md` command files. Do not delete whole skill or command directories because they may contain unrelated files.
-2. **Install all eight skills.**
+2. **Install all nine skills.**
 
    ```bash
    npx skills add owainlewis/blueprint
    ```
 
 3. **Remove copied reviewer agents.** Delete any old Blueprint `code-reviewer` definition. The `/review` skill now launches a fresh generic subagent.
-4. **Check the result.** The `/architecture`, `/design`, `/architecture-review`, `/plan`, `/test`, `/review`, `/improve`, and `/task-to-pr` skills should be available.
+4. **Check the result.** The `/architecture`, `/design`, `/architecture-review`, `/plan`, `/test`, `/review`, `/improve`, `/task-to-pr`, and `/html-doc` skills should be available.
 
 ## Why cleanup is manual
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Choose the first skill based on what you need.
 | Prove a change works | `/test` | Acceptance criteria mapped to evidence |
 | Review an implementation change | `/review` | Findings and a pre-merge verdict from a fresh subagent |
 | Simplify existing code without changing behavior | `/improve` | Clearer, smaller, better-structured code |
+| Make an existing PRD or design easier to read | `/html-doc` | A verified static HTML reading view |
 
 Small, decided work can go straight to `/task-to-pr`. Use `/architecture` for the system as it works now. Use `/design` to write a proposal and `/architecture-review` to challenge important technical choices before implementation. The proposal may be in a design, RFC, ADR, architecture document, or issue. Use `/plan` only when the work needs splitting.
 
@@ -58,7 +59,7 @@ The model has two layers:
 1. **Repository instructions define policy.** `AGENTS.md` says what good work means in a codebase.
 2. **Skills define each kind of work.** Each skill produces one clear result and has a clear stopping point. `/task-to-pr` joins the steps needed to deliver code.
 
-## The seven phase skills
+## The skills
 
 | Skill | Owns | Stops when |
 | --- | --- | --- |
@@ -69,6 +70,7 @@ The model has two layers:
 | `/test` | Automated checks, failure paths, and real-browser proof when relevant | Every criterion is pass, fail, or explicitly unverified |
 | `/review` | Independent review of an implementation's correctness, security, regressions, complexity, and proof | Findings and a verdict are reported |
 | `/improve` | Behavior-preserving simplification of existing code | Relevant checks prove behavior was preserved |
+| `/html-doc` | A static HTML reading view of a complete Markdown PRD or technical design | The browser-verified candidate atomically replaces the prior generated view |
 
 Writing code is a basic agent ability, not a separate skill. Branching, committing, debugging, browser checks, and feedback are steps inside a workflow.
 
@@ -88,7 +90,7 @@ It leaves pull requests open unless the user asks to merge them.
 
 ## Install
 
-Install all eight skills:
+Install all nine skills:
 
 ```bash
 npx skills add owainlewis/blueprint
@@ -101,7 +103,7 @@ Read the [changelog](CHANGELOG.md) for notable changes.
 ## Repository map
 
 ```text
-skills/                 seven phase skills and one delivery workflow skill
+skills/                 seven phase skills, one delivery workflow, and one presentation skill
 AGENTS.md                portable repository policy
 CLAUDE.md                Claude Code adapter
 REVIEW.md                review standard for Blueprint itself

--- a/docs/html-doc/design.html
+++ b/docs/html-doc/design.html
@@ -3,642 +3,364 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; script-src 'none'; object-src 'none'; frame-src 'none'; connect-src 'none'; base-uri 'none'; form-action 'none'">
-  <meta name="document-kind" content="Technical design">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
+  <meta name="document-kind" content="design">
   <meta name="source-path" content="docs/html-doc/design.md">
-  <meta name="source-sha256" content="d56b026571bdb9de09b99a95a00a684755d82d9eb67c521fe9e8d965cee03497">
+  <meta name="source-sha256" content="4f1429ad719088f428da1d40dac7cade0e5c50effd5bee4ef093b6cbda619258">
   <meta name="generator" content="blueprint/html-doc@1">
   <title>HTML PRD and design document skill</title>
-  <style>
-    :root {
-      color-scheme: light;
-      --paper: #e8edf0;
-      --sheet: #fbfcfd;
-      --ink: #202a31;
-      --muted: #5c6d78;
-      --line: #c7d2d9;
-      --accent: #536f82;
-      --accent-soft: #dce6ec;
-      --secondary: #3f6575;
-      --secondary-soft: #dbe8eb;
-      --note-soft: #e8eef2;
-      --code: #202a32;
-      --shadow: 0 22px 60px rgba(39, 56, 67, 0.1);
-      --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      --serif: Iowan Old Style, Baskerville, "Times New Roman", serif;
-      --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-    }
+  <style>:root {
+  color-scheme: light;
+  --paper: #f7f9fb;
+  --surface: #ffffff;
+  --surface-soft: #edf2f5;
+  --ink: #172630;
+  --muted: #526773;
+  --line: #ccd8df;
+  --line-strong: #8fa5b3;
+  --accent: #385e75;
+  --accent-soft: #dbe5ec;
+  --focus: #176b93;
+  --risk: #6b4f28;
+  --risk-soft: #f3ecdf;
+  --radius: 12px;
+  --shadow: 0 16px 42px rgb(31 54 68 / 10%);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+  background: var(--paper);
+  color: var(--ink);
+}
 
-    * { box-sizing: border-box; }
-    html { scroll-behavior: smooth; background: var(--paper); }
-    body {
-      margin: 0;
-      color: var(--ink);
-      background:
-        radial-gradient(circle at 8% 3%, rgba(83, 111, 130, 0.12), transparent 24rem),
-        radial-gradient(circle at 92% 12%, rgba(63, 101, 117, 0.08), transparent 26rem),
-        var(--paper);
-      font-family: var(--sans);
-      font-size: 17px;
-      line-height: 1.68;
-      text-rendering: optimizeLegibility;
-    }
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; background: var(--paper); }
+a { color: var(--accent); text-underline-offset: 0.16em; }
+a:hover { text-decoration-thickness: 2px; }
+a:focus-visible, summary:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
 
-    a { color: var(--secondary); text-underline-offset: 0.16em; }
-    a:hover { color: var(--accent); }
-    a:focus-visible, [tabindex="-1"]:focus-visible {
-      outline: 3px solid var(--accent);
-      outline-offset: 4px;
-      border-radius: 3px;
-    }
+.skip-link {
+  position: fixed;
+  z-index: 10;
+  left: 1rem;
+  top: 1rem;
+  padding: .65rem .9rem;
+  background: var(--ink);
+  color: white;
+  transform: translateY(-180%);
+}
+.skip-link:focus { transform: translateY(0); }
 
-    .skip-link {
-      position: fixed;
-      z-index: 20;
-      top: 0.75rem;
-      left: 0.75rem;
-      transform: translateY(-180%);
-      padding: 0.65rem 0.9rem;
-      color: white;
-      background: var(--ink);
-      border-radius: 0.35rem;
-    }
-    .skip-link:focus { transform: translateY(0); }
+.document-header {
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(145deg, #e5edf2 0%, #f7f9fb 70%);
+}
+.document-header__inner,
+.page-shell,
+.document-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin-inline: auto;
+}
+.document-header__inner { padding: 3.8rem 0 3rem; }
+.eyebrow {
+  margin: 0 0 .8rem;
+  color: var(--accent);
+  font-size: .78rem;
+  font-weight: 750;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+.document-title {
+  max-width: 900px;
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2.25rem, 5vw, 4.6rem);
+  font-weight: 500;
+  line-height: 1.05;
+  letter-spacing: -.035em;
+}
+.metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .55rem 1.25rem;
+  margin: 1.6rem 0 0;
+  color: var(--muted);
+  font-size: .88rem;
+}
+.metadata dt { font-weight: 700; color: var(--ink); }
+.metadata dd { margin: 0; overflow-wrap: anywhere; }
+.metadata__item { display: grid; grid-template-columns: auto 1fr; gap: .35rem; }
 
-    .masthead {
-      border-bottom: 1px solid rgba(63, 78, 88, 0.18);
-      background: rgba(251, 252, 253, 0.76);
-    }
-    .masthead-inner {
-      max-width: 1440px;
-      margin: 0 auto;
-      padding: 1.1rem clamp(1rem, 4vw, 3rem);
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1.25rem;
-    }
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 0.7rem;
-      font-weight: 760;
-      letter-spacing: -0.015em;
-    }
-    .brand-mark {
-      width: 2.1rem;
-      height: 2.1rem;
-      display: grid;
-      place-items: center;
-      border-radius: 50%;
-      color: var(--sheet);
-      background: var(--accent);
-      font-family: var(--serif);
-      font-size: 1.15rem;
-    }
-    .meta-strip {
-      display: flex;
-      justify-content: flex-end;
-      gap: 0.65rem;
-      flex-wrap: wrap;
-      color: var(--muted);
-      font-size: 0.78rem;
-    }
-    .pill {
-      padding: 0.28rem 0.55rem;
-      border: 1px solid var(--line);
-      border-radius: 999px;
-      background: var(--sheet);
-    }
-    .pill strong { color: var(--ink); }
+.page-shell {
+  display: grid;
+  grid-template-columns: minmax(190px, 250px) minmax(0, 1fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: start;
+  padding-block: 3rem 5rem;
+}
+.toc {
+  position: sticky;
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+  padding: 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgb(255 255 255 / 78%);
+}
+.toc-title { margin: 0 0 .75rem; font: 750 .78rem/1.2 Inter, sans-serif; letter-spacing: .09em; text-transform: uppercase; }
+.toc ol { list-style: none; padding: 0; margin: 0; }
+.toc li + li { margin-top: .34rem; }
+.toc li[data-level="3"] { padding-left: .8rem; font-size: .88rem; }
+.toc a { display: block; color: var(--muted); text-decoration: none; line-height: 1.35; }
+.toc a:hover { color: var(--ink); }
 
-    .shell {
-      width: min(1440px, 100%);
-      margin: 0 auto;
-      padding: clamp(1rem, 3vw, 2.6rem);
-      display: grid;
-      grid-template-columns: minmax(220px, 270px) minmax(0, 1fr);
-      gap: clamp(1rem, 3vw, 2.5rem);
-      align-items: start;
-    }
+.document-content {
+  min-width: 0;
+  padding: clamp(1.4rem, 4vw, 3.8rem);
+  border: 1px solid var(--line);
+  border-radius: calc(var(--radius) + 4px);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+.source-block { min-width: 0; }
+.source-block > :first-child { margin-top: 0; }
+.source-block > :last-child { margin-bottom: 0; }
+.source-block + .source-block { margin-top: 1rem; }
+.source-block:has(> h1), .source-block:has(> h2) { margin-top: 3.7rem; }
+.source-block:first-child { margin-top: 0; }
+h1, h2, h3, h4 { color: var(--ink); line-height: 1.2; scroll-margin-top: 1.5rem; }
+.document-content h1 { font: 500 clamp(2rem, 5vw, 3.2rem)/1.08 Georgia, serif; letter-spacing: -.025em; }
+.document-content h2 { padding-top: .4rem; font: 500 clamp(1.7rem, 3vw, 2.3rem)/1.15 Georgia, serif; letter-spacing: -.018em; }
+.document-content h3 { font-size: 1.12rem; }
+.document-content h4 { font-size: 1rem; }
+p, ul, ol, blockquote, pre, table, figure { margin-block: 1rem; }
+blockquote {
+  margin-inline: 0;
+  padding: .8rem 1rem;
+  border-left: 4px solid var(--line-strong);
+  background: var(--surface-soft);
+  color: #314854;
+}
+blockquote > :first-child { margin-top: 0; }
+blockquote > :last-child { margin-bottom: 0; }
+.role-requirements, .role-acceptance-criteria, .role-invariants,
+.role-decisions, .role-risks, .role-open-questions {
+  margin-top: 1.25rem;
+  padding: 1rem 1.2rem;
+  border-left: 4px solid var(--line-strong);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  background: var(--surface-soft);
+}
+.role-risks, .role-open-questions { border-left-color: var(--risk); background: var(--risk-soft); }
+code, pre { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
+code { padding: .12em .32em; border-radius: 4px; background: var(--surface-soft); font-size: .9em; }
+pre {
+  max-width: 100%;
+  overflow: auto;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #132630;
+  color: #edf4f7;
+  line-height: 1.48;
+}
+pre code { padding: 0; background: transparent; color: inherit; }
+.table-wrap { max-width: 100%; overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; font-size: .93rem; }
+th, td { padding: .68rem .75rem; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+th { background: var(--surface-soft); font-weight: 720; }
+tbody tr:nth-child(even) { background: #f9fbfc; }
+.diagram {
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: #fbfcfd;
+}
+.diagram img { display: block; width: 100%; height: auto; max-height: 650px; object-fit: contain; }
+.diagram figcaption { margin-top: .75rem; color: var(--muted); font-size: .86rem; }
+.diagram details { margin-top: .8rem; }
+.diagram summary { cursor: pointer; color: var(--accent); font-weight: 650; }
+.diagram details pre { max-height: 18rem; }
+.document-footer { padding: 0 0 3rem; color: var(--muted); font-size: .82rem; }
 
-    #TOC {
-      position: sticky;
-      top: 1.5rem;
-      max-height: calc(100vh - 3rem);
-      overflow-y: auto;
-      padding: 1.15rem 0.35rem 1.15rem 0;
-      color: var(--muted);
-      font-size: 0.82rem;
-      line-height: 1.35;
-      scrollbar-width: thin;
-    }
-    #TOC::before {
-      content: "On this page";
-      display: block;
-      margin: 0 0 0.85rem 0.75rem;
-      color: var(--ink);
-      font-weight: 800;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      font-size: 0.7rem;
-    }
-    #TOC ul { margin: 0; padding: 0; list-style: none; }
-    #TOC ul ul { padding-left: 0.85rem; margin-top: 0.15rem; }
-    #TOC li { margin: 0.12rem 0; }
-    #TOC a {
-      display: block;
-      padding: 0.38rem 0.72rem;
-      color: var(--muted);
-      text-decoration: none;
-      border-left: 2px solid transparent;
-      border-radius: 0 0.3rem 0.3rem 0;
-    }
-    #TOC a:hover, #TOC a:focus-visible {
-      color: var(--ink);
-      border-left-color: var(--accent);
-      background: rgba(251, 252, 253, 0.82);
-    }
-    .mobile-toc { display: none; }
+@media (max-width: 760px) {
+  .document-header__inner { padding: 2.7rem 0 2.2rem; }
+  .page-shell { grid-template-columns: 1fr; gap: 1.2rem; padding-top: 1.25rem; }
+  .toc { position: static; max-height: none; }
+  .document-content { padding: 1.25rem; border-radius: var(--radius); }
+  .source-block:has(> h1), .source-block:has(> h2) { margin-top: 2.7rem; }
+}
 
-    main {
-      min-width: 0;
-      background: var(--sheet);
-      border: 1px solid rgba(85, 104, 116, 0.22);
-      box-shadow: var(--shadow);
-    }
-    main > .level1 > h1 {
-      margin: 0;
-      padding: clamp(2.2rem, 7vw, 6.2rem) clamp(1.2rem, 6vw, 5.5rem) 1rem;
-      max-width: 18ch;
-      font-family: var(--serif);
-      font-size: clamp(3rem, 6vw, 6.3rem);
-      line-height: 0.96;
-      font-weight: 500;
-      letter-spacing: -0.045em;
-      text-wrap: balance;
-    }
-    main > .level1 > blockquote {
-      margin: 1.2rem clamp(1.2rem, 6vw, 5.5rem) clamp(2.5rem, 7vw, 5.5rem);
-      width: fit-content;
-      padding: 0.4rem 0.75rem;
-      color: #314d5e;
-      background: var(--accent-soft);
-      border: 1px solid #b9cbd4;
-      border-radius: 999px;
-      font-size: 0.82rem;
-      font-weight: 740;
-    }
-    blockquote p { margin: 0; }
-
-    section.level2 {
-      padding: clamp(2.3rem, 6vw, 5rem) clamp(1.2rem, 6vw, 5.5rem);
-      border-top: 1px solid var(--line);
-    }
-    section.level2 > h2 {
-      margin: 0 0 1.7rem;
-      max-width: 24ch;
-      font-family: var(--serif);
-      font-size: clamp(2rem, 3.4vw, 3.5rem);
-      line-height: 1.04;
-      font-weight: 500;
-      letter-spacing: -0.028em;
-      text-wrap: balance;
-    }
-    section.level3 { margin-top: 2.8rem; }
-    section.level3 > h3 {
-      margin: 0 0 1rem;
-      color: var(--secondary);
-      font-size: 0.78rem;
-      line-height: 1.3;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-    }
-    p { max-width: 76ch; margin: 0.85rem 0; }
-    strong { font-weight: 780; }
-
-    [id="1-executive-summary"] {
-      position: relative;
-      background: var(--ink);
-      color: #f4f7f9;
-      border-top: 0;
-    }
-    [id="1-executive-summary"]::after {
-      content: "Source of truth → Human reading view";
-      display: block;
-      margin-top: 2.2rem;
-      color: #bad0da;
-      font-size: 0.76rem;
-      font-weight: 750;
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-    }
-    [id="1-executive-summary"] h2 { color: white; }
-    [id="1-executive-summary"] p { color: #dce5e9; font-size: 1.08rem; }
-
-    [id="12-open-questions"] { background: var(--note-soft); }
-    [id="8-security-privacy-and-operations"] { background: #edf3f5; }
-    [id="13-out-of-scope"] { background: #f1f4f6; }
-
-    ul, ol { max-width: 80ch; padding-left: 1.25rem; }
-    li { margin: 0.48rem 0; padding-left: 0.28rem; }
-    li::marker { color: var(--accent); font-weight: 800; }
-
-    #decisions > p {
-      padding: 1rem 1.1rem 1rem 1.25rem;
-      border-left: 4px solid var(--secondary);
-      background: var(--secondary-soft);
-      border-radius: 0 0.45rem 0.45rem 0;
-    }
-    #invariants ol {
-      list-style: none;
-      padding: 0;
-      counter-reset: invariant;
-      display: grid;
-      gap: 0.7rem;
-    }
-    #invariants li {
-      counter-increment: invariant;
-      display: grid;
-      grid-template-columns: 2rem 1fr;
-      gap: 0.8rem;
-      align-items: start;
-      margin: 0;
-      padding: 0.9rem 1rem;
-      border: 1px solid var(--line);
-      background: white;
-    }
-    #invariants li::before {
-      content: counter(invariant);
-      width: 2rem;
-      height: 2rem;
-      display: grid;
-      place-items: center;
-      border-radius: 50%;
-      color: white;
-      background: var(--accent);
-      font-weight: 800;
-    }
-
-    .table-wrap { width: 100%; overflow-x: auto; margin: 1.5rem 0; }
-    table {
-      width: 100%;
-      min-width: 640px;
-      border-collapse: collapse;
-      font-size: 0.88rem;
-      line-height: 1.45;
-    }
-    th, td { padding: 0.85rem 0.9rem; text-align: left; vertical-align: top; border-bottom: 1px solid var(--line); }
-    th { color: var(--sheet); background: var(--ink); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.07em; }
-    tbody tr:nth-child(even) { background: #eff3f5; }
-
-    code {
-      padding: 0.12rem 0.32rem;
-      border-radius: 0.25rem;
-      color: #315565;
-      background: #e2ebf0;
-      font-family: var(--mono);
-      font-size: 0.86em;
-    }
-    pre {
-      max-width: 100%;
-      overflow-x: auto;
-      margin: 1.35rem 0;
-      padding: 1.15rem 1.25rem;
-      color: #edf3f6;
-      background: var(--code);
-      border-radius: 0.5rem;
-      line-height: 1.55;
-      white-space: pre;
-    }
-    pre code { padding: 0; color: inherit; background: transparent; white-space: pre; }
-
-    figure.diagram {
-      margin: 2rem 0;
-      padding: clamp(0.7rem, 2vw, 1.5rem);
-      background: #f0f4f6;
-      border: 1px solid var(--line);
-      border-radius: 0.65rem;
-    }
-    figure.diagram svg { display: block; width: min(100%, 720px); height: auto; margin: 0 auto; }
-    figure.diagram figcaption { margin-top: 0.8rem; color: var(--muted); text-align: center; font-size: 0.82rem; }
-    .diagram .node { fill: var(--sheet); stroke: #82939e; stroke-width: 2; }
-    .diagram .node-source { fill: var(--secondary-soft); stroke: var(--secondary); }
-    .diagram .node-output { fill: var(--accent-soft); stroke: var(--accent); }
-    .diagram .label { fill: var(--ink); font-family: var(--sans); font-size: 25px; font-weight: 730; text-anchor: middle; dominant-baseline: middle; }
-    .diagram .small-label { fill: var(--accent); font-family: var(--sans); font-size: 18px; font-weight: 760; text-anchor: middle; }
-    .diagram .arrow { fill: none; stroke: #687984; stroke-width: 3; marker-end: url(#arrowhead); }
-    .diagram .return { fill: none; stroke: var(--accent); stroke-width: 3; stroke-dasharray: 9 8; marker-end: url(#accent-arrow); }
-
-    footer {
-      max-width: 1440px;
-      margin: 0 auto;
-      padding: 0.2rem clamp(1rem, 4vw, 3rem) 2.5rem;
-      color: var(--muted);
-      font-size: 0.76rem;
-      text-align: right;
-    }
-
-    @media (max-width: 900px) {
-      .masthead-inner { align-items: flex-start; flex-direction: column; }
-      .meta-strip { justify-content: flex-start; }
-      .shell { grid-template-columns: minmax(0, 1fr); gap: 1rem; }
-      #TOC { display: none; }
-      .mobile-toc {
-        display: block;
-        margin: 1rem 1rem 0;
-        background: rgba(251, 252, 253, 0.82);
-        border: 1px solid var(--line);
-      }
-      .mobile-toc summary {
-        padding: 0.8rem 1rem;
-        color: var(--ink);
-        cursor: pointer;
-        font-size: 0.75rem;
-        font-weight: 800;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-      }
-      .mobile-toc nav { padding: 0 1rem 1rem; font-size: 0.82rem; }
-      .mobile-toc ul { margin: 0; padding-left: 1rem; }
-      .mobile-toc li { margin: 0.25rem 0; }
-      .mobile-toc a { color: var(--muted); text-decoration: none; }
-    }
-
-    @media (max-width: 560px) {
-      body { font-size: 16px; }
-      .masthead-inner { padding: 0.85rem 1rem; }
-      .meta-strip { gap: 0.4rem; }
-      .pill { max-width: 100%; overflow-wrap: anywhere; }
-      .shell { padding: 0.75rem; }
-      main > .level1 > h1 { font-size: clamp(2.7rem, 14vw, 4rem); padding-top: 2.6rem; }
-      main > .level1 > blockquote { border-radius: 0.4rem; }
-      section.level2 { padding-top: 2.8rem; padding-bottom: 2.8rem; }
-      section.level2 > h2 { font-size: 2.15rem; }
-      #invariants li { grid-template-columns: 1.8rem 1fr; padding: 0.8rem; }
-      #invariants li::before { width: 1.8rem; height: 1.8rem; }
-      figure.diagram { overflow-x: auto; }
-      figure.diagram svg { width: 520px; max-width: none; }
-    }
-
-    @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
-
-    @media print {
-      @page { size: auto; margin: 16mm; }
-      html, body { background: white; }
-      body { font-size: 10.5pt; line-height: 1.45; }
-      .masthead, #TOC, .skip-link { display: none; }
-      .shell { display: block; width: auto; margin: 0; padding: 0; }
-      main { border: 0; box-shadow: none; }
-      main > .level1 > h1 { padding: 0 0 8mm; font-size: 32pt; }
-      main > .level1 > blockquote { margin: 0 0 10mm; }
-      section.level2 { padding: 9mm 0; break-inside: auto; }
-      section.level2 > h2, section.level3 > h3 { break-after: avoid; }
-      p, li { orphans: 3; widows: 3; }
-      table { min-width: 0; font-size: 8pt; }
-      thead { display: table-header-group; }
-      tr, figure, pre { break-inside: avoid; }
-      pre { white-space: pre-wrap; overflow-wrap: anywhere; }
-      a { color: inherit; text-decoration: none; }
-      footer { padding: 8mm 0 0; }
-    }
-  </style>
+@media print {
+  :root { background: white; font-size: 10.5pt; }
+  @page { size: auto; margin: 16mm; }
+  .skip-link, .toc { display: none; }
+  .document-header { background: white; }
+  .document-header__inner, .page-shell, .document-footer { width: 100%; }
+  .document-header__inner { padding: 0 0 12mm; }
+  .document-title { font-size: 28pt; }
+  .page-shell { display: block; padding: 0; }
+  .document-content { padding: 0; border: 0; box-shadow: none; }
+  h1, h2, h3, h4 { break-after: avoid-page; }
+  table, figure, pre, blockquote { break-inside: avoid; }
+  thead { display: table-header-group; }
+  pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+  .document-footer { padding: 10mm 0 0; }
+}
+</style>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to document</a>
-  <header class="masthead" aria-label="Document metadata">
-    <div class="masthead-inner">
-      <div class="brand"><span class="brand-mark" aria-hidden="true">B</span>Blueprint document</div>
-      <div class="meta-strip">
-        <span class="pill"><strong>Kind:</strong> Technical
-design</span>
-        <span class="pill"><strong>Source:</strong> docs/html-doc/design.md</span>
-        <span class="pill"><strong>Revision:</strong> <span title="d56b026571bdb9de09b99a95a00a684755d82d9eb67c521fe9e8d965cee03497">d56b026571bd</span></span>
-      </div>
+  <a class="skip-link" href="#document-content">Skip to document</a>
+  <header class="document-header">
+    <div class="document-header__inner">
+      <p class="eyebrow">Technical design</p>
+      <p class="document-title">HTML PRD and design document skill</p>
+      <dl class="metadata">
+        <div class="metadata__item"><dt>Status</dt><dd>Proposed for review</dd></div>
+        <div class="metadata__item"><dt>Source</dt><dd>docs/html-doc/design.md</dd></div>
+        <div class="metadata__item"><dt>SHA-256</dt><dd><code>4f1429ad719088f428da1d40dac7cade0e5c50effd5bee4ef093b6cbda619258</code></dd></div>
+      </dl>
     </div>
   </header>
-  <aside class="mobile-toc" aria-label="Document navigation">
-    <details>
-      <summary>Contents</summary>
-      <nav aria-label="Document sections on small screens">
-<ul>
-<li><a href="#html-prd-and-design-document-skill"
-id="toc-html-prd-and-design-document-skill">HTML PRD and design document
-skill</a>
-<ul>
-<li><a href="#1-executive-summary" id="toc-1-executive-summary">1.
-Executive summary</a></li>
-<li><a href="#2-context-and-scope" id="toc-2-context-and-scope">2.
-Context and scope</a></li>
-<li><a href="#3-system-context" id="toc-3-system-context">3. System
-context</a></li>
-<li><a href="#4-proposed-design" id="toc-4-proposed-design">4. Proposed
-design</a>
-<ul>
-<li><a href="#how-it-works" id="toc-how-it-works">How it works</a></li>
-<li><a href="#page-structure" id="toc-page-structure">Page
-structure</a></li>
-<li><a href="#components-and-responsibilities"
-id="toc-components-and-responsibilities">Components and
-responsibilities</a></li>
-<li><a href="#decisions" id="toc-decisions">Decisions</a></li>
-</ul></li>
-<li><a href="#5-invariants-and-requirements"
-id="toc-5-invariants-and-requirements">5. Invariants and
-requirements</a>
-<ul>
-<li><a href="#invariants" id="toc-invariants">Invariants</a></li>
-<li><a href="#requirements" id="toc-requirements">Requirements</a></li>
-</ul></li>
-<li><a href="#6-interfaces-and-data" id="toc-6-interfaces-and-data">6.
-Interfaces and data</a>
-<ul>
-<li><a href="#naming-and-identity" id="toc-naming-and-identity">Naming
-and identity</a></li>
-</ul></li>
-<li><a href="#7-failure-behavior-and-lifecycle"
-id="toc-7-failure-behavior-and-lifecycle">7. Failure behavior and
-lifecycle</a></li>
-<li><a href="#8-security-privacy-and-operations"
-id="toc-8-security-privacy-and-operations">8. Security, privacy, and
-operations</a></li>
-<li><a href="#9-acceptance-criteria" id="toc-9-acceptance-criteria">9.
-Acceptance criteria</a></li>
-<li><a href="#10-test-approach" id="toc-10-test-approach">10. Test
-approach</a></li>
-<li><a href="#11-risks-and-tradeoffs"
-id="toc-11-risks-and-tradeoffs">11. Risks and tradeoffs</a></li>
-<li><a href="#12-open-questions" id="toc-12-open-questions">12. Open
-questions</a></li>
-<li><a href="#13-out-of-scope" id="toc-13-out-of-scope">13. Out of
-scope</a></li>
-</ul></li>
-</ul>
-      </nav>
-    </details>
-  </aside>
-  <div class="shell">
-    <nav id="TOC" aria-label="Document sections">
-<ul>
-<li><a href="#html-prd-and-design-document-skill"
-id="toc-html-prd-and-design-document-skill">HTML PRD and design document
-skill</a>
-<ul>
-<li><a href="#1-executive-summary" id="toc-1-executive-summary">1.
-Executive summary</a></li>
-<li><a href="#2-context-and-scope" id="toc-2-context-and-scope">2.
-Context and scope</a></li>
-<li><a href="#3-system-context" id="toc-3-system-context">3. System
-context</a></li>
-<li><a href="#4-proposed-design" id="toc-4-proposed-design">4. Proposed
-design</a>
-<ul>
-<li><a href="#how-it-works" id="toc-how-it-works">How it works</a></li>
-<li><a href="#page-structure" id="toc-page-structure">Page
-structure</a></li>
-<li><a href="#components-and-responsibilities"
-id="toc-components-and-responsibilities">Components and
-responsibilities</a></li>
-<li><a href="#decisions" id="toc-decisions">Decisions</a></li>
-</ul></li>
-<li><a href="#5-invariants-and-requirements"
-id="toc-5-invariants-and-requirements">5. Invariants and
-requirements</a>
-<ul>
-<li><a href="#invariants" id="toc-invariants">Invariants</a></li>
-<li><a href="#requirements" id="toc-requirements">Requirements</a></li>
-</ul></li>
-<li><a href="#6-interfaces-and-data" id="toc-6-interfaces-and-data">6.
-Interfaces and data</a>
-<ul>
-<li><a href="#naming-and-identity" id="toc-naming-and-identity">Naming
-and identity</a></li>
-</ul></li>
-<li><a href="#7-failure-behavior-and-lifecycle"
-id="toc-7-failure-behavior-and-lifecycle">7. Failure behavior and
-lifecycle</a></li>
-<li><a href="#8-security-privacy-and-operations"
-id="toc-8-security-privacy-and-operations">8. Security, privacy, and
-operations</a></li>
-<li><a href="#9-acceptance-criteria" id="toc-9-acceptance-criteria">9.
-Acceptance criteria</a></li>
-<li><a href="#10-test-approach" id="toc-10-test-approach">10. Test
-approach</a></li>
-<li><a href="#11-risks-and-tradeoffs"
-id="toc-11-risks-and-tradeoffs">11. Risks and tradeoffs</a></li>
-<li><a href="#12-open-questions" id="toc-12-open-questions">12. Open
-questions</a></li>
-<li><a href="#13-out-of-scope" id="toc-13-out-of-scope">13. Out of
-scope</a></li>
-</ul></li>
-</ul>
-    </nav>
-    <main id="main-content" tabindex="-1">
-<section id="html-prd-and-design-document-skill" class="level1">
+  <div class="page-shell">
+    <nav class="toc" aria-label="Document contents"><p class="toc-title">Contents</p><ol><li data-level="2"><a href="#1-executive-summary">1. Executive summary</a></li><li data-level="2"><a href="#2-context-and-scope">2. Context and scope</a></li><li data-level="2"><a href="#3-system-context">3. System context</a></li><li data-level="2"><a href="#4-proposed-design">4. Proposed design</a></li><li data-level="3"><a href="#how-it-works">How it works</a></li><li data-level="3"><a href="#page-structure">Page structure</a></li><li data-level="3"><a href="#components-and-responsibilities">Components and responsibilities</a></li><li data-level="3"><a href="#decisions">Decisions</a></li><li data-level="2"><a href="#5-invariants-and-requirements">5. Invariants and requirements</a></li><li data-level="3"><a href="#invariants">Invariants</a></li><li data-level="3"><a href="#requirements">Requirements</a></li><li data-level="2"><a href="#6-interfaces-and-data">6. Interfaces and data</a></li><li data-level="3"><a href="#naming-and-identity">Naming and identity</a></li><li data-level="2"><a href="#7-failure-behavior-and-lifecycle">7. Failure behavior and lifecycle</a></li><li data-level="2"><a href="#8-security-privacy-and-operations">8. Security, privacy, and operations</a></li><li data-level="2"><a href="#9-acceptance-criteria">9. Acceptance criteria</a></li><li data-level="2"><a href="#10-test-approach">10. Test approach</a></li><li data-level="2"><a href="#11-risks-and-tradeoffs">11. Risks and tradeoffs</a></li><li data-level="2"><a href="#12-open-questions">12. Open questions</a></li><li data-level="2"><a href="#13-out-of-scope">13. Out of scope</a></li></ol></nav>
+    <main id="document-content" class="document-content" data-source-block-count="67">
+<section id="html-prd-and-design-document-skill" class="source-block"
+data-source-block="1"
+data-source-sha256="5c87239cbf702197a780c0f5050b2f1dba574b5f24e3375c5c8f8bd199d324d9">
 <h1>HTML PRD and design document skill</h1>
+</section>
+<div class="source-block" data-source-block="2"
+data-source-sha256="f3cfda141bb0d969e973d91600064c759ac4c936fa82e9f2c3f6bb2a60fbb270">
 <blockquote>
 <p><strong>Status:</strong> Proposed for review</p>
 </blockquote>
-<section id="1-executive-summary" class="level2">
+</div>
+<section id="1-executive-summary" class="source-block role-summary"
+data-source-block="3"
+data-source-sha256="369eedb81a8602aa50ed832662b898c91ab782d2b66611d11a6b18d8001d4703">
 <h2>1. Executive summary</h2>
+</section>
+<div class="source-block" data-source-block="4"
+data-source-sha256="e158b5356dbf723b53c1b1328aa3a566a3234c585d6fc7333d912b517993ad76">
 <p>Add an <code>/html-doc</code> skill that turns an existing Markdown
 product requirements document (PRD) or technical design into a clear,
 static HTML document. The Markdown file remains the source of truth. The
 HTML adds navigation, stronger visual hierarchy, useful callouts,
 readable diagrams, responsive layout, and print styles without changing
 the document's meaning.</p>
+</div>
+<div class="source-block" data-source-block="5"
+data-source-sha256="e011c17e2e516fa530cc5891aa38668b3badb1e939b69ad4259a1ee9eb0c9ac6">
 <p>The skill is a presentation step, not another product or technical
 design workflow. This avoids competing with <code>/design</code> and
 prevents requirements from changing during rendering. The main downside
 is a second file that can drift from its source. The generated page
 records the source path and content hash, and the skill regenerates
 rather than edits HTML by hand.</p>
-</section>
-<section id="2-context-and-scope" class="level2">
+</div>
+<section id="2-context-and-scope" class="source-block"
+data-source-block="6"
+data-source-sha256="7f27d9838429652fd04876b144f647ac2408f51de0d0db5fc261c40076a8d500">
 <h2>2. Context and scope</h2>
+</section>
+<div class="source-block" data-source-block="7"
+data-source-sha256="a446c72f1a3350eb86a91be298f797fad246999ec82bcfa98bf0b5aa81b8b75e">
 <p>Markdown is good for writing and source review. Long PRDs and design
 documents are harder to scan in raw form because summaries, decisions,
 requirements, risks, diagrams, and open questions have similar visual
 weight.</p>
+</div>
+<div class="source-block" data-source-block="8"
+data-source-sha256="0f35595400f20a96a672b977f5c419b1a954b2738f2d05d964cb4970c8675217">
 <p>The new skill accepts a Markdown file or exact Markdown supplied in
 the request. It creates one sibling HTML file for people to read in a
 browser, print, or attach to a review. It preserves all source content
 and order while changing its presentation.</p>
+</div>
+<div class="source-block" data-source-block="9"
+data-source-sha256="16c287ddb4e59dc98e396e27eabb680dad7241926b7ef23b3d4a9b4e80b3c1e3">
 <p>This design covers PRDs and proposed technical designs. It does not
 decide product requirements, settle technical choices, host documents,
 or replace the Markdown source.</p>
-</section>
-<section id="3-system-context" class="level2">
+</div>
+<section id="3-system-context" class="source-block"
+data-source-block="10"
+data-source-sha256="40793fe15cdedd8ecf4489800820100043e0c3ebe6ee96e6db9b0dc8f866fabd">
 <h2>3. System context</h2>
-<figure class="diagram" aria-labelledby="flow-title flow-caption">
-  <svg role="img" viewBox="0 0 720 900" xmlns="http://www.w3.org/2000/svg">
-    <title id="flow-title">From idea to human review</title>
-    <desc>An idea becomes a PRD or technical design in canonical Markdown. The HTML document skill turns it into generated HTML for human review. Content changes return to the Markdown source.</desc>
-    <defs>
-      <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#687984"/></marker>
-      <marker id="accent-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#536f82"/></marker>
-    </defs>
-    <rect class="node" x="190" y="25" width="340" height="86" rx="43"/>
-    <text class="label" x="360" y="69">Idea or problem</text>
-    <path class="arrow" d="M360 111 L360 153"/>
-
-    <rect class="node" x="120" y="160" width="480" height="90" rx="14"/>
-    <text class="label" x="360" y="205">PRD authoring or /design</text>
-    <path class="arrow" d="M360 250 L360 292"/>
-
-    <rect class="node node-source" x="120" y="300" width="480" height="90" rx="14"/>
-    <text class="label" x="360" y="345">Canonical Markdown</text>
-    <path class="arrow" d="M360 390 L360 432"/>
-
-    <rect class="node" x="120" y="440" width="480" height="90" rx="14"/>
-    <text class="label" x="360" y="485">/html-doc</text>
-    <path class="arrow" d="M360 530 L360 572"/>
-
-    <rect class="node node-output" x="120" y="580" width="480" height="90" rx="14"/>
-    <text class="label" x="360" y="625">Generated HTML</text>
-    <path class="arrow" d="M360 670 L360 712"/>
-
-    <rect class="node" x="190" y="720" width="340" height="86" rx="43"/>
-    <text class="label" x="360" y="764">Human review</text>
-
-    <path class="return" d="M530 763 C670 763 674 345 610 345"/>
-    <rect x="552" y="510" width="145" height="54" rx="27" fill="#fbfcfd" stroke="#c7d2d9"/>
-    <text class="small-label" x="624" y="543">content changes</text>
-  </svg>
-  <figcaption id="flow-caption">Meaning stays in Markdown. HTML is the human reading view.</figcaption>
-</figure>
-
+</section>
+<figure class="diagram source-block" data-source-sha256="f09900d2595c17f1942bd5b1a12b147e293b0c3243668025ab15fbe9fa192eda" data-source-block="11"><img alt="Diagram 1 showing Idea or problem, PRD authoring or /design, Canonical Markdown, /html-doc, Generated HTML, Human review, content changes" src="data:image/svg+xml;base64,PHN2ZyBpZD0ibXktc3ZnIiB3aWR0aD0iMTAwJSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgY2xhc3M9ImZsb3djaGFydCIgc3R5bGU9Im1heC13aWR0aDogMTQ2Mi40M3B4OyBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDsiIHZpZXdCb3g9IjAgMCAxNDYyLjQzMjg2MTMyODEyNSAxMTMiIHJvbGU9ImdyYXBoaWNzLWRvY3VtZW50IGRvY3VtZW50IiBhcmlhLXJvbGVkZXNjcmlwdGlvbj0iZmxvd2NoYXJ0LXYyIj48c3R5bGU+I215LXN2Z3tmb250LWZhbWlseTpJbnRlcix1aS1zYW5zLXNlcmlmLHN5c3RlbS11aSxzYW5zLXNlcmlmO2ZvbnQtc2l6ZToxNnB4O2ZpbGw6IzE3MjYzMDt9QGtleWZyYW1lcyBlZGdlLWFuaW1hdGlvbi1mcmFtZXtmcm9te3N0cm9rZS1kYXNob2Zmc2V0OjA7fX1Aa2V5ZnJhbWVzIGRhc2h7dG97c3Ryb2tlLWRhc2hvZmZzZXQ6MDt9fSNteS1zdmcgLmVkZ2UtYW5pbWF0aW9uLXNsb3d7c3Ryb2tlLWRhc2hhcnJheTo5LDUhaW1wb3J0YW50O3N0cm9rZS1kYXNob2Zmc2V0OjkwMDthbmltYXRpb246ZGFzaCA1MHMgbGluZWFyIGluZmluaXRlO3N0cm9rZS1saW5lY2FwOnJvdW5kO30jbXktc3ZnIC5lZGdlLWFuaW1hdGlvbi1mYXN0e3N0cm9rZS1kYXNoYXJyYXk6OSw1IWltcG9ydGFudDtzdHJva2UtZGFzaG9mZnNldDo5MDA7YW5pbWF0aW9uOmRhc2ggMjBzIGxpbmVhciBpbmZpbml0ZTtzdHJva2UtbGluZWNhcDpyb3VuZDt9I215LXN2ZyAuZXJyb3ItaWNvbntmaWxsOiNmN2Y5ZmI7fSNteS1zdmcgLmVycm9yLXRleHR7ZmlsbDojMDgwNjA0O3N0cm9rZTojMDgwNjA0O30jbXktc3ZnIC5lZGdlLXRoaWNrbmVzcy1ub3JtYWx7c3Ryb2tlLXdpZHRoOjFweDt9I215LXN2ZyAuZWRnZS10aGlja25lc3MtdGhpY2t7c3Ryb2tlLXdpZHRoOjMuNXB4O30jbXktc3ZnIC5lZGdlLXBhdHRlcm4tc29saWR7c3Ryb2tlLWRhc2hhcnJheTowO30jbXktc3ZnIC5lZGdlLXRoaWNrbmVzcy1pbnZpc2libGV7c3Ryb2tlLXdpZHRoOjA7ZmlsbDpub25lO30jbXktc3ZnIC5lZGdlLXBhdHRlcm4tZGFzaGVke3N0cm9rZS1kYXNoYXJyYXk6Mzt9I215LXN2ZyAuZWRnZS1wYXR0ZXJuLWRvdHRlZHtzdHJva2UtZGFzaGFycmF5OjI7fSNteS1zdmcgLm1hcmtlcntmaWxsOiM1MjZhNzk7c3Ryb2tlOiM1MjZhNzk7fSNteS1zdmcgLm1hcmtlci5jcm9zc3tzdHJva2U6IzUyNmE3OTt9I215LXN2ZyBzdmd7Zm9udC1mYW1pbHk6SW50ZXIsdWktc2Fucy1zZXJpZixzeXN0ZW0tdWksc2Fucy1zZXJpZjtmb250LXNpemU6MTZweDt9I215LXN2ZyBwe21hcmdpbjowO30jbXktc3ZnIC5sYWJlbHtmb250LWZhbWlseTpJbnRlcix1aS1zYW5zLXNlcmlmLHN5c3RlbS11aSxzYW5zLXNlcmlmO2NvbG9yOiMxNzI2MzA7fSNteS1zdmcgLmNsdXN0ZXItbGFiZWwgdGV4dHtmaWxsOiMwODA2MDQ7fSNteS1zdmcgLmNsdXN0ZXItbGFiZWwgc3Bhbntjb2xvcjojMDgwNjA0O30jbXktc3ZnIC5jbHVzdGVyLWxhYmVsIHNwYW4gcHtiYWNrZ3JvdW5kLWNvbG9yOnRyYW5zcGFyZW50O30jbXktc3ZnIC5sYWJlbCB0ZXh0LCNteS1zdmcgc3BhbntmaWxsOiMxNzI2MzA7Y29sb3I6IzE3MjYzMDt9I215LXN2ZyAubm9kZSByZWN0LCNteS1zdmcgLm5vZGUgY2lyY2xlLCNteS1zdmcgLm5vZGUgZWxsaXBzZSwjbXktc3ZnIC5ub2RlIHBvbHlnb24sI215LXN2ZyAubm9kZSBwYXRoe2ZpbGw6I2RiZTVlYztzdHJva2U6IzYwNzk4YTtzdHJva2Utd2lkdGg6MXB4O30jbXktc3ZnIC5yb3VnaC1ub2RlIC5sYWJlbCB0ZXh0LCNteS1zdmcgLm5vZGUgLmxhYmVsIHRleHQsI215LXN2ZyAuaW1hZ2Utc2hhcGUgLmxhYmVsLCNteS1zdmcgLmljb24tc2hhcGUgLmxhYmVse3RleHQtYW5jaG9yOm1pZGRsZTt9I215LXN2ZyAubm9kZSAua2F0ZXggcGF0aHtmaWxsOiMwMDA7c3Ryb2tlOiMwMDA7c3Ryb2tlLXdpZHRoOjFweDt9I215LXN2ZyAucm91Z2gtbm9kZSAubGFiZWwsI215LXN2ZyAubm9kZSAubGFiZWwsI215LXN2ZyAuaW1hZ2Utc2hhcGUgLmxhYmVsLCNteS1zdmcgLmljb24tc2hhcGUgLmxhYmVse3RleHQtYWxpZ246Y2VudGVyO30jbXktc3ZnIC5ub2RlLmNsaWNrYWJsZXtjdXJzb3I6cG9pbnRlcjt9I215LXN2ZyAucm9vdCAuYW5jaG9yIHBhdGh7ZmlsbDojNTI2YTc5IWltcG9ydGFudDtzdHJva2Utd2lkdGg6MDtzdHJva2U6IzUyNmE3OTt9I215LXN2ZyAuYXJyb3doZWFkUGF0aHtmaWxsOiMwODA2MDQ7fSNteS1zdmcgLmVkZ2VQYXRoIC5wYXRoe3N0cm9rZTojNTI2YTc5O3N0cm9rZS13aWR0aDoxcHg7fSNteS1zdmcgLmZsb3djaGFydC1saW5re3N0cm9rZTojNTI2YTc5O2ZpbGw6bm9uZTt9I215LXN2ZyAuZWRnZUxhYmVse2JhY2tncm91bmQtY29sb3I6I2VkZjJmNTt0ZXh0LWFsaWduOmNlbnRlcjt9I215LXN2ZyAuZWRnZUxhYmVsIHB7YmFja2dyb3VuZC1jb2xvcjojZWRmMmY1O30jbXktc3ZnIC5lZGdlTGFiZWwgcmVjdHtvcGFjaXR5OjAuNTtiYWNrZ3JvdW5kLWNvbG9yOiNlZGYyZjU7ZmlsbDojZWRmMmY1O30jbXktc3ZnIC5sYWJlbEJrZ3tiYWNrZ3JvdW5kLWNvbG9yOnJnYmEoMjM3LCAyNDIsIDI0NSwgMC41KTt9I215LXN2ZyAuY2x1c3RlciByZWN0e2ZpbGw6I2Y3ZjlmYjtzdHJva2U6aHNsKDIxMCwgMCUsIDg3LjY0NzA1ODgyMzUlKTtzdHJva2Utd2lkdGg6MXB4O30jbXktc3ZnIC5jbHVzdGVyIHRleHR7ZmlsbDojMDgwNjA0O30jbXktc3ZnIC5jbHVzdGVyIHNwYW57Y29sb3I6IzA4MDYwNDt9I215LXN2ZyBkaXYubWVybWFpZFRvb2x0aXB7cG9zaXRpb246YWJzb2x1dGU7dGV4dC1hbGlnbjpjZW50ZXI7bWF4LXdpZHRoOjIwMHB4O3BhZGRpbmc6MnB4O2ZvbnQtZmFtaWx5OkludGVyLHVpLXNhbnMtc2VyaWYsc3lzdGVtLXVpLHNhbnMtc2VyaWY7Zm9udC1zaXplOjEycHg7YmFja2dyb3VuZDojZjdmOWZiO2JvcmRlcjoxcHggc29saWQgaHNsKDIxMCwgMCUsIDg3LjY0NzA1ODgyMzUlKTtib3JkZXItcmFkaXVzOjJweDtwb2ludGVyLWV2ZW50czpub25lO3otaW5kZXg6MTAwO30jbXktc3ZnIC5mbG93Y2hhcnRUaXRsZVRleHR7dGV4dC1hbmNob3I6bWlkZGxlO2ZvbnQtc2l6ZToxOHB4O2ZpbGw6IzE3MjYzMDt9I215LXN2ZyByZWN0LnRleHR7ZmlsbDpub25lO3N0cm9rZS13aWR0aDowO30jbXktc3ZnIC5pY29uLXNoYXBlLCNteS1zdmcgLmltYWdlLXNoYXBle2JhY2tncm91bmQtY29sb3I6I2VkZjJmNTt0ZXh0LWFsaWduOmNlbnRlcjt9I215LXN2ZyAuaWNvbi1zaGFwZSBwLCNteS1zdmcgLmltYWdlLXNoYXBlIHB7YmFja2dyb3VuZC1jb2xvcjojZWRmMmY1O3BhZGRpbmc6MnB4O30jbXktc3ZnIC5pY29uLXNoYXBlIC5sYWJlbCByZWN0LCNteS1zdmcgLmltYWdlLXNoYXBlIC5sYWJlbCByZWN0e29wYWNpdHk6MC41O2JhY2tncm91bmQtY29sb3I6I2VkZjJmNTtmaWxsOiNlZGYyZjU7fSNteS1zdmcgLmxhYmVsLWljb257ZGlzcGxheTppbmxpbmUtYmxvY2s7aGVpZ2h0OjFlbTtvdmVyZmxvdzp2aXNpYmxlO3ZlcnRpY2FsLWFsaWduOi0wLjEyNWVtO30jbXktc3ZnIC5ub2RlIC5sYWJlbC1pY29uIHBhdGh7ZmlsbDpjdXJyZW50Q29sb3I7c3Ryb2tlOnJldmVydDtzdHJva2Utd2lkdGg6cmV2ZXJ0O30jbXktc3ZnIC5ub2RlIC5uZW8tbm9kZXtzdHJva2U6IzYwNzk4YTt9I215LXN2ZyBbZGF0YS1sb29rPSJuZW8iXS5ub2RlIHJlY3QsI215LXN2ZyBbZGF0YS1sb29rPSJuZW8iXS5jbHVzdGVyIHJlY3QsI215LXN2ZyBbZGF0YS1sb29rPSJuZW8iXS5ub2RlIHBvbHlnb257c3Ryb2tlOnVybCgjbXktc3ZnLWdyYWRpZW50KTtmaWx0ZXI6ZHJvcC1zaGFkb3coIDFweCAycHggMnB4IHJnYmEoMTg1LDE4NSwxODUsMSkpO30jbXktc3ZnIFtkYXRhLWxvb2s9Im5lbyJdLnN3aW1sYW5lLmNsdXN0ZXIgcmVjdHtmaWx0ZXI6bm9uZTt9I215LXN2ZyBbZGF0YS1sb29rPSJuZW8iXS5ub2RlIHBhdGh7c3Ryb2tlOnVybCgjbXktc3ZnLWdyYWRpZW50KTtzdHJva2Utd2lkdGg6MXB4O30jbXktc3ZnIFtkYXRhLWxvb2s9Im5lbyJdLm5vZGUgLm91dGVyLXBhdGh7ZmlsdGVyOmRyb3Atc2hhZG93KCAxcHggMnB4IDJweCByZ2JhKDE4NSwxODUsMTg1LDEpKTt9I215LXN2ZyBbZGF0YS1sb29rPSJuZW8iXS5ub2RlIC5uZW8tbGluZSBwYXRoe3N0cm9rZTojNjA3OThhO2ZpbHRlcjpub25lO30jbXktc3ZnIFtkYXRhLWxvb2s9Im5lbyJdLm5vZGUgY2lyY2xle3N0cm9rZTp1cmwoI215LXN2Zy1ncmFkaWVudCk7ZmlsdGVyOmRyb3Atc2hhZG93KCAxcHggMnB4IDJweCByZ2JhKDE4NSwxODUsMTg1LDEpKTt9I215LXN2ZyBbZGF0YS1sb29rPSJuZW8iXS5ub2RlIGNpcmNsZSAuc3RhdGUtc3RhcnR7ZmlsbDojMDAwMDAwO30jbXktc3ZnIFtkYXRhLWxvb2s9Im5lbyJdLmljb24tc2hhcGUgLmljb257ZmlsbDp1cmwoI215LXN2Zy1ncmFkaWVudCk7ZmlsdGVyOmRyb3Atc2hhZG93KCAxcHggMnB4IDJweCByZ2JhKDE4NSwxODUsMTg1LDEpKTt9I215LXN2ZyBbZGF0YS1sb29rPSJuZW8iXS5pY29uLXNoYXBlIC5pY29uLW5lbyBwYXRoe3N0cm9rZTp1cmwoI215LXN2Zy1ncmFkaWVudCk7ZmlsdGVyOmRyb3Atc2hhZG93KCAxcHggMnB4IDJweCByZ2JhKDE4NSwxODUsMTg1LDEpKTt9I215LXN2ZyA6cm9vdHstLW1lcm1haWQtZm9udC1mYW1pbHk6InRyZWJ1Y2hldCBtcyIsdmVyZGFuYSxhcmlhbCxzYW5zLXNlcmlmO308L3N0eWxlPjxnPjxtYXJrZXIgaWQ9Im15LXN2Z19mbG93Y2hhcnQtdjItcG9pbnRFbmQiIGNsYXNzPSJtYXJrZXIgZmxvd2NoYXJ0LXYyIiB2aWV3Qm94PSIwIDAgMTAgMTAiIHJlZlg9IjUiIHJlZlk9IjUiIG1hcmtlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgbWFya2VyV2lkdGg9IjgiIG1hcmtlckhlaWdodD0iOCIgb3JpZW50PSJhdXRvIj48cGF0aCBkPSJNIDAgMCBMIDEwIDUgTCAwIDEwIHoiIGNsYXNzPSJhcnJvd01hcmtlclBhdGgiIHN0eWxlPSJzdHJva2Utd2lkdGg6IDE7IHN0cm9rZS1kYXNoYXJyYXk6IDEsIDA7Ii8+PC9tYXJrZXI+PG1hcmtlciBpZD0ibXktc3ZnX2Zsb3djaGFydC12Mi1wb2ludFN0YXJ0IiBjbGFzcz0ibWFya2VyIGZsb3djaGFydC12MiIgdmlld0JveD0iMCAwIDEwIDEwIiByZWZYPSI0LjUiIHJlZlk9IjUiIG1hcmtlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgbWFya2VyV2lkdGg9IjgiIG1hcmtlckhlaWdodD0iOCIgb3JpZW50PSJhdXRvIj48cGF0aCBkPSJNIDAgNSBMIDEwIDEwIEwgMTAgMCB6IiBjbGFzcz0iYXJyb3dNYXJrZXJQYXRoIiBzdHlsZT0ic3Ryb2tlLXdpZHRoOiAxOyBzdHJva2UtZGFzaGFycmF5OiAxLCAwOyIvPjwvbWFya2VyPjxtYXJrZXIgaWQ9Im15LXN2Z19mbG93Y2hhcnQtdjItcG9pbnRFbmQtbWFyZ2luIiBjbGFzcz0ibWFya2VyIGZsb3djaGFydC12MiIgdmlld0JveD0iMCAwIDExLjUgMTQiIHJlZlg9IjExLjUiIHJlZlk9IjciIG1hcmtlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgbWFya2VyV2lkdGg9IjEwLjUiIG1hcmtlckhlaWdodD0iMTQiIG9yaWVudD0iYXV0byI+PHBhdGggZD0iTSAwIDAgTCAxMS41IDcgTCAwIDE0IHoiIGNsYXNzPSJhcnJvd01hcmtlclBhdGgiIHN0eWxlPSJzdHJva2Utd2lkdGg6IDA7IHN0cm9rZS1kYXNoYXJyYXk6IDEsIDA7Ii8+PC9tYXJrZXI+PG1hcmtlciBpZD0ibXktc3ZnX2Zsb3djaGFydC12Mi1wb2ludFN0YXJ0LW1hcmdpbiIgY2xhc3M9Im1hcmtlciBmbG93Y2hhcnQtdjIiIHZpZXdCb3g9IjAgMCAxMS41IDE0IiByZWZYPSIxIiByZWZZPSI3IiBtYXJrZXJVbml0cz0idXNlclNwYWNlT25Vc2UiIG1hcmtlcldpZHRoPSIxMS41IiBtYXJrZXJIZWlnaHQ9IjE0IiBvcmllbnQ9ImF1dG8iPjxwb2x5Z29uIHBvaW50cz0iMCw3IDExLjUsMTQgMTEuNSwwIiBjbGFzcz0iYXJyb3dNYXJrZXJQYXRoIiBzdHlsZT0ic3Ryb2tlLXdpZHRoOiAwOyBzdHJva2UtZGFzaGFycmF5OiAxLCAwOyIvPjwvbWFya2VyPjxtYXJrZXIgaWQ9Im15LXN2Z19mbG93Y2hhcnQtdjItY2lyY2xlRW5kIiBjbGFzcz0ibWFya2VyIGZsb3djaGFydC12MiIgdmlld0JveD0iMCAwIDEwIDEwIiByZWZYPSIxMSIgcmVmWT0iNSIgbWFya2VyVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBtYXJrZXJXaWR0aD0iMTEiIG1hcmtlckhlaWdodD0iMTEiIG9yaWVudD0iYXV0byI+PGNpcmNsZSBjeD0iNSIgY3k9IjUiIHI9IjUiIGNsYXNzPSJhcnJvd01hcmtlclBhdGgiIHN0eWxlPSJzdHJva2Utd2lkdGg6IDE7IHN0cm9rZS1kYXNoYXJyYXk6IDEsIDA7Ii8+PC9tYXJrZXI+PG1hcmtlciBpZD0ibXktc3ZnX2Zsb3djaGFydC12Mi1jaXJjbGVTdGFydCIgY2xhc3M9Im1hcmtlciBmbG93Y2hhcnQtdjIiIHZpZXdCb3g9IjAgMCAxMCAxMCIgcmVmWD0iLTEiIHJlZlk9IjUiIG1hcmtlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgbWFya2VyV2lkdGg9IjExIiBtYXJrZXJIZWlnaHQ9IjExIiBvcmllbnQ9ImF1dG8iPjxjaXJjbGUgY3g9IjUiIGN5PSI1IiByPSI1IiBjbGFzcz0iYXJyb3dNYXJrZXJQYXRoIiBzdHlsZT0ic3Ryb2tlLXdpZHRoOiAxOyBzdHJva2UtZGFzaGFycmF5OiAxLCAwOyIvPjwvbWFya2VyPjxtYXJrZXIgaWQ9Im15LXN2Z19mbG93Y2hhcnQtdjItY2lyY2xlRW5kLW1hcmdpbiIgY2xhc3M9Im1hcmtlciBmbG93Y2hhcnQtdjIiIHZpZXdCb3g9IjAgMCAxMCAxMCIgcmVmWT0iNSIgcmVmWD0iMTIuMjUiIG1hcmtlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgbWFya2VyV2lkdGg9IjE0IiBtYXJrZXJIZWlnaHQ9IjE0IiBvcmllbnQ9ImF1dG8iPjxjaXJjbGUgY3g9IjUiIGN5PSI1IiByPSI1IiBjbGFzcz0iYXJyb3dNYXJrZXJQYXRoIiBzdHlsZT0ic3Ryb2tlLXdpZHRoOiAwOyBzdHJva2UtZGFzaGFycmF5OiAxLCAwOyIvPjwvbWFya2VyPjxtYXJrZXIgaWQ9Im15LXN2Z19mbG93Y2hhcnQtdjItY2lyY2xlU3RhcnQtbWFyZ2luIiBjbGFzcz0ibWFya2VyIGZsb3djaGFydC12MiIgdmlld0JveD0iMCAwIDEwIDEwIiByZWZYPSItMiIgcmVmWT0iNSIgbWFya2VyVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBtYXJrZXJXaWR0aD0iMTQiIG1hcmtlckhlaWdodD0iMTQiIG9yaWVudD0iYXV0byI+PGNpcmNsZSBjeD0iNSIgY3k9IjUiIHI9IjUiIGNsYXNzPSJhcnJvd01hcmtlclBhdGgiIHN0eWxlPSJzdHJva2Utd2lkdGg6IDA7IHN0cm9rZS1kYXNoYXJyYXk6IDEsIDA7Ii8+PC9tYXJrZXI+PG1hcmtlciBpZD0ibXktc3ZnX2Zsb3djaGFydC12Mi1jcm9zc0VuZCIgY2xhc3M9Im1hcmtlciBjcm9zcyBmbG93Y2hhcnQtdjIiIHZpZXdCb3g9IjAgMCAxMSAxMSIgcmVmWD0iMTIiIHJlZlk9IjUuMiIgbWFya2VyVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBtYXJrZXJXaWR0aD0iMTEiIG1hcmtlckhlaWdodD0iMTEiIG9yaWVudD0iYXV0byI+PHBhdGggZD0iTSAxLDEgbCA5LDkgTSAxMCwxIGwgLTksOSIgY2xhc3M9ImFycm93TWFya2VyUGF0aCIgc3R5bGU9InN0cm9rZS13aWR0aDogMjsgc3Ryb2tlLWRhc2hhcnJheTogMSwgMDsiLz48L21hcmtlcj48bWFya2VyIGlkPSJteS1zdmdfZmxvd2NoYXJ0LXYyLWNyb3NzU3RhcnQiIGNsYXNzPSJtYXJrZXIgY3Jvc3MgZmxvd2NoYXJ0LXYyIiB2aWV3Qm94PSIwIDAgMTEgMTEiIHJlZlg9Ii0xIiByZWZZPSI1LjIiIG1hcmtlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgbWFya2VyV2lkdGg9IjExIiBtYXJrZXJIZWlnaHQ9IjExIiBvcmllbnQ9ImF1dG8iPjxwYXRoIGQ9Ik0gMSwxIGwgOSw5IE0gMTAsMSBsIC05LDkiIGNsYXNzPSJhcnJvd01hcmtlclBhdGgiIHN0eWxlPSJzdHJva2Utd2lkdGg6IDI7IHN0cm9rZS1kYXNoYXJyYXk6IDEsIDA7Ii8+PC9tYXJrZXI+PG1hcmtlciBpZD0ibXktc3ZnX2Zsb3djaGFydC12Mi1jcm9zc0VuZC1tYXJnaW4iIGNsYXNzPSJtYXJrZXIgY3Jvc3MgZmxvd2NoYXJ0LXYyIiB2aWV3Qm94PSIwIDAgMTUgMTUiIHJlZlg9IjE3LjciIHJlZlk9IjcuNSIgbWFya2VyVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBtYXJrZXJXaWR0aD0iMTIiIG1hcmtlckhlaWdodD0iMTIiIG9yaWVudD0iYXV0byI+PHBhdGggZD0iTSAxLDEgTCAxNCwxNCBNIDEsMTQgTCAxNCwxIiBjbGFzcz0iYXJyb3dNYXJrZXJQYXRoIiBzdHlsZT0ic3Ryb2tlLXdpZHRoOiAyLjU7Ii8+PC9tYXJrZXI+PG1hcmtlciBpZD0ibXktc3ZnX2Zsb3djaGFydC12Mi1jcm9zc1N0YXJ0LW1hcmdpbiIgY2xhc3M9Im1hcmtlciBjcm9zcyBmbG93Y2hhcnQtdjIiIHZpZXdCb3g9IjAgMCAxNSAxNSIgcmVmWD0iLTMuNSIgcmVmWT0iNy41IiBtYXJrZXJVbml0cz0idXNlclNwYWNlT25Vc2UiIG1hcmtlcldpZHRoPSIxMiIgbWFya2VySGVpZ2h0PSIxMiIgb3JpZW50PSJhdXRvIj48cGF0aCBkPSJNIDEsMSBMIDE0LDE0IE0gMSwxNCBMIDE0LDEiIGNsYXNzPSJhcnJvd01hcmtlclBhdGgiIHN0eWxlPSJzdHJva2Utd2lkdGg6IDIuNTsgc3Ryb2tlLWRhc2hhcnJheTogMSwgMDsiLz48L21hcmtlcj48ZyBjbGFzcz0icm9vdCI+PGcgY2xhc3M9ImNsdXN0ZXJzIi8+PGcgY2xhc3M9ImVkZ2VQYXRocyI+PHBhdGggZD0iTTE1MS4xNyw2My41TDE1NS4yNTMsNjMuNDE3QzE1OS4zMzYsNjMuMzMzLDE2Ny41MDMsNjMuMTY3LDE3NS4wODYsNjMuMDgzQzE4Mi42Nyw2MywxODkuNjcsNjMsMTkzLjE3LDYzTDE5Ni42Nyw2MyIgaWQ9Im15LXN2Zy1MX0JyaWVmX0F1dGhvcl8wIiBjbGFzcz0iZWRnZS10aGlja25lc3Mtbm9ybWFsIGVkZ2UtcGF0dGVybi1zb2xpZCBlZGdlLXRoaWNrbmVzcy1ub3JtYWwgZWRnZS1wYXR0ZXJuLXNvbGlkIGZsb3djaGFydC1saW5rIiBzdHlsZT0iOyIgZGF0YS1lZGdlPSJ0cnVlIiBkYXRhLWV0PSJlZGdlIiBkYXRhLWlkPSJMX0JyaWVmX0F1dGhvcl8wIiBkYXRhLXBvaW50cz0iVzNzaWVDSTZNVFV4TGpFMk9UVXhOelUyTnpBeU5ESXNJbmtpT2pZekxqUTVPVGs1T1RrNU9UazVPVGs1ZlN4N0luZ2lPakUzTlM0Mk5qazFNalV4TkRZME9EUXpPQ3dpZVNJNk5qTjlMSHNpZUNJNk1qQXdMalkyT1RVeU5URTBOalE0TkRNNExDSjVJam8yTTMxZCIgZGF0YS1sb29rPSJjbGFzc2ljIiBtYXJrZXItZW5kPSJ1cmwoI215LXN2Z19mbG93Y2hhcnQtdjItcG9pbnRFbmQpIi8+PHBhdGggZD0iTTQ0OS45ODIsNjNMNDU0LjE0OSw2M0M0NTguMzE1LDYzLDQ2Ni42NDksNjMsNDc0LjMxNSw2M0M0ODEuOTgyLDYzLDQ4OC45ODIsNjMsNDkyLjQ4Miw2M0w0OTUuOTgyLDYzIiBpZD0ibXktc3ZnLUxfQXV0aG9yX1NvdXJjZV8wIiBjbGFzcz0iZWRnZS10aGlja25lc3Mtbm9ybWFsIGVkZ2UtcGF0dGVybi1zb2xpZCBlZGdlLXRoaWNrbmVzcy1ub3JtYWwgZWRnZS1wYXR0ZXJuLXNvbGlkIGZsb3djaGFydC1saW5rIiBzdHlsZT0iOyIgZGF0YS1lZGdlPSJ0cnVlIiBkYXRhLWV0PSJlZGdlIiBkYXRhLWlkPSJMX0F1dGhvcl9Tb3VyY2VfMCIgZGF0YS1wb2ludHM9Ilczc2llQ0k2TkRRNUxqazRNakF5TlRFME5qUTRORFFzSW5raU9qWXpmU3g3SW5naU9qUTNOQzQ1T0RJd01qVXhORFkwT0RRMExDSjVJam8yTTMwc2V5SjRJam8wT1RrdU9UZ3lNREkxTVRRMk5EZzBOQ3dpZVNJNk5qTjlYUT09IiBkYXRhLWxvb2s9ImNsYXNzaWMiIG1hcmtlci1lbmQ9InVybCgjbXktc3ZnX2Zsb3djaGFydC12Mi1wb2ludEVuZCkiLz48cGF0aCBkPSJNNzE4LjA2LDM4LjU5NUw3MjIuMjI3LDM3LjY2M0M3MjYuMzkzLDM2LjczLDczNC43MjcsMzQuODY1LDc0Mi4zOTMsMzMuOTMzQzc1MC4wNiwzMyw3NTcuMDYsMzMsNzYwLjU2LDMzTDc2NC4wNiwzMyIgaWQ9Im15LXN2Zy1MX1NvdXJjZV9Ta2lsbF8wIiBjbGFzcz0iZWRnZS10aGlja25lc3Mtbm9ybWFsIGVkZ2UtcGF0dGVybi1zb2xpZCBlZGdlLXRoaWNrbmVzcy1ub3JtYWwgZWRnZS1wYXR0ZXJuLXNvbGlkIGZsb3djaGFydC1saW5rIiBzdHlsZT0iOyIgZGF0YS1lZGdlPSJ0cnVlIiBkYXRhLWV0PSJlZGdlIiBkYXRhLWlkPSJMX1NvdXJjZV9Ta2lsbF8wIiBkYXRhLXBvaW50cz0iVzNzaWVDSTZOekU0TGpBMk1ERTFNREUwTmpRNE5EUXNJbmtpT2pNNExqVTVOVE00TXpnd09ETTFPREV4ZlN4N0luZ2lPamMwTXk0d05qQXhOVEF4TkRZME9EUTBMQ0o1SWpvek0zMHNleUo0SWpvM05qZ3VNRFl3TVRVd01UUTJORGcwTkN3aWVTSTZNek45WFE9PSIgZGF0YS1sb29rPSJjbGFzc2ljIiBtYXJrZXItZW5kPSJ1cmwoI215LXN2Z19mbG93Y2hhcnQtdjItcG9pbnRFbmQpIi8+PHBhdGggZD0iTTkwMi41MjksMzNMOTE3LjU5NSwzM0M5MzIuNjYyLDMzLDk2Mi43OTUsMzMsOTkyLjI2MSwzM0MxMDIxLjcyNywzMywxMDUwLjUyNiwzMywxMDY0LjkyNiwzM0wxMDc5LjMyNiwzMyIgaWQ9Im15LXN2Zy1MX1NraWxsX1BhZ2VfMCIgY2xhc3M9ImVkZ2UtdGhpY2tuZXNzLW5vcm1hbCBlZGdlLXBhdHRlcm4tc29saWQgZWRnZS10aGlja25lc3Mtbm9ybWFsIGVkZ2UtcGF0dGVybi1zb2xpZCBmbG93Y2hhcnQtbGluayIgc3R5bGU9IjsiIGRhdGEtZWRnZT0idHJ1ZSIgZGF0YS1ldD0iZWRnZSIgZGF0YS1pZD0iTF9Ta2lsbF9QYWdlXzAiIGRhdGEtcG9pbnRzPSJXM3NpZUNJNk9UQXlMalV5T0Rrd01ERTBOalE0TkRRc0lua2lPak16ZlN4N0luZ2lPams1TWk0NU1qY3pNemMyTkRZME9EUTBMQ0o1SWpvek0zMHNleUo0SWpveE1EZ3pMak15TlRjM05URTBOalE0TkRRc0lua2lPak16ZlYwPSIgZGF0YS1sb29rPSJjbGFzc2ljIiBtYXJrZXItZW5kPSJ1cmwoI215LXN2Z19mbG93Y2hhcnQtdjItcG9pbnRFbmQpIi8+PHBhdGggZD0iTTEyNzMuMDEzLDMzTDEyNzcuMTgsMzNDMTI4MS4zNDcsMzMsMTI4OS42OCwzMywxMjk5Ljc4NiwzNS4wMTVDMTMwOS44OTIsMzcuMDI5LDEzMjEuNzcxLDQxLjA1OSwxMzI3LjcxLDQzLjA3NEwxMzMzLjY1LDQ1LjA4OCIgaWQ9Im15LXN2Zy1MX1BhZ2VfUmV2aWV3XzAiIGNsYXNzPSJlZGdlLXRoaWNrbmVzcy1ub3JtYWwgZWRnZS1wYXR0ZXJuLXNvbGlkIGVkZ2UtdGhpY2tuZXNzLW5vcm1hbCBlZGdlLXBhdHRlcm4tc29saWQgZmxvd2NoYXJ0LWxpbmsiIHN0eWxlPSI7IiBkYXRhLWVkZ2U9InRydWUiIGRhdGEtZXQ9ImVkZ2UiIGRhdGEtaWQ9IkxfUGFnZV9SZXZpZXdfMCIgZGF0YS1wb2ludHM9Ilczc2llQ0k2TVRJM015NHdNVE15TnpVeE5EWTBPRFEwTENKNUlqb3pNMzBzZXlKNElqb3hNams0TGpBeE16STNOVEUwTmpRNE5EUXNJbmtpT2pNemZTeDdJbmdpT2pFek16Y3VORE0zTlRrek5UazFORFl3T0N3aWVTSTZORFl1TXpjek1qVXhNVEk1TVRNeU1URTFmVjA9IiBkYXRhLWxvb2s9ImNsYXNzaWMiIG1hcmtlci1lbmQ9InVybCgjbXktc3ZnX2Zsb3djaGFydC12Mi1wb2ludEVuZCkiLz48cGF0aCBkPSJNMTMzNy40MzgsODAuNjI3TDEzMzAuODY3LDgyLjY4OUMxMzI0LjI5Niw4NC43NTEsMTMxMS4xNTUsODguODc2LDEyODQuNjEsOTAuOTM4QzEyNTguMDY1LDkzLDEyMTguMTE3LDkzLDExNjcuMjcsOTNDMTExNi40MjIsOTMsMTA1NC42NzUsOTMsOTk3LjUyOSw5M0M5NDAuMzgzLDkzLDg4Ny44MzksOTMsODQ2LjE5NCw5M0M4MDQuNTUsOTMsNzczLjgwNSw5Myw3NTQuOTE2LDkyLjIxM0M3MzYuMDI4LDkxLjQyNiw3MjguOTk2LDg5Ljg1Miw3MjUuNDgsODkuMDY1TDcyMS45NjQsODguMjc4IiBpZD0ibXktc3ZnLUxfUmV2aWV3X1NvdXJjZV8wIiBjbGFzcz0iZWRnZS10aGlja25lc3Mtbm9ybWFsIGVkZ2UtcGF0dGVybi1zb2xpZCBlZGdlLXRoaWNrbmVzcy1ub3JtYWwgZWRnZS1wYXR0ZXJuLXNvbGlkIGZsb3djaGFydC1saW5rIiBzdHlsZT0iOyIgZGF0YS1lZGdlPSJ0cnVlIiBkYXRhLWV0PSJlZGdlIiBkYXRhLWlkPSJMX1Jldmlld19Tb3VyY2VfMCIgZGF0YS1wb2ludHM9Ilczc2llQ0k2TVRNek55NDBNemMxT1RNMU9UVTBOVFkxTENKNUlqbzRNQzQyTWpZM05EZzROekE0Tmprek9IMHNleUo0SWpveE1qazRMakF4TXpJM05URTBOalE0TkRRc0lua2lPamt6ZlN4N0luZ2lPakV4TnpndU1UWTVOVEkxTVRRMk5EZzBOQ3dpZVNJNk9UTjlMSHNpZUNJNk9Ua3lMamt5TnpNek56WTBOalE0TkRRc0lua2lPamt6ZlN4N0luZ2lPamd6TlM0eU9UUTFNalV4TkRZME9EUTBMQ0o1SWpvNU0zMHNleUo0SWpvM05ETXVNRFl3TVRVd01UUTJORGcwTkN3aWVTSTZPVE45TEhzaWVDSTZOekU0TGpBMk1ERTFNREUwTmpRNE5EUXNJbmtpT2pnM0xqUXdORFl4TmpFNU1UWTBNVGc1ZlYwPSIgZGF0YS1sb29rPSJjbGFzc2ljIiBtYXJrZXItZW5kPSJ1cmwoI215LXN2Z19mbG93Y2hhcnQtdjItcG9pbnRFbmQpIi8+PC9nPjxnIGNsYXNzPSJlZGdlTGFiZWxzIj48ZyBjbGFzcz0iZWRnZUxhYmVsIj48ZyBjbGFzcz0ibGFiZWwiIGRhdGEtaWQ9IkxfQnJpZWZfQXV0aG9yXzAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAsIDApIj48dGV4dCB5PSItMTAuMSIgdGV4dC1hbmNob3I9Im1pZGRsZSI+PHRzcGFuIGNsYXNzPSJ0ZXh0LW91dGVyLXRzcGFuIHJvdyIgeD0iMCIgeT0iLTAuMWVtIiBkeT0iMS4xZW0iIHRleHQtYW5jaG9yPSJtaWRkbGUiLz48L3RleHQ+PC9nPjwvZz48Zz48cmVjdCBjbGFzcz0iYmFja2dyb3VuZCIgc3R5bGU9InN0cm9rZTogbm9uZSIvPjwvZz48ZyBjbGFzcz0iZWRnZUxhYmVsIj48ZyBjbGFzcz0ibGFiZWwiIGRhdGEtaWQ9IkxfQXV0aG9yX1NvdXJjZV8wIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLCAwKSI+PHRleHQgeT0iLTEwLjEiIHRleHQtYW5jaG9yPSJtaWRkbGUiPjx0c3BhbiBjbGFzcz0idGV4dC1vdXRlci10c3BhbiByb3ciIHg9IjAiIHk9Ii0wLjFlbSIgZHk9IjEuMWVtIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIi8+PC90ZXh0PjwvZz48L2c+PGc+PHJlY3QgY2xhc3M9ImJhY2tncm91bmQiIHN0eWxlPSJzdHJva2U6IG5vbmUiLz48L2c+PGcgY2xhc3M9ImVkZ2VMYWJlbCI+PGcgY2xhc3M9ImxhYmVsIiBkYXRhLWlkPSJMX1NvdXJjZV9Ta2lsbF8wIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLCAwKSI+PHRleHQgeT0iLTEwLjEiIHRleHQtYW5jaG9yPSJtaWRkbGUiPjx0c3BhbiBjbGFzcz0idGV4dC1vdXRlci10c3BhbiByb3ciIHg9IjAiIHk9Ii0wLjFlbSIgZHk9IjEuMWVtIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIi8+PC90ZXh0PjwvZz48L2c+PGc+PHJlY3QgY2xhc3M9ImJhY2tncm91bmQiIHN0eWxlPSJzdHJva2U6IG5vbmUiLz48L2c+PGcgY2xhc3M9ImVkZ2VMYWJlbCI+PGcgY2xhc3M9ImxhYmVsIiBkYXRhLWlkPSJMX1NraWxsX1BhZ2VfMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCwgMCkiPjx0ZXh0IHk9Ii0xMC4xIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj48dHNwYW4gY2xhc3M9InRleHQtb3V0ZXItdHNwYW4gcm93IiB4PSIwIiB5PSItMC4xZW0iIGR5PSIxLjFlbSIgdGV4dC1hbmNob3I9Im1pZGRsZSIvPjwvdGV4dD48L2c+PC9nPjxnPjxyZWN0IGNsYXNzPSJiYWNrZ3JvdW5kIiBzdHlsZT0ic3Ryb2tlOiBub25lIi8+PC9nPjxnIGNsYXNzPSJlZGdlTGFiZWwiPjxnIGNsYXNzPSJsYWJlbCIgZGF0YS1pZD0iTF9QYWdlX1Jldmlld18wIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLCAwKSI+PHRleHQgeT0iLTEwLjEiIHRleHQtYW5jaG9yPSJtaWRkbGUiPjx0c3BhbiBjbGFzcz0idGV4dC1vdXRlci10c3BhbiByb3ciIHg9IjAiIHk9Ii0wLjFlbSIgZHk9IjEuMWVtIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIi8+PC90ZXh0PjwvZz48L2c+PGc+PHJlY3QgY2xhc3M9ImJhY2tncm91bmQiIHN0eWxlPSJzdHJva2U6IG5vbmUiLz48L2c+PGcgY2xhc3M9ImVkZ2VMYWJlbCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOTkyLjkyNzMzNzY0NjQ4NDQsIDkzKSI+PGcgY2xhc3M9ImxhYmVsIiBkYXRhLWlkPSJMX1Jldmlld19Tb3VyY2VfMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCwgLTEwKSI+PGc+PHJlY3QgY2xhc3M9ImJhY2tncm91bmQiIHN0eWxlPSIiIHg9Ii02NS4zOTg0Mzc1IiB5PSItMiIgd2lkdGg9IjEzMC43OTY4NzUiIGhlaWdodD0iMjQiLz48dGV4dCB5PSItMTAuMSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgc3R5bGU9IiI+PHRzcGFuIGNsYXNzPSJ0ZXh0LW91dGVyLXRzcGFuIHJvdyIgeD0iMCIgeT0iLTAuMWVtIiBkeT0iMS4xZW0iIHRleHQtYW5jaG9yPSJtaWRkbGUiPjx0c3BhbiBmb250LXN0eWxlPSJub3JtYWwiIGNsYXNzPSJ0ZXh0LWlubmVyLXRzcGFuIiBmb250LXdlaWdodD0ibm9ybWFsIj5jb250ZW50PC90c3Bhbj48dHNwYW4gZm9udC1zdHlsZT0ibm9ybWFsIiBjbGFzcz0idGV4dC1pbm5lci10c3BhbiIgZm9udC13ZWlnaHQ9Im5vcm1hbCI+IGNoYW5nZXM8L3RzcGFuPjwvdHNwYW4+PC90ZXh0PjwvZz48L2c+PC9nPjwvZz48ZyBjbGFzcz0ibm9kZXMiPjxnIGNsYXNzPSJub2RlIGRlZmF1bHQiIGlkPSJteS1zdmctZmxvd2NoYXJ0LUJyaWVmLTAiIGRhdGEtbG9vaz0iY2xhc3NpYyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNzkuMzM0NzYyNTczMjQyMTksIDYzKSI+PGcgY2xhc3M9ImJhc2ljIGxhYmVsLWNvbnRhaW5lciBvdXRlci1wYXRoIj48cGF0aCBkPSJNLTUzLjg0Mzc1IC0xNy41IEMtMzIuMjQxNDM4MTIyNDEzMzcgLTE3LjUsIC0xMC42MzkxMjYyNDQ4MjY3NDggLTE3LjUsIDUzLjg0Mzc1IC0xNy41IEM1My44NDM3NSAtMTcuNSwgNTMuODQzNzUgLTE3LjUsIDUzLjg0Mzc1IC0xNy41IEM1NC4yOTE2MDkxMjI1MjEyMSAtMTcuNDg1NjM4MDI5NjQ1NjQyLCA1NC43Mzk0NjgyNDUwNDI0MiAtMTcuNDcxMjc2MDU5MjkxMjg4LCA1NC45NjQ5Nzg4NDk2NjI0NyAtMTcuNDY0MDQ0MzczMTMwODg2IEM1NS4zMzMwMTUyMzI4MDI2NjYgLTE3LjQyODU0MDM0NTg3Nzg2LCA1NS43MDEwNTE2MTU5NDI4NjYgLTE3LjM5MzAzNjMxODYyNDgzNywgNTYuMDgxNjAwMzI5NDc4ODUgLTE3LjM1NjMyNTI0MTkwNjgxIEM1Ni4zNjYyMjk3MTA3MTgxMyAtMTcuMzEwMzA4NTcwODgxODYyLCA1Ni42NTA4NTkwOTE5NTc0MSAtMTcuMjY0MjkxODk5ODU2OTEsIDU3LjE4OTAyNjAwMjI3NDAxIC0xNy4xNzcyODUyNDczNDM2NDQgQzU3LjQxNzQxODI1NjYzMTQgLTE3LjEyNTE1NjIwNTY4NTMxNSwgNTcuNjQ1ODEwNTEwOTg4NzkgLTE3LjA3MzAyNzE2NDAyNjk4NiwgNTguMjgyNzA1MjE4NDE2Mzc1IC0xNi45Mjc2NjAxMDMxODMwMTUgQzU4LjUzOTE0NTY4MzAwNTczNSAtMTYuODUxNTQ5OTE5Mzc2MzYsIDU4Ljc5NTU4NjE0NzU5NTA5IC0xNi43NzU0Mzk3MzU1Njk3MSwgNTkuMzU4MTQzODE1NDEzMzY0IC0xNi42MDg0NzU1NzI2ODY3IEM1OS42Mzg2MTA1NDc5Mjk0MSAtMTYuNTA1MjYxMjIyNTE0NzQsIDU5LjkxOTA3NzI4MDQ0NTQ1IC0xNi40MDIwNDY4NzIzNDI3ODMsIDYwLjQxMDkyMjU4NTM4OTA0NSAtMTYuMjIxMDQzMjUzNTU1MzggQzYwLjcyMzc0NjE0ODg1NzI0IC0xNi4wODI1NjU1NDE1ODkzMTgsIDYxLjAzNjU2OTcxMjMyNTQyNCAtMTUuOTQ0MDg3ODI5NjIzMjU5LCA2MS40MzY3MTU0MzQ1NTcyNjQgLTE1Ljc2Njk1NTE4ODI5MjMzNiBDNjEuNjQyODc2NTMzODgxNDcgLTE1LjY1OTQwMTA3NDgyNzM4NCwgNjEuODQ5MDM3NjMzMjA1Njc1IC0xNS41NTE4NDY5NjEzNjI0MzQsIDYyLjQzMTMwNzE2MDA2ODkxIC0xNS4yNDgwNzczMjIxNTkzMTYgQzYyLjY0NzgzMTcwODgyMTU2IC0xNS4xMTY4MTg4NjgyNjU5NywgNjIuODY0MzU2MjU3NTc0MjE1IC0xNC45ODU1NjA0MTQzNzI2MjUsIDYzLjM5MDYxMDc3MTE4NDYgLTE0LjY2NjU0MTgzNTYwNzIxMiBDNjMuNjYyOTY4MDU0NTkwOTUgLTE0LjQ3NjU1NzE4NDg1OTcxOCwgNjMuOTM1MzI1MzM3OTk3MjkgLTE0LjI4NjU3MjUzNDExMjIyNiwgNjQuMzEwNjg0MjgzNTk2MjcgLTE0LjAyNDczODM4MjY4OTI0MSBDNjQuNTgxMDc1Nzc1MDkxNjUgLTEzLjgwOTEwODM2MzY0MTQ1OCwgNjQuODUxNDY3MjY2NTg3MDIgLTEzLjU5MzQ3ODM0NDU5MzY3NiwgNjUuMTg3NzQ2OTE3ODg2MyAtMTMuMzI1MzA0MjcxNDU5ODU1IEM2NS40OTA5MTc1NTc1OTQ0NyAtMTMuMDQ5OTcyNzE3OTMyNDUyLCA2NS43OTQwODgxOTczMDI2NiAtMTIuNzc0NjQxMTY0NDA1MDQ5LCA2Ni4wMTgxOTQ2MzU1NjEwMiAtMTIuNTcxMTEzNjI2NzEwMjMzIEM2Ni4yMjQ2MjkyNjE1NTQxMSAtMTIuMzU3OTUyOTI2Nzc0MzU4LCA2Ni40MzEwNjM4ODc1NDcyMyAtMTIuMTQ0NzkyMjI2ODM4NDgzLCA2Ni43OTg2MTQ5NDg4MTgwMSAtMTEuNzY1MjY1NTc5NTczMDQ3IEM2Ni45NzMyNjU0NTQzMzQ1NCAtMTEuNTYwMTExMTU3ODk4MDUxLCA2Ny4xNDc5MTU5NTk4NTEwNSAtMTEuMzU0OTU2NzM2MjIzMDU1LCA2Ny41MjU4MDA5NDMxOTA1MiAtMTAuOTExMDcxNTMyNTI3ODM4IEM2Ny43ODA1NDE5MzUwMjI0MSAtMTAuNTY5NzQxODEwODU0ODc3LCA2OC4wMzUyODI5MjY4NTQzMSAtMTAuMjI4NDEyMDg5MTgxOTE2LCA2OC4xOTY3NjQ0NTU0NDY3MyAtMTAuMDEyMDQxNTUyMTM3OTczIEM2OC40MDg3MDY1NDc0MTc3NSAtOS42ODY0NDE1ODQ0NTAwMTgsIDY4LjYyMDY0ODYzOTM4ODc2IC05LjM2MDg0MTYxNjc2MjA2NCwgNjguODA4NzQ4MzUyNTkzNTUgLTkuMDcxODY5OTQ1NDM0MTkxIEM2OS4wMjMzODkzOTc0MTY3OSAtOC42OTA3NTMwMzU1ODc5MTYsIDY5LjIzODAzMDQ0MjI0MDAyIC04LjMwOTYzNjEyNTc0MTY0LCA2OS4zNTkyMzc4NjE1Mjc1IC04LjA5NDQyMDA3OTIxNDYxNyBDNjkuNDc5NjQ0MjIxNzQ5NjUgLTcuODQ0MzkzNjk1OTI5OTM1LCA2OS42MDAwNTA1ODE5NzE3OSAtNy41OTQzNjczMTI2NDUyNTQsIDY5Ljg0NTk3MDkwMjc3NjcxIC03LjA4MzcwODUwNDY0MTg5NiBDNjkuOTU4NjEyNjcyODE1MiAtNi44MDU0ODExNTQ4NjYzNDYsIDcwLjA3MTI1NDQ0Mjg1MzcgLTYuNTI3MjUzODA1MDkwNzk2LCA3MC4yNjY5NDczODU4NzA4MSAtNi4wNDM4ODg0NTIzNzI4OTIgQzcwLjM0NTc1NDc3OTgwMDMgLTUuODA2NTMzMTM4MTEwMjk5LCA3MC40MjQ1NjIxNzM3Mjk4IC01LjU2OTE3NzgyMzg0NzcwNiwgNzAuNjIwNDM3NDI4MTQxNTYgLTQuOTc5MjMyNzY2MDQzMDczIEM3MC43MDQ0ODk3MzgxMzgxNSAtNC42NTg3MDQ4Nzk1MjQ0NTIsIDcwLjc4ODU0MjA0ODEzNDc2IC00LjMzODE3Njk5MzAwNTgyOSwgNzAuOTA0OTg4NDYzMTgxOTEgLTMuODk0MTE2MzQ0MjM1NTA0IEM3MC45ODczMDMzNTYyNzg5MSAtMy40NzE0NDY3NjU0NDExOTEsIDcxLjA2OTYxODI0OTM3NTkyIC0zLjA0ODc3NzE4NjY0Njg3ODIsIDcxLjExOTQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDE0MyBDNzEuMTYyOTE4NDMxMzY3ODYgLTIuNDU1NzE5ODU5NzYxNjExLCA3MS4yMDY0MDU2NTI5ODI4MiAtMi4xMTg0NDE1NTY0MzkwNzg2LCA3MS4yNjI4ODQ0NzY2MTA5NiAtMS42ODA0MDI5NTMzODQ0MzQgQzcxLjI4ODgyNjQyMjk2MjY0IC0xLjI3NjMzNjE5ODk5NDg2OTIsIDcxLjMxNDc2ODM2OTMxNDMxIC0wLjg3MjI2OTQ0NDYwNTMwNDEsIDcxLjMzNDc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk2NTQgQzcxLjMzNDc1ODc4MzUxMjAzIC0wLjIwMTEzMDQ4Njg2MzkzMjYsIDcxLjMzNDc1ODc4MzUxMjAzIDAuMTU4NjQxNjMzNzc2MTAwMiwgNzEuMzM0NzU4NzgzNTEyMDMgMC41NjA5MDI2MDc1MDM5NjExIEM3MS4zMTEwNTE1NTE4NzU2OCAwLjkzMDE2MTg3NjM3MzEzNzYsIDcxLjI4NzM0NDMyMDIzOTMzIDEuMjk5NDIxMTQ1MjQyMzE0LCA3MS4yNjI4ODQ0NzY2MTA5NiAxLjY4MDQwMjk1MzM4NDQyMiBDNzEuMjA5NjA1MTEyMTg0OTUgMi4wOTM2MjcxODI2NzIwNTA1LCA3MS4xNTYzMjU3NDc3NTg5NCAyLjUwNjg1MTQxMTk1OTY3OSwgNzEuMTE5NDMxMjA5NzUyODggMi43OTI5OTgxNjMwODQxMzEgQzcxLjA0ODc2NjE3NjAyNTM3IDMuMTU1ODQ4MTc2MjE0NzMzNywgNzAuOTc4MTAxMTQyMjk3ODUgMy41MTg2OTgxODkzNDUzMzY0LCA3MC45MDQ5ODg0NjMxODE5MSAzLjg5NDExNjM0NDIzNTUgQzcwLjgzNjgxMDIxNjIzMDc2IDQuMTU0MTA5NTQ4NDk5MzcsIDcwLjc2ODYzMTk2OTI3OTYxIDQuNDE0MTAyNzUyNzYzMjQxLCA3MC42MjA0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2MSBDNzAuNTE4MTkwNjA1NDY0MTQgNS4yODcxODM5MDUxMjg1NjksIDcwLjQxNTk0Mzc4Mjc4Njc0IDUuNTk1MTM1MDQ0MjE0MDc4LCA3MC4yNjY5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg4IEM3MC4xMjgzNTc4MzY4MzY1OSA2LjM4NjIwNzMxNzkzNDA0NiwgNjkuOTg5NzY4Mjg3ODAyMzggNi43Mjg1MjYxODM0OTUyMTE1LCA2OS44NDU5NzA5MDI3NzY3MSA3LjA4MzcwODUwNDY0MTg5MTUgQzY5LjY3NjE0MTg5MjI1NTE3IDcuNDM2MzYyMDc4NzQ4NTg0NSwgNjkuNTA2MzEyODgxNzMzNjMgNy43ODkwMTU2NTI4NTUyNzY1LCA2OS4zNTkyMzc4NjE1Mjc1IDguMDk0NDIwMDc5MjE0NjEzIEM2OS4yMzM1ODgyMTgyNjY4NyA4LjMxNzUyMzc0NDIyOTkxLCA2OS4xMDc5Mzg1NzUwMDYyNiA4LjU0MDYyNzQwOTI0NTIwNCwgNjguODA4NzQ4MzUyNTkzNTUgOS4wNzE4Njk5NDU0MzQxODYgQzY4LjU2NzY2MDUzMjc5NjI4IDkuNDQyMjQ1NTc3Nzg3MDE2LCA2OC4zMjY1NzI3MTI5OTkwMiA5LjgxMjYyMTIxMDEzOTg0NSwgNjguMTk2NzY0NDU1NDQ2NzMgMTAuMDEyMDQxNTUyMTM3OTY0IEM2Ny45Njg4NzAyNDc0MTM3NiAxMC4zMTczOTkwMjkzMTI2NzEsIDY3Ljc0MDk3NjAzOTM4MDgxIDEwLjYyMjc1NjUwNjQ4NzM3NywgNjcuNTI1ODAwOTQzMTkwNTIgMTAuOTExMDcxNTMyNTI3ODM1IEM2Ny4zNzc2NzcxMzA0Mzk2NCAxMS4wODUwNjYxOTE0Njg3NDMsIDY3LjIyOTU1MzMxNzY4ODc0IDExLjI1OTA2MDg1MDQwOTY0OCwgNjYuNzk4NjE0OTQ4ODE4MDMgMTEuNzY1MjY1NTc5NTczMDM4IEM2Ni42MTQwOTMyMjI3MTU1NSAxMS45NTU3OTk0MTEyODkzLCA2Ni40Mjk1NzE0OTY2MTMwOCAxMi4xNDYzMzMyNDMwMDU1NjQsIDY2LjAxODE5NDYzNTU2MTAyIDEyLjU3MTExMzYyNjcxMDIyOSBDNjUuNzkyMzM0MTY0MjM1MiAxMi43NzYyMzQxMzA4Mjc3NCwgNjUuNTY2NDczNjkyOTA5MzggMTIuOTgxMzU0NjM0OTQ1MjUsIDY1LjE4Nzc0NjkxNzg4NjMyIDEzLjMyNTMwNDI3MTQ1OTg0MiBDNjQuOTk1ODAwNzcyMTU4MzkgMTMuNDc4Mzc2MjE0Nzc2NDEsIDY0LjgwMzg1NDYyNjQzMDQ1IDEzLjYzMTQ0ODE1ODA5Mjk4LCA2NC4zMTA2ODQyODM1OTYyOSAxNC4wMjQ3MzgzODI2ODkyNCBDNjMuOTk2MDU2NzE5MTk5NjIgMTQuMjQ0MjA4OTUxNjA0NjA1LCA2My42ODE0MjkxNTQ4MDI5NiAxNC40NjM2Nzk1MjA1MTk5NzEsIDYzLjM5MDYxMDc3MTE4NDYxIDE0LjY2NjU0MTgzNTYwNzIwNyBDNjMuMDM3MTU5MjI3MzIxOTggMTQuODgwODA2MjM4NjA4NTY0LCA2Mi42ODM3MDc2ODM0NTkzNCAxNS4wOTUwNzA2NDE2MDk5MiwgNjIuNDMxMzA3MTYwMDY4OTEgMTUuMjQ4MDc3MzIyMTU5MzE1IEM2Mi4xNTYzNDUzMTEyMTc4IDE1LjM5MTUyNDc0MjU4MzQ2OSwgNjEuODgxMzgzNDYyMzY2NjkgMTUuNTM0OTcyMTYzMDA3NjIzLCA2MS40MzY3MTU0MzQ1NTcyNyAxNS43NjY5NTUxODgyOTIzMzIgQzYxLjEzODc0NDMxOTgxMTg0IDE1Ljg5ODg1ODE2MTc5MTA2NSwgNjAuODQwNzczMjA1MDY2NDIgMTYuMDMwNzYxMTM1Mjg5Nzk3LCA2MC40MTA5MjI1ODUzODkwNSAxNi4yMjEwNDMyNTM1NTUzOCBDNjAuMDgwNjgzMzUyODcyNjUgMTYuMzQyNTc0MzQzODE5NDE4LCA1OS43NTA0NDQxMjAzNTYyNCAxNi40NjQxMDU0MzQwODM0NTQsIDU5LjM1ODE0MzgxNTQxMzM3IDE2LjYwODQ3NTU3MjY4NjY5NyBDNTguOTQ5NjY3NzM4OTA4Mzc0IDE2LjcyOTcwOTEyODA1ODcsIDU4LjU0MTE5MTY2MjQwMzM4NSAxNi44NTA5NDI2ODM0MzA3MDYsIDU4LjI4MjcwNTIxODQxNjM5NiAxNi45Mjc2NjAxMDMxODMwMTIgQzU3Ljk3OTYwNjM5MjIyNDc3NCAxNi45OTY4NDA0MzIzNTY1NjQsIDU3LjY3NjUwNzU2NjAzMzE0NSAxNy4wNjYwMjA3NjE1MzAxMTUsIDU3LjE4OTAyNjAwMjI3NDAyIDE3LjE3NzI4NTI0NzM0MzY0NCBDNTYuOTE1NDgxMTg3ODI0NDIgMTcuMjIxNTA5ODUxNTcyMTM3LCA1Ni42NDE5MzYzNzMzNzQ4MiAxNy4yNjU3MzQ0NTU4MDA2MywgNTYuMDgxNjAwMzI5NDc4ODcgMTcuMzU2MzI1MjQxOTA2ODA2IEM1NS42Njc3MDMyMzU4MjExMzYgMTcuMzk2MjUzMzk2NzQ3ODg0LCA1NS4yNTM4MDYxNDIxNjM0MDUgMTcuNDM2MTgxNTUxNTg4OTYyLCA1NC45NjQ5Nzg4NDk2NjI0NyAxNy40NjQwNDQzNzMxMzA4ODYgQzU0LjU0MjE2MzM4NzI4OTQ0IDE3LjQ3NzYwMzI0MjA0ODgyLCA1NC4xMTkzNDc5MjQ5MTY0MSAxNy40OTExNjIxMTA5NjY3NDgsIDUzLjg0Mzc1IDE3LjUgQzUzLjg0Mzc1IDE3LjUsIDUzLjg0Mzc1IDE3LjUsIDUzLjg0Mzc1IDE3LjUgQzIwLjY3MTk5OTcxNjEwNDQxIDE3LjUsIC0xMi40OTk3NTA1Njc3OTExODIgMTcuNSwgLTUzLjg0Mzc1IDE3LjUgQy01NC4xODk1MjM3MzU5ODk1NCAxNy40ODg5MTE3MDkyOTQ1NjMsIC01NC41MzUyOTc0NzE5NzkwODUgMTcuNDc3ODIzNDE4NTg5MTMsIC01NC45NjQ5Nzg4NDk2NjI0NjUgMTcuNDY0MDQ0MzczMTMwODg2IEMtNTUuMTg5OTM1NjQ3NzkxOTcgMTcuNDQyMzQzMDYxMzY1NDYzLCAtNTUuNDE0ODkyNDQ1OTIxNDggMTcuNDIwNjQxNzQ5NjAwMDQ0LCAtNTYuMDgxNjAwMzI5NDc4ODYgMTcuMzU2MzI1MjQxOTA2ODA2IEMtNTYuNDQyOTExMzgzOTExNzMgMTcuMjk3OTExMjcyNjM1MTc2LCAtNTYuODA0MjIyNDM4MzQ0NTk2IDE3LjIzOTQ5NzMwMzM2MzU0NiwgLTU3LjE4OTAyNjAwMjI3NDAxIDE3LjE3NzI4NTI0NzM0MzY0NCBDLTU3LjQ2MTYxNDQ0NjgwODk2NiAxNy4xMTUwNjg3MTM2ODQzOCwgLTU3LjczNDIwMjg5MTM0MzkxIDE3LjA1Mjg1MjE4MDAyNTExNiwgLTU4LjI4MjcwNTIxODQxNjM3NSAxNi45Mjc2NjAxMDMxODMwMTUgQy01OC40OTg0OTkxOTQwNTk1MiAxNi44NjM2MTM1ODM5Mzc4MjMsIC01OC43MTQyOTMxNjk3MDI2NiAxNi43OTk1NjcwNjQ2OTI2MywgLTU5LjM1ODE0MzgxNTQxMzM2IDE2LjYwODQ3NTU3MjY4NjcwNCBDLTU5LjY3OTkyNzg3MjgyODI0NSAxNi40OTAwNTYwNjUwMTg4MDUsIC02MC4wMDE3MTE5MzAyNDMxMjUgMTYuMzcxNjM2NTU3MzUwOTA3LCAtNjAuNDEwOTIyNTg1Mzg5MDQ1IDE2LjIyMTA0MzI1MzU1NTM4IEMtNjAuNzg3NDcwMDE3ODkxMjkgMTYuMDU0MzU2ODc1MDY5MzYsIC02MS4xNjQwMTc0NTAzOTM1MiAxNS44ODc2NzA0OTY1ODMzMzgsIC02MS40MzY3MTU0MzQ1NTcyNjQgMTUuNzY2OTU1MTg4MjkyMzM4IEMtNjEuNjQwMDU1MjYwNjg1MTIgMTUuNjYwODcyOTMxMjQ2ODA3LCAtNjEuODQzMzk1MDg2ODEyOTkgMTUuNTU0NzkwNjc0MjAxMjc1LCAtNjIuNDMxMzA3MTYwMDY4OTA0IDE1LjI0ODA3NzMyMjE1OTMxOCBDLTYyLjcyOTExOTkyNzY2ODcxIDE1LjA2NzU0MTQ3MjI5ODIzLCAtNjMuMDI2OTMyNjk1MjY4NTIgMTQuODg3MDA1NjIyNDM3MTQsIC02My4zOTA2MTA3NzExODQ1OSAxNC42NjY1NDE4MzU2MDcyMTggQy02My42MTE2NzAzMTIzODE5NSAxNC41MTIzNDAyNjkxODEyNCwgLTYzLjgzMjcyOTg1MzU3OTMyIDE0LjM1ODEzODcwMjc1NTI2MiwgLTY0LjMxMDY4NDI4MzU5NjI3IDE0LjAyNDczODM4MjY4OTI0MyBDLTY0LjU3NDY0MDY3MDU2MjM5IDEzLjgxNDI0MDE4ODI1ODIyOCwgLTY0LjgzODU5NzA1NzUyODQ5IDEzLjYwMzc0MTk5MzgyNzIxMiwgLTY1LjE4Nzc0NjkxNzg4NjMgMTMuMzI1MzA0MjcxNDU5ODU2IEMtNjUuNDMyMzg0MTg2NzU3NjIgMTMuMTAzMTMxMTc2NjE4MzcsIC02NS42NzcwMjE0NTU2Mjg5MiAxMi44ODA5NTgwODE3NzY4ODQsIC02Ni4wMTgxOTQ2MzU1NjEgMTIuNTcxMTEzNjI2NzEwMjQxIEMtNjYuMTgyODI0MTk2MzYzNCAxMi40MDExMjAwODg4NDM0NTQsIC02Ni4zNDc0NTM3NTcxNjU4MSAxMi4yMzExMjY1NTA5NzY2NjcsIC02Ni43OTg2MTQ5NDg4MTgwMyAxMS43NjUyNjU1Nzk1NzMwNDMgQy02Ny4wNzU2MjEwMTE4MDIzMSAxMS40Mzk4Nzg0OTU5MDAxOTIsIC02Ny4zNTI2MjcwNzQ3ODY2IDExLjExNDQ5MTQxMjIyNzM0MSwgLTY3LjUyNTgwMDk0MzE5MDUyIDEwLjkxMTA3MTUzMjUyNzg0IEMtNjcuNzIyNTAwNDczMTM4NCAxMC42NDc1MTIwODIwOTM1MDgsIC02Ny45MTkyMDAwMDMwODYyNyAxMC4zODM5NTI2MzE2NTkxNzcsIC02OC4xOTY3NjQ0NTU0NDY3MyAxMC4wMTIwNDE1NTIxMzc5NzQgQy02OC40MzYxMTYwMDg5Mjc3NSA5LjY0NDMzMzI5MTA5OTY3NCwgLTY4LjY3NTQ2NzU2MjQwODc4IDkuMjc2NjI1MDMwMDYxMzcxLCAtNjguODA4NzQ4MzUyNTkzNTUgOS4wNzE4Njk5NDU0MzQxOTggQy02OC45Njc2ODc1MjIxNDA5NiA4Ljc4OTY1NzM1NTU2NjY1LCAtNjkuMTI2NjI2NjkxNjg4MzcgOC41MDc0NDQ3NjU2OTkxMDQsIC02OS4zNTkyMzc4NjE1Mjc1IDguMDk0NDIwMDc5MjE0NjE4IEMtNjkuNTAyMTk2NDg0MzM1MDMgNy43OTc1NjM0NDAxMzAyNTksIC02OS42NDUxNTUxMDcxNDI1NyA3LjUwMDcwNjgwMTA0NTg5OSwgLTY5Ljg0NTk3MDkwMjc3NjcxIDcuMDgzNzA4NTA0NjQxODk4IEMtNzAuMDA3ODk4NjQ4NzU5OTYgNi42ODM3NDM4NDE0MDMyODksIC03MC4xNjk4MjYzOTQ3NDMyMSA2LjI4Mzc3OTE3ODE2NDY3OTUsIC03MC4yNjY5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg5NCBDLTcwLjQwNzk5NzA4NzMyNzg0IDUuNjE5MDY5MjI0ODAyMzA5LCAtNzAuNTQ5MDQ2Nzg4Nzg0ODYgNS4xOTQyNDk5OTcyMzE3MjQsIC03MC42MjA0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2OCBDLTcwLjczMzE0NDU5MTgyNjc0IDQuNTQ5NDMxNTAzMzE3NzE0LCAtNzAuODQ1ODUxNzU1NTExOTMgNC4xMTk2MzAyNDA1OTIzNTksIC03MC45MDQ5ODg0NjMxODE5MSAzLjg5NDExNjM0NDIzNTUwNjIgQy03MC45NjQ3NDA0NDExNTUxOSAzLjU4NzMwMjU2NTkyNzc1OCwgLTcxLjAyNDQ5MjQxOTEyODQ2IDMuMjgwNDg4Nzg3NjIwMDEwNiwgLTcxLjExOTQzMTIwOTc1Mjg4IDIuNzkyOTk4MTYzMDg0MTQ0NyBDLTcxLjE0ODg1OTc4MTg4Njk4IDIuNTY0NzU1OTY4OTQwODU1NCwgLTcxLjE3ODI4ODM1NDAyMTA5IDIuMzM2NTEzNzc0Nzk3NTY1NywgLTcxLjI2Mjg4NDQ3NjYxMDk2IDEuNjgwNDAyOTUzMzg0NDQ0IEMtNzEuMjkxNDE0MTg3OTUxODQgMS4yMzYwMjk2NzA0ODE3NjA2LCAtNzEuMzE5OTQzODk5MjkyNzEgMC43OTE2NTYzODc1NzkwNzc0LCAtNzEuMzM0NzU4NzgzNTEyMDMgMC41NjA5MDI2MDc1MDM5Njc2IEMtNzEuMzM0NzU4NzgzNTEyMDMgMC4xNjg4OTA4NjgxNTE2NjQxLCAtNzEuMzM0NzU4NzgzNTEyMDMgLTAuMjIzMTIwODcxMjAwNjM5NCwgLTcxLjMzNDc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBDLTcxLjMxMTcwMTQzNDk1MTg5IC0wLjkyMDAzOTQyMjg4NTAyMTcsIC03MS4yODg2NDQwODYzOTE3NCAtMS4yNzkxNzYyMzgyNjYwODQ1LCAtNzEuMjYyODg0NDc2NjEwOTYgLTEuNjgwNDAyOTUzMzg0NDE5OCBDLTcxLjIyMTkwNjExNjgyMzkgLTEuOTk4MjIzMDE5ODAwNDg4NywgLTcxLjE4MDkyNzc1NzAzNjg0IC0yLjMxNjA0MzA4NjIxNjU1NzUsIC03MS4xMTk0MzEyMDk3NTI4OCAtMi43OTI5OTgxNjMwODQxMzY3IEMtNzEuMDY4NDQwNDA5MjY1MTQgLTMuMDU0ODI1MTQ2Njc5MTc4NywgLTcxLjAxNzQ0OTYwODc3NzQgLTMuMzE2NjUyMTMwMjc0MjIwNywgLTcwLjkwNDk4ODQ2MzE4MTkxIC0zLjg5NDExNjM0NDIzNTQ5OCBDLTcwLjgwNDU3Mjg3MzUzMDE5IC00LjI3NzA0NDUwNzk2OTM2LCAtNzAuNzA0MTU3MjgzODc4NDcgLTQuNjU5OTcyNjcxNzAzMjIzLCAtNzAuNjIwNDM3NDI4MTQxNTcgLTQuOTc5MjMyNzY2MDQzMDU5IEMtNzAuNTE4NjY1Mjc3MjYzOTMgLTUuMjg1NzU0MjY5Mjk2Mjk2LCAtNzAuNDE2ODkzMTI2Mzg2MzEgLTUuNTkyMjc1NzcyNTQ5NTM0NSwgLTcwLjI2Njk0NzM4NTg3MDgxIC02LjA0Mzg4ODQ1MjM3Mjg3MTUgQy03MC4xMzc1NjEwNjAxNzY0IC02LjM2MzQ3NTE3ODM1MjUxNCwgLTcwLjAwODE3NDczNDQ4MTk3IC02LjY4MzA2MTkwNDMzMjE1NiwgLTY5Ljg0NTk3MDkwMjc3NjcxIC03LjA4MzcwODUwNDY0MTg4OSBDLTY5LjcwMDczMDU1MTQyMDc1IC03LjM4NTMwMzIwMTg3ODIzNSwgLTY5LjU1NTQ5MDIwMDA2NDc4IC03LjY4Njg5Nzg5OTExNDU4MSwgLTY5LjM1OTIzNzg2MTUyNzUgLTguMDk0NDIwMDc5MjE0NjExIEMtNjkuMjQ3NTc1MzM3ODY0NjMgLTguMjkyNjg4MTk3MDM0NjYsIC02OS4xMzU5MTI4MTQyMDE3NiAtOC40OTA5NTYzMTQ4NTQ3MSwgLTY4LjgwODc0ODM1MjU5MzU1IC05LjA3MTg2OTk0NTQzNDE5MyBDLTY4LjYwNDAxNDM5MDU0MTc2IC05LjM4NjM5NjI4OTkxMjMsIC02OC4zOTkyODA0Mjg0ODk5OSAtOS43MDA5MjI2MzQzOTA0MDksIC02OC4xOTY3NjQ0NTU0NDY3MyAtMTAuMDEyMDQxNTUyMTM3OTY5IEMtNjguMDEwMTY3MTE1MjY0OCAtMTAuMjYyMDY0OTg4NjE0MzQzLCAtNjcuODIzNTY5Nzc1MDgyODkgLTEwLjUxMjA4ODQyNTA5MDcxNywgLTY3LjUyNTgwMDk0MzE5MDUyIC0xMC45MTEwNzE1MzI1Mjc4MzUgQy02Ny4zMDYyNzcwNTI0NTAyNiAtMTEuMTY4OTM2Nzg1ODU0NTk2LCAtNjcuMDg2NzUzMTYxNzA5OTkgLTExLjQyNjgwMjAzOTE4MTM1OSwgLTY2Ljc5ODYxNDk0ODgxODAzIC0xMS43NjUyNjU1Nzk1NzMwMzggQy02Ni41NTkxMTQ3NDI5MTIyMyAtMTIuMDEyNTY5MjA1NTAzMzYxLCAtNjYuMzE5NjE0NTM3MDA2NDQgLTEyLjI1OTg3MjgzMTQzMzY4MiwgLTY2LjAxODE5NDYzNTU2MTAyIC0xMi41NzExMTM2MjY3MTAyMjQgQy02NS42OTUwNTY1OTYyMTg3NSAtMTIuODY0NTc5MDQ0Mjc2ODcxLCAtNjUuMzcxOTE4NTU2ODc2NDcgLTEzLjE1ODA0NDQ2MTg0MzUxOCwgLTY1LjE4Nzc0NjkxNzg4NjMyIC0xMy4zMjUzMDQyNzE0NTk4NCBDLTY0Ljk2MzA1NDEyNjgwMzYxIC0xMy41MDQ0OTA3OTMwMjIwMTEsIC02NC43MzgzNjEzMzU3MjA5MSAtMTMuNjgzNjc3MzE0NTg0MTgsIC02NC4zMTA2ODQyODM1OTYyOSAtMTQuMDI0NzM4MzgyNjg5MjM2IEMtNjQuMDgwMjAxODY3MDE2MzMgLTE0LjE4NTUxMjkzOTA3MjQxLCAtNjMuODQ5NzE5NDUwNDM2MzcgLTE0LjM0NjI4NzQ5NTQ1NTU4NCwgLTYzLjM5MDYxMDc3MTE4NDYxIC0xNC42NjY1NDE4MzU2MDcyMDUgQy02My4xMDYyMjU4MTQ0MDk3MyAtMTQuODM4OTM3NjY3NjM1NjQ4LCAtNjIuODIxODQwODU3NjM0ODU0IC0xNS4wMTEzMzM0OTk2NjQwOSwgLTYyLjQzMTMwNzE2MDA2ODkxIC0xNS4yNDgwNzczMjIxNTkzMTMgQy02Mi4xNjE3NDM4MzAxNjQ1OCAtMTUuMzg4NzA4MzM4NzA2ODQ5LCAtNjEuODkyMTgwNTAwMjYwMjUgLTE1LjUyOTMzOTM1NTI1NDM4NCwgLTYxLjQzNjcxNTQzNDU1NzI3IC0xNS43NjY5NTUxODgyOTIzMzIgQy02MS4xODgwNTY4NTA5MjYxIC0xNS44NzcwMjg5NjcwNzEwNDUsIC02MC45MzkzOTgyNjcyOTQ5MjYgLTE1Ljk4NzEwMjc0NTg0OTc1NywgLTYwLjQxMDkyMjU4NTM4OTA2IC0xNi4yMjEwNDMyNTM1NTUzNzYgQy02MC4wODA4Mzc1Njk2NjE4NCAtMTYuMzQyNTE3NTkwNjE1NDMsIC01OS43NTA3NTI1NTM5MzQ2MjUgLTE2LjQ2Mzk5MTkyNzY3NTQ4MywgLTU5LjM1ODE0MzgxNTQxMzM4IC0xNi42MDg0NzU1NzI2ODY2OTcgQy01OS4wNDM0NTA1MzY1NTcwNyAtMTYuNzAxODc0ODg1OTkyNTIsIC01OC43Mjg3NTcyNTc3MDA3NiAtMTYuNzk1Mjc0MTk5Mjk4MzQ0LCAtNTguMjgyNzA1MjE4NDE2Mzk2IC0xNi45Mjc2NjAxMDMxODMwMSBDLTU4LjAwMzMwNzU3MzA2MTE2NCAtMTYuOTkxNDMwNzkyNDk1MzEsIC01Ny43MjM5MDk5Mjc3MDU5NCAtMTcuMDU1MjAxNDgxODA3NjE4LCAtNTcuMTg5MDI2MDAyMjc0MDIgLTE3LjE3NzI4NTI0NzM0MzY0IEMtNTYuOTU1MzgzODcxMDc5NCAtMTcuMjE1MDU4Njk1MTkzNCwgLTU2LjcyMTc0MTczOTg4NDc4NCAtMTcuMjUyODMyMTQzMDQzMTU3LCAtNTYuMDgxNjAwMzI5NDc4ODcgLTE3LjM1NjMyNTI0MTkwNjgwNiBDLTU1LjY4MjUyNTI5MTA3NTMzIC0xNy4zOTQ4MjM1MzA5MDM2NCwgLTU1LjI4MzQ1MDI1MjY3MTc4NCAtMTcuNDMzMzIxODE5OTAwNDc4LCAtNTQuOTY0OTc4ODQ5NjYyNDggLTE3LjQ2NDA0NDM3MzEzMDg4NiBDLTU0LjU3OTUxMzg1NTg1ODU4IC0xNy40NzY0MDU0ODUyMjAwOCwgLTU0LjE5NDA0ODg2MjA1NDY4IC0xNy40ODg3NjY1OTczMDkyOCwgLTUzLjg0Mzc1MDAwMDAwMDAxIC0xNy41IEMtNTMuODQzNzUwMDAwMDAwMDEgLTE3LjUsIC01My44NDM3NSAtMTcuNSwgLTUzLjg0Mzc1IC0xNy41IiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMCIgZmlsbD0iI2RiZTVlYyIgc3R5bGU9IiIvPjxwYXRoIGQ9Ik0tNTMuODQzNzUgLTE3LjUgQy0yMy4zMDA3MDA0MDk5NTkyMTYgLTE3LjUsIDcuMjQyMzQ5MTgwMDgxNTY4IC0xNy41LCA1My44NDM3NSAtMTcuNSBNLTUzLjg0Mzc1IC0xNy41IEMtMTguNDM3MTYyODA2MjI5NDIzIC0xNy41LCAxNi45Njk0MjQzODc1NDExNTMgLTE3LjUsIDUzLjg0Mzc1IC0xNy41IE01My44NDM3NSAtMTcuNSBDNTMuODQzNzUgLTE3LjUsIDUzLjg0Mzc1IC0xNy41LCA1My44NDM3NSAtMTcuNSBNNTMuODQzNzUgLTE3LjUgQzUzLjg0Mzc1IC0xNy41LCA1My44NDM3NSAtMTcuNSwgNTMuODQzNzUgLTE3LjUgTTUzLjg0Mzc1IC0xNy41IEM1NC4xNzI3ODI0NjEwOTcyOSAtMTcuNDg5NDQ4NTY5Mzk1NDQyLCA1NC41MDE4MTQ5MjIxOTQ1OSAtMTcuNDc4ODk3MTM4NzkwODg4LCA1NC45NjQ5Nzg4NDk2NjI0NyAtMTcuNDY0MDQ0MzczMTMwODg2IE01My44NDM3NSAtMTcuNSBDNTQuMTExNTE3Mjc2NTY5MTc0IC0xNy40OTE0MTMyMjQ2MTc4MTIsIDU0LjM3OTI4NDU1MzEzODM1NSAtMTcuNDgyODI2NDQ5MjM1NjI0LCA1NC45NjQ5Nzg4NDk2NjI0NyAtMTcuNDY0MDQ0MzczMTMwODg2IE01NC45NjQ5Nzg4NDk2NjI0NyAtMTcuNDY0MDQ0MzczMTMwODg2IEM1NS4zNDUzNjk3MjIzNjk2MyAtMTcuNDI3MzQ4NTIzMTI3NzgzLCA1NS43MjU3NjA1OTUwNzY4IC0xNy4zOTA2NTI2NzMxMjQ2OCwgNTYuMDgxNjAwMzI5NDc4ODUgLTE3LjM1NjMyNTI0MTkwNjgxIE01NC45NjQ5Nzg4NDk2NjI0NyAtMTcuNDY0MDQ0MzczMTMwODg2IEM1NS4zNDQzODU3MjA3MDA5ODQgLTE3LjQyNzQ0MzQ0ODU4NTMyMiwgNTUuNzIzNzkyNTkxNzM5NDk2IC0xNy4zOTA4NDI1MjQwMzk3NjIsIDU2LjA4MTYwMDMyOTQ3ODg1IC0xNy4zNTYzMjUyNDE5MDY4MSBNNTYuMDgxNjAwMzI5NDc4ODUgLTE3LjM1NjMyNTI0MTkwNjgxIEM1Ni41MDMwODMzNDgwMzgwNyAtMTcuMjg4MTgzMTM2MTE1NzgsIDU2LjkyNDU2NjM2NjU5NzI5IC0xNy4yMjAwNDEwMzAzMjQ3NSwgNTcuMTg5MDI2MDAyMjc0MDEgLTE3LjE3NzI4NTI0NzM0MzY0NCBNNTYuMDgxNjAwMzI5NDc4ODUgLTE3LjM1NjMyNTI0MTkwNjgxIEM1Ni40NDY1OTUzNDAxMjkyNiAtMTcuMjk3MzE1Njc5MTYzNDMyLCA1Ni44MTE1OTAzNTA3Nzk2NiAtMTcuMjM4MzA2MTE2NDIwMDYsIDU3LjE4OTAyNjAwMjI3NDAxIC0xNy4xNzcyODUyNDczNDM2NDQgTTU3LjE4OTAyNjAwMjI3NDAxIC0xNy4xNzcyODUyNDczNDM2NDQgQzU3LjQ4ODY3NTM0MTIzMDY4IC0xNy4xMDg4OTIyNDExMjE0NjMsIDU3Ljc4ODMyNDY4MDE4NzM0NCAtMTcuMDQwNDk5MjM0ODk5MjgsIDU4LjI4MjcwNTIxODQxNjM3NSAtMTYuOTI3NjYwMTAzMTgzMDE1IE01Ny4xODkwMjYwMDIyNzQwMSAtMTcuMTc3Mjg1MjQ3MzQzNjQ0IEM1Ny40NDI4MTMyMzA1MzkzNSAtMTcuMTE5MzU5OTY4NjA4NTE3LCA1Ny42OTY2MDA0NTg4MDQ2OCAtMTcuMDYxNDM0Njg5ODczMzksIDU4LjI4MjcwNTIxODQxNjM3NSAtMTYuOTI3NjYwMTAzMTgzMDE1IE01OC4yODI3MDUyMTg0MTYzNzUgLTE2LjkyNzY2MDEwMzE4MzAxNSBDNTguNTgzODU0NDc2NTkzNzM2IC0xNi44MzgyODA1ODQxMjA2OSwgNTguODg1MDAzNzM0NzcxMSAtMTYuNzQ4OTAxMDY1MDU4MzYyLCA1OS4zNTgxNDM4MTU0MTMzNjQgLTE2LjYwODQ3NTU3MjY4NjcgTTU4LjI4MjcwNTIxODQxNjM3NSAtMTYuOTI3NjYwMTAzMTgzMDE1IEM1OC42NzU5MDIxMDg5NjI5MiAtMTYuODEwOTYxMzMwMDAxMzk4LCA1OS4wNjkwOTg5OTk1MDk0NjQgLTE2LjY5NDI2MjU1NjgxOTc3NiwgNTkuMzU4MTQzODE1NDEzMzY0IC0xNi42MDg0NzU1NzI2ODY3IE01OS4zNTgxNDM4MTU0MTMzNjQgLTE2LjYwODQ3NTU3MjY4NjcgQzU5Ljc1NDgyMjI2ODgyNjY2IC0xNi40NjI0OTQyMzQ5NzUxODIsIDYwLjE1MTUwMDcyMjIzOTk1IC0xNi4zMTY1MTI4OTcyNjM2NiwgNjAuNDEwOTIyNTg1Mzg5MDQ1IC0xNi4yMjEwNDMyNTM1NTUzOCBNNTkuMzU4MTQzODE1NDEzMzY0IC0xNi42MDg0NzU1NzI2ODY3IEM1OS42MzQ2OTQ5MDYxNzYzNyAtMTYuNTA2NzAyMjE0ODc1NjUyLCA1OS45MTEyNDU5OTY5MzkzOCAtMTYuNDA0OTI4ODU3MDY0NjA4LCA2MC40MTA5MjI1ODUzODkwNDUgLTE2LjIyMTA0MzI1MzU1NTM4IE02MC40MTA5MjI1ODUzODkwNDUgLTE2LjIyMTA0MzI1MzU1NTM4IEM2MC43MjYxMjQzNTIyNDgwMzYgLTE2LjA4MTUxMjc4MTQ5NTEwNywgNjEuMDQxMzI2MTE5MTA3MDI2IC0xNS45NDE5ODIzMDk0MzQ4MzYsIDYxLjQzNjcxNTQzNDU1NzI2NCAtMTUuNzY2OTU1MTg4MjkyMzM2IE02MC40MTA5MjI1ODUzODkwNDUgLTE2LjIyMTA0MzI1MzU1NTM4IEM2MC42MjA1MjQ4MjQxNjcyMiAtMTYuMTI4MjU4NTYwMDc3Nzg2LCA2MC44MzAxMjcwNjI5NDUzOSAtMTYuMDM1NDczODY2NjAwMTksIDYxLjQzNjcxNTQzNDU1NzI2NCAtMTUuNzY2OTU1MTg4MjkyMzM2IE02MS40MzY3MTU0MzQ1NTcyNjQgLTE1Ljc2Njk1NTE4ODI5MjMzNiBDNjEuNjk5MjU2NTQ1MTIzMDg1IC0xNS42Mjk5ODc2NTkwNzU3NTYsIDYxLjk2MTc5NzY1NTY4ODkwNSAtMTUuNDkzMDIwMTI5ODU5MTc0LCA2Mi40MzEzMDcxNjAwNjg5MSAtMTUuMjQ4MDc3MzIyMTU5MzE2IE02MS40MzY3MTU0MzQ1NTcyNjQgLTE1Ljc2Njk1NTE4ODI5MjMzNiBDNjEuNzY2NDgwNjY4MzkzMyAtMTUuNTk0OTE2ODc3MDI0NzksIDYyLjA5NjI0NTkwMjIyOTMzNCAtMTUuNDIyODc4NTY1NzU3MjQ0LCA2Mi40MzEzMDcxNjAwNjg5MSAtMTUuMjQ4MDc3MzIyMTU5MzE2IE02Mi40MzEzMDcxNjAwNjg5MSAtMTUuMjQ4MDc3MzIyMTU5MzE2IEM2Mi43NzQxNDgxMDM1NTczOTQgLTE1LjA0MDI0NTEyNzQ1OTU4MSwgNjMuMTE2OTg5MDQ3MDQ1ODcgLTE0LjgzMjQxMjkzMjc1OTg0NCwgNjMuMzkwNjEwNzcxMTg0NiAtMTQuNjY2NTQxODM1NjA3MjEyIE02Mi40MzEzMDcxNjAwNjg5MSAtMTUuMjQ4MDc3MzIyMTU5MzE2IEM2Mi44MTE1OTE1MzUwMDQ1NDYgLTE1LjAxNzU0NjY5OTI3NDI4NiwgNjMuMTkxODc1OTA5OTQwMTggLTE0Ljc4NzAxNjA3NjM4OTI1NywgNjMuMzkwNjEwNzcxMTg0NiAtMTQuNjY2NTQxODM1NjA3MjEyIE02My4zOTA2MTA3NzExODQ2IC0xNC42NjY1NDE4MzU2MDcyMTIgQzYzLjcyNTM1ODQ4NDQ5Mjg0NCAtMTQuNDMzMDM2MzIxNzk4MzMzLCA2NC4wNjAxMDYxOTc4MDEwOSAtMTQuMTk5NTMwODA3OTg5NDU2LCA2NC4zMTA2ODQyODM1OTYyNyAtMTQuMDI0NzM4MzgyNjg5MjQxIE02My4zOTA2MTA3NzExODQ2IC0xNC42NjY1NDE4MzU2MDcyMTIgQzYzLjY3OTY5MTUyMzYyMTg4NCAtMTQuNDY0ODkxNjE2ODExMDQzLCA2My45Njg3NzIyNzYwNTkxNyAtMTQuMjYzMjQxMzk4MDE0ODczLCA2NC4zMTA2ODQyODM1OTYyNyAtMTQuMDI0NzM4MzgyNjg5MjQxIE02NC4zMTA2ODQyODM1OTYyNyAtMTQuMDI0NzM4MzgyNjg5MjQxIEM2NC41NDA3OTE3MDUzMTY1NSAtMTMuODQxMjMzODM3MjgyOTgzLCA2NC43NzA4OTkxMjcwMzY4MyAtMTMuNjU3NzI5MjkxODc2NzIzLCA2NS4xODc3NDY5MTc4ODYzIC0xMy4zMjUzMDQyNzE0NTk4NTUgTTY0LjMxMDY4NDI4MzU5NjI3IC0xNC4wMjQ3MzgzODI2ODkyNDEgQzY0LjY0NzkwNjA5Mzg5MzE3IC0xMy43NTU4MTI5NjI4MjY3MiwgNjQuOTg1MTI3OTA0MTkwMDcgLTEzLjQ4Njg4NzU0Mjk2NDE5NywgNjUuMTg3NzQ2OTE3ODg2MyAtMTMuMzI1MzA0MjcxNDU5ODU1IE02NS4xODc3NDY5MTc4ODYzIC0xMy4zMjUzMDQyNzE0NTk4NTUgQzY1LjQ3NTYxNDgwMzM0MTYzIC0xMy4wNjM4NzAyNzQ0NTYyMDMsIDY1Ljc2MzQ4MjY4ODc5Njk2IC0xMi44MDI0MzYyNzc0NTI1NTIsIDY2LjAxODE5NDYzNTU2MTAyIC0xMi41NzExMTM2MjY3MTAyMzMgTTY1LjE4Nzc0NjkxNzg4NjMgLTEzLjMyNTMwNDI3MTQ1OTg1NSBDNjUuNDE4NDU2NjYwMjY4MDUgLTEzLjExNTc3OTc4NzY3NDAyNywgNjUuNjQ5MTY2NDAyNjQ5ODEgLTEyLjkwNjI1NTMwMzg4ODIwMiwgNjYuMDE4MTk0NjM1NTYxMDIgLTEyLjU3MTExMzYyNjcxMDIzMyBNNjYuMDE4MTk0NjM1NTYxMDIgLTEyLjU3MTExMzYyNjcxMDIzMyBDNjYuMjYwNzg0NTY4MTEyNjEgLTEyLjMyMDYxOTYwNDM0NjgzNSwgNjYuNTAzMzc0NTAwNjY0MjIgLTEyLjA3MDEyNTU4MTk4MzQzNywgNjYuNzk4NjE0OTQ4ODE4MDEgLTExLjc2NTI2NTU3OTU3MzA0NyBNNjYuMDE4MTk0NjM1NTYxMDIgLTEyLjU3MTExMzYyNjcxMDIzMyBDNjYuMjY0MTg4NjcyMjM5NzcgLTEyLjMxNzEwNDU4NzM1MzM5NywgNjYuNTEwMTgyNzA4OTE4NTMgLTEyLjA2MzA5NTU0Nzk5NjU2LCA2Ni43OTg2MTQ5NDg4MTgwMSAtMTEuNzY1MjY1NTc5NTczMDQ3IE02Ni43OTg2MTQ5NDg4MTgwMSAtMTEuNzY1MjY1NTc5NTczMDQ3IEM2Ni45Nzk4ODE1NDQyNTY0MyAtMTEuNTUyMzM5NTIyMjA5NjA1LCA2Ny4xNjExNDgxMzk2OTQ4NiAtMTEuMzM5NDEzNDY0ODQ2MTY0LCA2Ny41MjU4MDA5NDMxOTA1MiAtMTAuOTExMDcxNTMyNTI3ODM4IE02Ni43OTg2MTQ5NDg4MTgwMSAtMTEuNzY1MjY1NTc5NTczMDQ3IEM2Ny4wNTkxMTg4MTIzNjEzOCAtMTEuNDU5MjYyOTE4MzY1MjUzLCA2Ny4zMTk2MjI2NzU5MDQ3NSAtMTEuMTUzMjYwMjU3MTU3NDYsIDY3LjUyNTgwMDk0MzE5MDUyIC0xMC45MTEwNzE1MzI1Mjc4MzggTTY3LjUyNTgwMDk0MzE5MDUyIC0xMC45MTEwNzE1MzI1Mjc4MzggQzY3LjcyNzgwMzA0ODk1NzMzIC0xMC42NDA0MDcxMTM1NzA3MjYsIDY3LjkyOTgwNTE1NDcyNDE1IC0xMC4zNjk3NDI2OTQ2MTM2MTMsIDY4LjE5Njc2NDQ1NTQ0NjczIC0xMC4wMTIwNDE1NTIxMzc5NzMgTTY3LjUyNTgwMDk0MzE5MDUyIC0xMC45MTEwNzE1MzI1Mjc4MzggQzY3Ljc3MTY1NzQ4NDUwOTE2IC0xMC41ODE2NDYxNjUxNTI1MzYsIDY4LjAxNzUxNDAyNTgyNzgxIC0xMC4yNTIyMjA3OTc3NzcyMzYsIDY4LjE5Njc2NDQ1NTQ0NjczIC0xMC4wMTIwNDE1NTIxMzc5NzMgTTY4LjE5Njc2NDQ1NTQ0NjczIC0xMC4wMTIwNDE1NTIxMzc5NzMgQzY4LjQxMTcwOTI5OTE1NDE0IC05LjY4MTgyODU1MTQzMTE4OCwgNjguNjI2NjU0MTQyODYxNTQgLTkuMzUxNjE1NTUwNzI0NDAyLCA2OC44MDg3NDgzNTI1OTM1NSAtOS4wNzE4Njk5NDU0MzQxOTEgTTY4LjE5Njc2NDQ1NTQ0NjczIC0xMC4wMTIwNDE1NTIxMzc5NzMgQzY4LjQzNTEyNjMxODE4MDY0IC05LjY0NTg1MzcyMTg1NjQxNywgNjguNjczNDg4MTgwOTE0NTUgLTkuMjc5NjY1ODkxNTc0ODYyLCA2OC44MDg3NDgzNTI1OTM1NSAtOS4wNzE4Njk5NDU0MzQxOTEgTTY4LjgwODc0ODM1MjU5MzU1IC05LjA3MTg2OTk0NTQzNDE5MSBDNjguOTI3Mzk1NTI0MzE1NTcgLTguODYxMTk5ODc3NzEyODM3LCA2OS4wNDYwNDI2OTYwMzc1NyAtOC42NTA1Mjk4MDk5OTE0ODQsIDY5LjM1OTIzNzg2MTUyNzUgLTguMDk0NDIwMDc5MjE0NjE3IE02OC44MDg3NDgzNTI1OTM1NSAtOS4wNzE4Njk5NDU0MzQxOTEgQzY4LjkyNTIwNzAxMzc1MzQgLTguODY1MDg1Nzk5ODI2NzAxLCA2OS4wNDE2NjU2NzQ5MTMyMyAtOC42NTgzMDE2NTQyMTkyMTIsIDY5LjM1OTIzNzg2MTUyNzUgLTguMDk0NDIwMDc5MjE0NjE3IE02OS4zNTkyMzc4NjE1Mjc1IC04LjA5NDQyMDA3OTIxNDYxNyBDNjkuNDg1OTQwMjg0MDQxMTIgLTcuODMxMzE5Nzg3ODY3NTQ5LCA2OS42MTI2NDI3MDY1NTQ3MiAtNy41NjgyMTk0OTY1MjA0ODEsIDY5Ljg0NTk3MDkwMjc3NjcxIC03LjA4MzcwODUwNDY0MTg5NiBNNjkuMzU5MjM3ODYxNTI3NSAtOC4wOTQ0MjAwNzkyMTQ2MTcgQzY5LjUwNDYxMTQ2Nzg3NzAxIC03Ljc5MjU0ODY3NTEzMjk4OSwgNjkuNjQ5OTg1MDc0MjI2NSAtNy40OTA2NzcyNzEwNTEzNjIsIDY5Ljg0NTk3MDkwMjc3NjcxIC03LjA4MzcwODUwNDY0MTg5NiBNNjkuODQ1OTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODk2IEM2OS45NDEyODQzMjkxMTM1OSAtNi44NDgyODI0OTg4MzAwODgsIDcwLjAzNjU5Nzc1NTQ1MDQ2IC02LjYxMjg1NjQ5MzAxODI3OSwgNzAuMjY2OTQ3Mzg1ODcwODEgLTYuMDQzODg4NDUyMzcyODkyIE02OS44NDU5NzA5MDI3NzY3MSAtNy4wODM3MDg1MDQ2NDE4OTYgQzY5Ljk1ODQ4MjkzNDYyMzEgLTYuODA1ODAxNjEwNzA5MTQ1LCA3MC4wNzA5OTQ5NjY0Njk1MSAtNi41Mjc4OTQ3MTY3NzYzOTQsIDcwLjI2Njk0NzM4NTg3MDgxIC02LjA0Mzg4ODQ1MjM3Mjg5MiBNNzAuMjY2OTQ3Mzg1ODcwODEgLTYuMDQzODg4NDUyMzcyODkyIEM3MC4zNjUyNTg1MDQwNjgyNyAtNS43NDc3OTEwMjgxMTE2NiwgNzAuNDYzNTY5NjIyMjY1NzIgLTUuNDUxNjkzNjAzODUwNDI3LCA3MC42MjA0Mzc0MjgxNDE1NiAtNC45NzkyMzI3NjYwNDMwNzMgTTcwLjI2Njk0NzM4NTg3MDgxIC02LjA0Mzg4ODQ1MjM3Mjg5MiBDNzAuNDAxMDE1MTIxMjkxMjEgLTUuNjQwMDk3Nzk0MDc5NDM0LCA3MC41MzUwODI4NTY3MTE2IC01LjIzNjMwNzEzNTc4NTk3NiwgNzAuNjIwNDM3NDI4MTQxNTYgLTQuOTc5MjMyNzY2MDQzMDczIE03MC42MjA0Mzc0MjgxNDE1NiAtNC45NzkyMzI3NjYwNDMwNzMgQzcwLjczMDY4NjIxNTEwOTgzIC00LjU1ODgwNjM1OTIwNjU1NCwgNzAuODQwOTM1MDAyMDc4MDggLTQuMTM4Mzc5OTUyMzcwMDM0LCA3MC45MDQ5ODg0NjMxODE5MSAtMy44OTQxMTYzNDQyMzU1MDQgTTcwLjYyMDQzNzQyODE0MTU2IC00Ljk3OTIzMjc2NjA0MzA3MyBDNzAuNzA4OTEyNjc0OTM2MzMgLTQuNjQxODM4MzA0NjAwMDc5LCA3MC43OTczODc5MjE3MzExIC00LjMwNDQ0Mzg0MzE1NzA4NTUsIDcwLjkwNDk4ODQ2MzE4MTkxIC0zLjg5NDExNjM0NDIzNTUwNCBNNzAuOTA0OTg4NDYzMTgxOTEgLTMuODk0MTE2MzQ0MjM1NTA0IEM3MC45NTIwNjYyMzAyOTUwNyAtMy42NTIzODE5NTk5OTkwMjkzLCA3MC45OTkxNDM5OTc0MDgyMyAtMy40MTA2NDc1NzU3NjI1NTUsIDcxLjExOTQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDE0MyBNNzAuOTA0OTg4NDYzMTgxOTEgLTMuODk0MTE2MzQ0MjM1NTA0IEM3MC45ODQ1Mzk2MzY5MzcyNiAtMy40ODU2Mzc4ODAxNDgzMzE2LCA3MS4wNjQwOTA4MTA2OTI2IC0zLjA3NzE1OTQxNjA2MTE1OTcsIDcxLjExOTQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDE0MyBNNzEuMTE5NDMxMjA5NzUyODggLTIuNzkyOTk4MTYzMDg0MTQzIEM3MS4xNzQ4MjcxNjQ0MTcwMSAtMi4zNjMzNTgwNzc4Nzc2NDA2LCA3MS4yMzAyMjMxMTkwODExNSAtMS45MzM3MTc5OTI2NzExMzgzLCA3MS4yNjI4ODQ0NzY2MTA5NiAtMS42ODA0MDI5NTMzODQ0MzQgTTcxLjExOTQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDE0MyBDNzEuMTY5NDg4MDc1MjAwNDYgLTIuNDA0NzY2OTk5NTE4NzI3MywgNzEuMjE5NTQ0OTQwNjQ4MDYgLTIuMDE2NTM1ODM1OTUzMzEyLCA3MS4yNjI4ODQ0NzY2MTA5NiAtMS42ODA0MDI5NTMzODQ0MzQgTTcxLjI2Mjg4NDQ3NjYxMDk2IC0xLjY4MDQwMjk1MzM4NDQzNCBDNzEuMjg3OTE1OTc1NTQ4OSAtMS4yOTA1MTcxNTIzNjM4ODcyLCA3MS4zMTI5NDc0NzQ0ODY4MiAtMC45MDA2MzEzNTEzNDMzNDAyLCA3MS4zMzQ3NTg3ODM1MTIwMyAtMC41NjA5MDI2MDc1MDM5NjU0IE03MS4yNjI4ODQ0NzY2MTA5NiAtMS42ODA0MDI5NTMzODQ0MzQgQzcxLjI4Njg0NzgxMjUyODY1IC0xLjMwNzE1NDY1MzYwOTkzNCwgNzEuMzEwODExMTQ4NDQ2MzIgLTAuOTMzOTA2MzUzODM1NDM0MywgNzEuMzM0NzU4NzgzNTEyMDMgLTAuNTYwOTAyNjA3NTAzOTY1NCBNNzEuMzM0NzU4NzgzNTEyMDMgLTAuNTYwOTAyNjA3NTAzOTY1NCBDNzEuMzM0NzU4NzgzNTEyMDMgLTAuMjEwNzY5NTQ2NTIxNDQwNzUsIDcxLjMzNDc1ODc4MzUxMjAzIDAuMTM5MzYzNTE0NDYxMDgzODYsIDcxLjMzNDc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTYxMSBNNzEuMzM0NzU4NzgzNTEyMDMgLTAuNTYwOTAyNjA3NTAzOTY1NCBDNzEuMzM0NzU4NzgzNTEyMDMgLTAuMjMzMjI2ODg0MjY3NTEwMzcsIDcxLjMzNDc1ODc4MzUxMjAzIDAuMDk0NDQ4ODM4OTY4OTQ0NjMsIDcxLjMzNDc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTYxMSBNNzEuMzM0NzU4NzgzNTEyMDMgMC41NjA5MDI2MDc1MDM5NjExIEM3MS4zMTY4MjQ2NDk4MjU1IDAuODQwMjQxMjE1ODQzNjg5NywgNzEuMjk4ODkwNTE2MTM4OTggMS4xMTk1Nzk4MjQxODM0MTgzLCA3MS4yNjI4ODQ0NzY2MTA5NiAxLjY4MDQwMjk1MzM4NDQyMiBNNzEuMzM0NzU4NzgzNTEyMDMgMC41NjA5MDI2MDc1MDM5NjExIEM3MS4zMTA2NjQ4ODU2NDc3OCAwLjkzNjE4NDUxNDk4Mzg2NywgNzEuMjg2NTcwOTg3NzgzNTUgMS4zMTE0NjY0MjI0NjM3NzMsIDcxLjI2Mjg4NDQ3NjYxMDk2IDEuNjgwNDAyOTUzMzg0NDIyIE03MS4yNjI4ODQ0NzY2MTA5NiAxLjY4MDQwMjk1MzM4NDQyMiBDNzEuMjIxODI0NjY3NDY4MTggMS45OTg4NTQ3MjQ5MTkzNzY0LCA3MS4xODA3NjQ4NTgzMjU0MiAyLjMxNzMwNjQ5NjQ1NDMzMSwgNzEuMTE5NDMxMjA5NzUyODggMi43OTI5OTgxNjMwODQxMzEgTTcxLjI2Mjg4NDQ3NjYxMDk2IDEuNjgwNDAyOTUzMzg0NDIyIEM3MS4yMjM1ODIyNzA5NjUyOCAxLjk4NTIyMzA5OTI3NDA0OCwgNzEuMTg0MjgwMDY1MzE5NTggMi4yOTAwNDMyNDUxNjM2NzQsIDcxLjExOTQzMTIwOTc1Mjg4IDIuNzkyOTk4MTYzMDg0MTMxIE03MS4xMTk0MzEyMDk3NTI4OCAyLjc5Mjk5ODE2MzA4NDEzMSBDNzEuMDQ0NTY2Mzg0NTIyNTMgMy4xNzc0MTMyMTc5NTU1MjUyLCA3MC45Njk3MDE1NTkyOTIxOSAzLjU2MTgyODI3MjgyNjkxOSwgNzAuOTA0OTg4NDYzMTgxOTEgMy44OTQxMTYzNDQyMzU1IE03MS4xMTk0MzEyMDk3NTI4OCAyLjc5Mjk5ODE2MzA4NDEzMSBDNzEuMDM0NTIxNTE3NTYwNiAzLjIyODk5MTQ4NjgyMTYwNCwgNzAuOTQ5NjExODI1MzY4MzUgMy42NjQ5ODQ4MTA1NTkwNzY4LCA3MC45MDQ5ODg0NjMxODE5MSAzLjg5NDExNjM0NDIzNTUgTTcwLjkwNDk4ODQ2MzE4MTkxIDMuODk0MTE2MzQ0MjM1NSBDNzAuODE4MzEzMDA5NTk1MzcgNC4yMjQ2NDc0MTQxNDAxNjUsIDcwLjczMTYzNzU1NjAwODgzIDQuNTU1MTc4NDg0MDQ0ODI5LCA3MC42MjA0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2MSBNNzAuOTA0OTg4NDYzMTgxOTEgMy44OTQxMTYzNDQyMzU1IEM3MC44MjI4NzYwNjIxMzM2NiA0LjIwNzI0NjUxNzE3MjIwNSwgNzAuNzQwNzYzNjYxMDg1NDEgNC41MjAzNzY2OTAxMDg5MSwgNzAuNjIwNDM3NDI4MTQxNTYgNC45NzkyMzI3NjYwNDMwNjEgTTcwLjYyMDQzNzQyODE0MTU2IDQuOTc5MjMyNzY2MDQzMDYxIEM3MC40ODkwNDI2NzA2MjcyMSA1LjM3NDk3Mjg0MDc2NDY4NCwgNzAuMzU3NjQ3OTEzMTEyODcgNS43NzA3MTI5MTU0ODYzMDgsIDcwLjI2Njk0NzM4NTg3MDgxIDYuMDQzODg4NDUyMzcyODggTTcwLjYyMDQzNzQyODE0MTU2IDQuOTc5MjMyNzY2MDQzMDYxIEM3MC41MzI4NzE4NDQ5MzQyOSA1LjI0Mjk2NjM1MDk4MjMyNiwgNzAuNDQ1MzA2MjYxNzI3MDQgNS41MDY2OTk5MzU5MjE1OSwgNzAuMjY2OTQ3Mzg1ODcwODEgNi4wNDM4ODg0NTIzNzI4OCBNNzAuMjY2OTQ3Mzg1ODcwODEgNi4wNDM4ODg0NTIzNzI4OCBDNzAuMTU3MDQ4OTY0MjI2MjYgNi4zMTUzMzk2Nzg1NzYzMjYsIDcwLjA0NzE1MDU0MjU4MTczIDYuNTg2NzkwOTA0Nzc5NzcyLCA2OS44NDU5NzA5MDI3NzY3MSA3LjA4MzcwODUwNDY0MTg5MTUgTTcwLjI2Njk0NzM4NTg3MDgxIDYuMDQzODg4NDUyMzcyODggQzcwLjE2Nzc4NDE2MzE5NjQ2IDYuMjg4ODIzNTI5NTY5MDA0NSwgNzAuMDY4NjIwOTQwNTIyMTEgNi41MzM3NTg2MDY3NjUxMjksIDY5Ljg0NTk3MDkwMjc3NjcxIDcuMDgzNzA4NTA0NjQxODkxNSBNNjkuODQ1OTcwOTAyNzc2NzEgNy4wODM3MDg1MDQ2NDE4OTE1IEM2OS42NzkyMTUwNDE1MjgzNSA3LjQyOTk4MDYxODUyNzk2OSwgNjkuNTEyNDU5MTgwMjc5OTkgNy43NzYyNTI3MzI0MTQwNDcsIDY5LjM1OTIzNzg2MTUyNzUgOC4wOTQ0MjAwNzkyMTQ2MTMgTTY5Ljg0NTk3MDkwMjc3NjcxIDcuMDgzNzA4NTA0NjQxODkxNSBDNjkuNjc5OTk0MTAwNTA2OTUgNy40MjgzNjI4ODU4ODk3MTYsIDY5LjUxNDAxNzI5ODIzNzE5IDcuNzczMDE3MjY3MTM3NTQyLCA2OS4zNTkyMzc4NjE1Mjc1IDguMDk0NDIwMDc5MjE0NjEzIE02OS4zNTkyMzc4NjE1Mjc1IDguMDk0NDIwMDc5MjE0NjEzIEM2OS4xNDk5ODM3OTYzNDQyNyA4LjQ2NTk3MTg2MTIxOTIxNSwgNjguOTQwNzI5NzMxMTYxMDYgOC44Mzc1MjM2NDMyMjM4MTYsIDY4LjgwODc0ODM1MjU5MzU1IDkuMDcxODY5OTQ1NDM0MTg2IE02OS4zNTkyMzc4NjE1Mjc1IDguMDk0NDIwMDc5MjE0NjEzIEM2OS4xNDExNzg0NDk0MTA5MyA4LjQ4MTYwNjY0NjMzNzQ0NSwgNjguOTIzMTE5MDM3Mjk0MzQgOC44Njg3OTMyMTM0NjAyNzUsIDY4LjgwODc0ODM1MjU5MzU1IDkuMDcxODY5OTQ1NDM0MTg2IE02OC44MDg3NDgzNTI1OTM1NSA5LjA3MTg2OTk0NTQzNDE4NiBDNjguNjE0MjQxNDU5NDIxNzggOS4zNzA2ODQ3NjU3NjAwNzUsIDY4LjQxOTczNDU2NjI1IDkuNjY5NDk5NTg2MDg1OTY2LCA2OC4xOTY3NjQ0NTU0NDY3MyAxMC4wMTIwNDE1NTIxMzc5NjQgTTY4LjgwODc0ODM1MjU5MzU1IDkuMDcxODY5OTQ1NDM0MTg2IEM2OC42NjY0MTI4NDI2MzA0IDkuMjkwNTM1NTExMTczNjc4LCA2OC41MjQwNzczMzI2NjcyMiA5LjUwOTIwMTA3NjkxMzE3LCA2OC4xOTY3NjQ0NTU0NDY3MyAxMC4wMTIwNDE1NTIxMzc5NjQgTTY4LjE5Njc2NDQ1NTQ0NjczIDEwLjAxMjA0MTU1MjEzNzk2NCBDNjguMDU2NzEwNjg3MTczMzkgMTAuMTk5NzAwODQyNDYzNDYzLCA2Ny45MTY2NTY5MTg5MDAwNiAxMC4zODczNjAxMzI3ODg5NjEsIDY3LjUyNTgwMDk0MzE5MDUyIDEwLjkxMTA3MTUzMjUyNzgzNSBNNjguMTk2NzY0NDU1NDQ2NzMgMTAuMDEyMDQxNTUyMTM3OTY0IEM2Ny45NzU0MjczNTE3MDk2MyAxMC4zMDg2MTMxMDY5MjA3MTcsIDY3Ljc1NDA5MDI0Nzk3MjUxIDEwLjYwNTE4NDY2MTcwMzQ3LCA2Ny41MjU4MDA5NDMxOTA1MiAxMC45MTEwNzE1MzI1Mjc4MzUgTTY3LjUyNTgwMDk0MzE5MDUyIDEwLjkxMTA3MTUzMjUyNzgzNSBDNjcuMzAyNzgwNDgzMDE0OTggMTEuMTczMDQ0MDU1MjczNzA4LCA2Ny4wNzk3NjAwMjI4Mzk0NCAxMS40MzUwMTY1NzgwMTk1ODIsIDY2Ljc5ODYxNDk0ODgxODAzIDExLjc2NTI2NTU3OTU3MzAzOCBNNjcuNTI1ODAwOTQzMTkwNTIgMTAuOTExMDcxNTMyNTI3ODM1IEM2Ny4zNzY4NDI0NDA1MjY0NiAxMS4wODYwNDY2NjU3MzU5NjIsIDY3LjIyNzg4MzkzNzg2MjM5IDExLjI2MTAyMTc5ODk0NDA4OSwgNjYuNzk4NjE0OTQ4ODE4MDMgMTEuNzY1MjY1NTc5NTczMDM4IE02Ni43OTg2MTQ5NDg4MTgwMyAxMS43NjUyNjU1Nzk1NzMwMzggQzY2LjU5OTM4ODM4MzE4ODg0IDExLjk3MDk4MzM2NTM5MDQwNSwgNjYuNDAwMTYxODE3NTU5NjYgMTIuMTc2NzAxMTUxMjA3NzczLCA2Ni4wMTgxOTQ2MzU1NjEwMiAxMi41NzExMTM2MjY3MTAyMjkgTTY2Ljc5ODYxNDk0ODgxODAzIDExLjc2NTI2NTU3OTU3MzAzOCBDNjYuNjM2Mjg3OTkzMDg1NzkgMTEuOTMyODgxNDg4NjU3NDk1LCA2Ni40NzM5NjEwMzczNTM1NSAxMi4xMDA0OTczOTc3NDE5NSwgNjYuMDE4MTk0NjM1NTYxMDIgMTIuNTcxMTEzNjI2NzEwMjI5IE02Ni4wMTgxOTQ2MzU1NjEwMiAxMi41NzExMTM2MjY3MTAyMjkgQzY1LjgzNjUwNTYyMDgxMjI4IDEyLjczNjExODc4MjY3NzEzNywgNjUuNjU0ODE2NjA2MDYzNTMgMTIuOTAxMTIzOTM4NjQ0MDQ0LCA2NS4xODc3NDY5MTc4ODYzMiAxMy4zMjUzMDQyNzE0NTk4NDIgTTY2LjAxODE5NDYzNTU2MTAyIDEyLjU3MTExMzYyNjcxMDIyOSBDNjUuNjk3NjI1NjgzNDkxNDIgMTIuODYyMjQ1ODY3MTkwMTU4LCA2NS4zNzcwNTY3MzE0MjE4MiAxMy4xNTMzNzgxMDc2NzAwODYsIDY1LjE4Nzc0NjkxNzg4NjMyIDEzLjMyNTMwNDI3MTQ1OTg0MiBNNjUuMTg3NzQ2OTE3ODg2MzIgMTMuMzI1MzA0MjcxNDU5ODQyIEM2NC44NjQ4ODMxNzcyNTMwMyAxMy41ODI3Nzk1MTI4NDk5MTQsIDY0LjU0MjAxOTQzNjYxOTc1IDEzLjg0MDI1NDc1NDIzOTk4NiwgNjQuMzEwNjg0MjgzNTk2MjkgMTQuMDI0NzM4MzgyNjg5MjQgTTY1LjE4Nzc0NjkxNzg4NjMyIDEzLjMyNTMwNDI3MTQ1OTg0MiBDNjQuODkyMzU2ODMwMjE3MSAxMy41NjA4NzAwMDU3MTU2ODUsIDY0LjU5Njk2Njc0MjU0Nzg4IDEzLjc5NjQzNTczOTk3MTUzLCA2NC4zMTA2ODQyODM1OTYyOSAxNC4wMjQ3MzgzODI2ODkyNCBNNjQuMzEwNjg0MjgzNTk2MjkgMTQuMDI0NzM4MzgyNjg5MjQgQzY0LjA2NDgzMTczMDk0MjIgMTQuMTk2MjM0NDgwNjM1MjU1LCA2My44MTg5NzkxNzgyODgxMjQgMTQuMzY3NzMwNTc4NTgxMjcsIDYzLjM5MDYxMDc3MTE4NDYxIDE0LjY2NjU0MTgzNTYwNzIwNyBNNjQuMzEwNjg0MjgzNTk2MjkgMTQuMDI0NzM4MzgyNjg5MjQgQzY0LjA4MjAxNzg1NDU1NjI0IDE0LjE4NDI0NjE4NDc3NzQwNCwgNjMuODUzMzUxNDI1NTE2MTk1IDE0LjM0Mzc1Mzk4Njg2NTU2OCwgNjMuMzkwNjEwNzcxMTg0NjEgMTQuNjY2NTQxODM1NjA3MjA3IE02My4zOTA2MTA3NzExODQ2MSAxNC42NjY1NDE4MzU2MDcyMDcgQzYzLjA1NDIyNDQwMjIwMDY2IDE0Ljg3MDQ2MTIyOTMxMTAwNSwgNjIuNzE3ODM4MDMzMjE2NzE1IDE1LjA3NDM4MDYyMzAxNDgwMiwgNjIuNDMxMzA3MTYwMDY4OTEgMTUuMjQ4MDc3MzIyMTU5MzE1IE02My4zOTA2MTA3NzExODQ2MSAxNC42NjY1NDE4MzU2MDcyMDcgQzYzLjEyMTYyNDk1NjY4MDk5NiAxNC44Mjk2MDI2MTcwOTU0MDQsIDYyLjg1MjYzOTE0MjE3NzM4IDE0Ljk5MjY2MzM5ODU4MzYwMiwgNjIuNDMxMzA3MTYwMDY4OTEgMTUuMjQ4MDc3MzIyMTU5MzE1IE02Mi40MzEzMDcxNjAwNjg5MSAxNS4yNDgwNzczMjIxNTkzMTUgQzYyLjA3OTM2OTU0NDYxNDAxIDE1LjQzMTY4Mjk1MDcxNTMzNiwgNjEuNzI3NDMxOTI5MTU5MTEgMTUuNjE1Mjg4NTc5MjcxMzU4LCA2MS40MzY3MTU0MzQ1NTcyNyAxNS43NjY5NTUxODgyOTIzMzIgTTYyLjQzMTMwNzE2MDA2ODkxIDE1LjI0ODA3NzMyMjE1OTMxNSBDNjIuMDkxNDAwNDE4Mzk4MTIgMTUuNDI1NDA2NDUxNTY4MzA1LCA2MS43NTE0OTM2NzY3MjczNCAxNS42MDI3MzU1ODA5NzcyOTQsIDYxLjQzNjcxNTQzNDU1NzI3IDE1Ljc2Njk1NTE4ODI5MjMzMiBNNjEuNDM2NzE1NDM0NTU3MjcgMTUuNzY2OTU1MTg4MjkyMzMyIEM2MS4yMDQyODEyMjkzNjE4IDE1Ljg2OTg0NjkxNjAxNjY1LCA2MC45NzE4NDcwMjQxNjYzMTYgMTUuOTcyNzM4NjQzNzQwOTY4LCA2MC40MTA5MjI1ODUzODkwNSAxNi4yMjEwNDMyNTM1NTUzOCBNNjEuNDM2NzE1NDM0NTU3MjcgMTUuNzY2OTU1MTg4MjkyMzMyIEM2MS4xNDU5MjM3NjAzNTI2MTYgMTUuODk1NjgwMDM2NDM0MjAyLCA2MC44NTUxMzIwODYxNDc5NiAxNi4wMjQ0MDQ4ODQ1NzYwNywgNjAuNDEwOTIyNTg1Mzg5MDUgMTYuMjIxMDQzMjUzNTU1MzggTTYwLjQxMDkyMjU4NTM4OTA1IDE2LjIyMTA0MzI1MzU1NTM4IEM2MC4xMDA1ODE4NTkyMzU1NSAxNi4zMzUyNTE1MDk1MzgwOTMsIDU5Ljc5MDI0MTEzMzA4MjAzNCAxNi40NDk0NTk3NjU1MjA4MSwgNTkuMzU4MTQzODE1NDEzMzcgMTYuNjA4NDc1NTcyNjg2Njk3IE02MC40MTA5MjI1ODUzODkwNSAxNi4yMjEwNDMyNTM1NTUzOCBDNjAuMTQ1MjcyNDQ4NDM1MDY1IDE2LjMxODgwNDk1OTU5NzM5NCwgNTkuODc5NjIyMzExNDgxMDg2IDE2LjQxNjU2NjY2NTYzOTQwNCwgNTkuMzU4MTQzODE1NDEzMzcgMTYuNjA4NDc1NTcyNjg2Njk3IE01OS4zNTgxNDM4MTU0MTMzNyAxNi42MDg0NzU1NzI2ODY2OTcgQzU5LjExNjMzMTY3MjAyMTcgMTYuNjgwMjQ0MTQ3NTQ3NSwgNTguODc0NTE5NTI4NjMwMDMgMTYuNzUyMDEyNzIyNDA4MzEsIDU4LjI4MjcwNTIxODQxNjM5NiAxNi45Mjc2NjAxMDMxODMwMTIgTTU5LjM1ODE0MzgxNTQxMzM3IDE2LjYwODQ3NTU3MjY4NjY5NyBDNTkuMDA0NTk2NTk3NTcyODE0IDE2LjcxMzQwNjUzMTEzNDU2LCA1OC42NTEwNDkzNzk3MzIyNiAxNi44MTgzMzc0ODk1ODI0MiwgNTguMjgyNzA1MjE4NDE2Mzk2IDE2LjkyNzY2MDEwMzE4MzAxMiBNNTguMjgyNzA1MjE4NDE2Mzk2IDE2LjkyNzY2MDEwMzE4MzAxMiBDNTcuOTE2NDEwMjQwNDA1NzIgMTcuMDExMjY0NTQxNjE1ODM0LCA1Ny41NTAxMTUyNjIzOTUwNCAxNy4wOTQ4Njg5ODAwNDg2NTIsIDU3LjE4OTAyNjAwMjI3NDAyIDE3LjE3NzI4NTI0NzM0MzY0NCBNNTguMjgyNzA1MjE4NDE2Mzk2IDE2LjkyNzY2MDEwMzE4MzAxMiBDNTcuODgxNjM5OTU4MzI1MDMgMTcuMDE5MjAwNjMxNjAzNDU0LCA1Ny40ODA1NzQ2OTgyMzM2NiAxNy4xMTA3NDExNjAwMjM5LCA1Ny4xODkwMjYwMDIyNzQwMiAxNy4xNzcyODUyNDczNDM2NDQgTTU3LjE4OTAyNjAwMjI3NDAyIDE3LjE3NzI4NTI0NzM0MzY0NCBDNTYuOTI2OTA5ODc0MDU0OTMgMTcuMjE5NjYyMTUwMjEzMTc1LCA1Ni42NjQ3OTM3NDU4MzU4NCAxNy4yNjIwMzkwNTMwODI3MDIsIDU2LjA4MTYwMDMyOTQ3ODg3IDE3LjM1NjMyNTI0MTkwNjgwNiBNNTcuMTg5MDI2MDAyMjc0MDIgMTcuMTc3Mjg1MjQ3MzQzNjQ0IEM1Ni44MTAxNTE2MTg4ODE4NTQgMTcuMjM4NTM4NzE5NDM1NzYzLCA1Ni40MzEyNzcyMzU0ODk2OSAxNy4yOTk3OTIxOTE1Mjc4OCwgNTYuMDgxNjAwMzI5NDc4ODcgMTcuMzU2MzI1MjQxOTA2ODA2IE01Ni4wODE2MDAzMjk0Nzg4NyAxNy4zNTYzMjUyNDE5MDY4MDYgQzU1LjcxMDYzMTE2ODg2ODI5IDE3LjM5MjExMjE5MDY3NTIxNywgNTUuMzM5NjYyMDA4MjU3NzIgMTcuNDI3ODk5MTM5NDQzNjMsIDU0Ljk2NDk3ODg0OTY2MjQ3IDE3LjQ2NDA0NDM3MzEzMDg4NiBNNTYuMDgxNjAwMzI5NDc4ODcgMTcuMzU2MzI1MjQxOTA2ODA2IEM1NS42OTMyNTE2NDgyNDMzMiAxNy4zOTM3ODg3NzIxMjc5NzYsIDU1LjMwNDkwMjk2NzAwNzc2IDE3LjQzMTI1MjMwMjM0OTE0NywgNTQuOTY0OTc4ODQ5NjYyNDcgMTcuNDY0MDQ0MzczMTMwODg2IE01NC45NjQ5Nzg4NDk2NjI0NyAxNy40NjQwNDQzNzMxMzA4ODYgQzU0LjU0MzQ3OTUwNTcwNjI5NCAxNy40Nzc1NjEwMzY2OTI4NTgsIDU0LjEyMTk4MDE2MTc1MDExNiAxNy40OTEwNzc3MDAyNTQ4MywgNTMuODQzNzUgMTcuNSBNNTQuOTY0OTc4ODQ5NjYyNDcgMTcuNDY0MDQ0MzczMTMwODg2IEM1NC43MjIwNDM1NzU3ODE1OCAxNy40NzE4MzQ4MzQ1MTk0MiwgNTQuNDc5MTA4MzAxOTAwNjk1IDE3LjQ3OTYyNTI5NTkwNzk1NSwgNTMuODQzNzUgMTcuNSBNNTMuODQzNzUgMTcuNSBDNTMuODQzNzUgMTcuNSwgNTMuODQzNzUgMTcuNSwgNTMuODQzNzUgMTcuNSBNNTMuODQzNzUgMTcuNSBDNTMuODQzNzUgMTcuNSwgNTMuODQzNzUgMTcuNSwgNTMuODQzNzUgMTcuNSBNNTMuODQzNzUgMTcuNSBDMTYuMjUwMDI4Nzg4MTU1OTAyIDE3LjUsIC0yMS4zNDM2OTI0MjM2ODgxOTYgMTcuNSwgLTUzLjg0Mzc1IDE3LjUgTTUzLjg0Mzc1IDE3LjUgQzEzLjgwNzQ0OTg3NDExNjI0NCAxNy41LCAtMjYuMjI4ODUwMjUxNzY3NTEgMTcuNSwgLTUzLjg0Mzc1IDE3LjUgTS01My44NDM3NSAxNy41IEMtNTQuMTgzNTg5Nzg1Mzc2OCAxNy40ODkxMDE5OTk1NDA5OCwgLTU0LjUyMzQyOTU3MDc1MzYxIDE3LjQ3ODIwMzk5OTA4MTk2LCAtNTQuOTY0OTc4ODQ5NjYyNDY1IDE3LjQ2NDA0NDM3MzEzMDg4NiBNLTUzLjg0Mzc1IDE3LjUgQy01NC4yMzg2ODg4NzA2Mjc2MyAxNy40ODczMzUwNzkxMjA4NSwgLTU0LjYzMzYyNzc0MTI1NTI1IDE3LjQ3NDY3MDE1ODI0MTY5NywgLTU0Ljk2NDk3ODg0OTY2MjQ2NSAxNy40NjQwNDQzNzMxMzA4ODYgTS01NC45NjQ5Nzg4NDk2NjI0NjUgMTcuNDY0MDQ0MzczMTMwODg2IEMtNTUuNDA5MjkxMDI3MTQyNTYgMTcuNDIxMTgyMTExNzMyOTU0LCAtNTUuODUzNjAzMjA0NjIyNjUgMTcuMzc4MzE5ODUwMzM1MDI1LCAtNTYuMDgxNjAwMzI5NDc4ODYgMTcuMzU2MzI1MjQxOTA2ODA2IE0tNTQuOTY0OTc4ODQ5NjYyNDY1IDE3LjQ2NDA0NDM3MzEzMDg4NiBDLTU1LjE5MzIzNTEyMDAyNzQxIDE3LjQ0MjAyNDc2NTI0NzExLCAtNTUuNDIxNDkxMzkwMzkyMzUgMTcuNDIwMDA1MTU3MzYzMzMsIC01Ni4wODE2MDAzMjk0Nzg4NiAxNy4zNTYzMjUyNDE5MDY4MDYgTS01Ni4wODE2MDAzMjk0Nzg4NiAxNy4zNTYzMjUyNDE5MDY4MDYgQy01Ni4zODIyOTA4OTkyNDA4MSAxNy4zMDc3MTE5MjI0Nzc4OSwgLTU2LjY4Mjk4MTQ2OTAwMjc1NSAxNy4yNTkwOTg2MDMwNDg5NzIsIC01Ny4xODkwMjYwMDIyNzQwMSAxNy4xNzcyODUyNDczNDM2NDQgTS01Ni4wODE2MDAzMjk0Nzg4NiAxNy4zNTYzMjUyNDE5MDY4MDYgQy01Ni40NzczNTk3ODgyODE0NiAxNy4yOTIzNDE5MjE3NjgwNDIsIC01Ni44NzMxMTkyNDcwODQwNiAxNy4yMjgzNTg2MDE2MjkyNzgsIC01Ny4xODkwMjYwMDIyNzQwMSAxNy4xNzcyODUyNDczNDM2NDQgTS01Ny4xODkwMjYwMDIyNzQwMSAxNy4xNzcyODUyNDczNDM2NDQgQy01Ny40MjI1MDEzOTg0OTU0MDYgMTcuMTIzOTk2MDExNzI1NDU2LCAtNTcuNjU1OTc2Nzk0NzE2OCAxNy4wNzA3MDY3NzYxMDcyNywgLTU4LjI4MjcwNTIxODQxNjM3NSAxNi45Mjc2NjAxMDMxODMwMTUgTS01Ny4xODkwMjYwMDIyNzQwMSAxNy4xNzcyODUyNDczNDM2NDQgQy01Ny40NTQ4NzExNzgxNTU3MDYgMTcuMTE2NjA3ODIwNzUwNTQ1LCAtNTcuNzIwNzE2MzU0MDM3NDEgMTcuMDU1OTMwMzk0MTU3NDQ2LCAtNTguMjgyNzA1MjE4NDE2Mzc1IDE2LjkyNzY2MDEwMzE4MzAxNSBNLTU4LjI4MjcwNTIxODQxNjM3NSAxNi45Mjc2NjAxMDMxODMwMTUgQy01OC42NDk1MDI1NDc5ODAwMyAxNi44MTg3OTY1ODExMjY5OTYsIC01OS4wMTYyOTk4Nzc1NDM2OCAxNi43MDk5MzMwNTkwNzA5NzcsIC01OS4zNTgxNDM4MTU0MTMzNiAxNi42MDg0NzU1NzI2ODY3MDQgTS01OC4yODI3MDUyMTg0MTYzNzUgMTYuOTI3NjYwMTAzMTgzMDE1IEMtNTguNjY2NTA1Mjk3NzYyODkgMTYuODEzNzUwMjU0MjQwNywgLTU5LjA1MDMwNTM3NzEwOTQxIDE2LjY5OTg0MDQwNTI5ODM3OCwgLTU5LjM1ODE0MzgxNTQxMzM2IDE2LjYwODQ3NTU3MjY4NjcwNCBNLTU5LjM1ODE0MzgxNTQxMzM2IDE2LjYwODQ3NTU3MjY4NjcwNCBDLTU5LjY4NzYyMDEwNDY2MiAxNi40ODcyMjUyNTI1OTc3NywgLTYwLjAxNzA5NjM5MzkxMDY1NiAxNi4zNjU5NzQ5MzI1MDg4MzQsIC02MC40MTA5MjI1ODUzODkwNDUgMTYuMjIxMDQzMjUzNTU1MzggTS01OS4zNTgxNDM4MTU0MTMzNiAxNi42MDg0NzU1NzI2ODY3MDQgQy01OS43MjIwMTMzODEwMzM1OCAxNi40NzQ1NjgyMDg5NjUwNywgLTYwLjA4NTg4Mjk0NjY1MzggMTYuMzQwNjYwODQ1MjQzNDM0LCAtNjAuNDEwOTIyNTg1Mzg5MDQ1IDE2LjIyMTA0MzI1MzU1NTM4IE0tNjAuNDEwOTIyNTg1Mzg5MDQ1IDE2LjIyMTA0MzI1MzU1NTM4IEMtNjAuNzAxMzgyNzExNzU4MTEgMTYuMDkyNDY1MTcxODA1MzEsIC02MC45OTE4NDI4MzgxMjcxOCAxNS45NjM4ODcwOTAwNTUyNDEsIC02MS40MzY3MTU0MzQ1NTcyNjQgMTUuNzY2OTU1MTg4MjkyMzM4IE0tNjAuNDEwOTIyNTg1Mzg5MDQ1IDE2LjIyMTA0MzI1MzU1NTM4IEMtNjAuODA2MTY2MDkwMDcxNjU2IDE2LjA0NjA4MDY3ODUxNDM4MiwgLTYxLjIwMTQwOTU5NDc1NDI3NCAxNS44NzExMTgxMDM0NzMzODcsIC02MS40MzY3MTU0MzQ1NTcyNjQgMTUuNzY2OTU1MTg4MjkyMzM4IE0tNjEuNDM2NzE1NDM0NTU3MjY0IDE1Ljc2Njk1NTE4ODI5MjMzOCBDLTYxLjc1MTk0OTQxOTYwMDYxIDE1LjYwMjQ5NzgyMDIxMjIyOCwgLTYyLjA2NzE4MzQwNDY0Mzk1NiAxNS40MzgwNDA0NTIxMzIxMiwgLTYyLjQzMTMwNzE2MDA2ODkwNCAxNS4yNDgwNzczMjIxNTkzMTggTS02MS40MzY3MTU0MzQ1NTcyNjQgMTUuNzY2OTU1MTg4MjkyMzM4IEMtNjEuODExNTQxNDcyNjcwODggMTUuNTcxNDA4Njg0Mjk2LCAtNjIuMTg2MzY3NTEwNzg0NDkgMTUuMzc1ODYyMTgwMjk5NjYzLCAtNjIuNDMxMzA3MTYwMDY4OTA0IDE1LjI0ODA3NzMyMjE1OTMxOCBNLTYyLjQzMTMwNzE2MDA2ODkwNCAxNS4yNDgwNzczMjIxNTkzMTggQy02Mi43ODI2MTg1Mjg0MzAwMSAxNS4wMzUxMTAzMDYxMjQwNTcsIC02My4xMzM5Mjk4OTY3OTExMSAxNC44MjIxNDMyOTAwODg3OTYsIC02My4zOTA2MTA3NzExODQ1OSAxNC42NjY1NDE4MzU2MDcyMTggTS02Mi40MzEzMDcxNjAwNjg5MDQgMTUuMjQ4MDc3MzIyMTU5MzE4IEMtNjIuNzQ0MTgyOTU5ODIxNyAxNS4wNTg0MTAxNzM2ODY4ODYsIC02My4wNTcwNTg3NTk1NzQ0OTUgMTQuODY4NzQzMDI1MjE0NDUzLCAtNjMuMzkwNjEwNzcxMTg0NTkgMTQuNjY2NTQxODM1NjA3MjE4IE0tNjMuMzkwNjEwNzcxMTg0NTkgMTQuNjY2NTQxODM1NjA3MjE4IEMtNjMuNjAwNDQxNzI5MTM2NjMgMTQuNTIwMTcyODQyNzc1NjQ5LCAtNjMuODEwMjcyNjg3MDg4NjYgMTQuMzczODAzODQ5OTQ0MDc4LCAtNjQuMzEwNjg0MjgzNTk2MjcgMTQuMDI0NzM4MzgyNjg5MjQzIE0tNjMuMzkwNjEwNzcxMTg0NTkgMTQuNjY2NTQxODM1NjA3MjE4IEMtNjMuNjg4NTkyOTI0MDU2MzQgMTQuNDU4NjgyMzg1MjAzMzgzLCAtNjMuOTg2NTc1MDc2OTI4MDg0IDE0LjI1MDgyMjkzNDc5OTU1LCAtNjQuMzEwNjg0MjgzNTk2MjcgMTQuMDI0NzM4MzgyNjg5MjQzIE0tNjQuMzEwNjg0MjgzNTk2MjcgMTQuMDI0NzM4MzgyNjg5MjQzIEMtNjQuNjIxNjkzNDU2NzI0MzYgMTMuNzc2NzE2ODQzNDIxMjgzLCAtNjQuOTMyNzAyNjI5ODUyNDMgMTMuNTI4Njk1MzA0MTUzMzI0LCAtNjUuMTg3NzQ2OTE3ODg2MyAxMy4zMjUzMDQyNzE0NTk4NTYgTS02NC4zMTA2ODQyODM1OTYyNyAxNC4wMjQ3MzgzODI2ODkyNDMgQy02NC41ODQ2MDczMzM3MDUgMTMuODA2MjkyMDM5NjI2MDQyLCAtNjQuODU4NTMwMzgzODEzNzIgMTMuNTg3ODQ1Njk2NTYyODQzLCAtNjUuMTg3NzQ2OTE3ODg2MyAxMy4zMjUzMDQyNzE0NTk4NTYgTS02NS4xODc3NDY5MTc4ODYzIDEzLjMyNTMwNDI3MTQ1OTg1NiBDLTY1LjUxNDA1ODYyNDczMzE3IDEzLjAyODk1NjYxMzAzNjE3NiwgLTY1Ljg0MDM3MDMzMTU4MDA1IDEyLjczMjYwODk1NDYxMjQ5MywgLTY2LjAxODE5NDYzNTU2MSAxMi41NzExMTM2MjY3MTAyNDEgTS02NS4xODc3NDY5MTc4ODYzIDEzLjMyNTMwNDI3MTQ1OTg1NiBDLTY1LjQyNzQzOTg3NzEyMTYzIDEzLjEwNzYyMTQ2NzgxMDQ5OCwgLTY1LjY2NzEzMjgzNjM1Njk3IDEyLjg4OTkzODY2NDE2MTE0MSwgLTY2LjAxODE5NDYzNTU2MSAxMi41NzExMTM2MjY3MTAyNDEgTS02Ni4wMTgxOTQ2MzU1NjEgMTIuNTcxMTEzNjI2NzEwMjQxIEMtNjYuMTk5MzEwNDQxNDMwMTMgMTIuMzg0MDk2Njg3MjY2MTY5LCAtNjYuMzgwNDI2MjQ3Mjk5MjUgMTIuMTk3MDc5NzQ3ODIyMDk2LCAtNjYuNzk4NjE0OTQ4ODE4MDMgMTEuNzY1MjY1NTc5NTczMDQzIE0tNjYuMDE4MTk0NjM1NTYxIDEyLjU3MTExMzYyNjcxMDI0MSBDLTY2LjI5MzIwMzg4NDkxNTUzIDEyLjI4NzE0Mzk5ODA3MjQxNCwgLTY2LjU2ODIxMzEzNDI3MDA1IDEyLjAwMzE3NDM2OTQzNDU5LCAtNjYuNzk4NjE0OTQ4ODE4MDMgMTEuNzY1MjY1NTc5NTczMDQzIE0tNjYuNzk4NjE0OTQ4ODE4MDMgMTEuNzY1MjY1NTc5NTczMDQzIEMtNjcuMDgyMTcwNjA5OTM5MDQgMTEuNDMyMTg0OTY1MjQ2MDk4LCAtNjcuMzY1NzI2MjcxMDYwMDUgMTEuMDk5MTA0MzUwOTE5MTU0LCAtNjcuNTI1ODAwOTQzMTkwNTIgMTAuOTExMDcxNTMyNTI3ODQgTS02Ni43OTg2MTQ5NDg4MTgwMyAxMS43NjUyNjU1Nzk1NzMwNDMgQy02Ny4wMzI1MzE4NTA3MTUyNyAxMS40OTA0OTM0NzYzNTU3NiwgLTY3LjI2NjQ0ODc1MjYxMjUyIDExLjIxNTcyMTM3MzEzODQ3NSwgLTY3LjUyNTgwMDk0MzE5MDUyIDEwLjkxMTA3MTUzMjUyNzg0IE0tNjcuNTI1ODAwOTQzMTkwNTIgMTAuOTExMDcxNTMyNTI3ODQgQy02Ny42NjQ1ODMwNzIxNTg1MiAxMC43MjUxMTYxMjMwMjI3NTgsIC02Ny44MDMzNjUyMDExMjY1NCAxMC41MzkxNjA3MTM1MTc2NzYsIC02OC4xOTY3NjQ0NTU0NDY3MyAxMC4wMTIwNDE1NTIxMzc5NzQgTS02Ny41MjU4MDA5NDMxOTA1MiAxMC45MTEwNzE1MzI1Mjc4NCBDLTY3Ljc3NDkwODkwNjMxMTQyIDEwLjU3NzI4OTU1NjE0ODE0LCAtNjguMDI0MDE2ODY5NDMyMzIgMTAuMjQzNTA3NTc5NzY4NDQsIC02OC4xOTY3NjQ0NTU0NDY3MyAxMC4wMTIwNDE1NTIxMzc5NzQgTS02OC4xOTY3NjQ0NTU0NDY3MyAxMC4wMTIwNDE1NTIxMzc5NzQgQy02OC4zNDM0MzY1MzY0NzAxIDkuNzg2NzEzODQ4NzE3NjMyLCAtNjguNDkwMTA4NjE3NDkzNDYgOS41NjEzODYxNDUyOTcyOSwgLTY4LjgwODc0ODM1MjU5MzU1IDkuMDcxODY5OTQ1NDM0MTk4IE0tNjguMTk2NzY0NDU1NDQ2NzMgMTAuMDEyMDQxNTUyMTM3OTc0IEMtNjguNDE0MTUyNTQ5Njk0NzkgOS42NzgwNzUwNjI0OTYxMDIsIC02OC42MzE1NDA2NDM5NDI4NyA5LjM0NDEwODU3Mjg1NDIzLCAtNjguODA4NzQ4MzUyNTkzNTUgOS4wNzE4Njk5NDU0MzQxOTggTS02OC44MDg3NDgzNTI1OTM1NSA5LjA3MTg2OTk0NTQzNDE5OCBDLTY4Ljk3MzM3MzA3NjI3NjQzIDguNzc5NTYyMDc4NDc0MzQsIC02OS4xMzc5OTc3OTk5NTkzMSA4LjQ4NzI1NDIxMTUxNDQ4MiwgLTY5LjM1OTIzNzg2MTUyNzUgOC4wOTQ0MjAwNzkyMTQ2MTggTS02OC44MDg3NDgzNTI1OTM1NSA5LjA3MTg2OTk0NTQzNDE5OCBDLTY5LjAwNjc4MDYzNzE5NjE2IDguNzIwMjQzNTcxMTc4OTksIC02OS4yMDQ4MTI5MjE3OTg3NiA4LjM2ODYxNzE5NjkyMzc4LCAtNjkuMzU5MjM3ODYxNTI3NSA4LjA5NDQyMDA3OTIxNDYxOCBNLTY5LjM1OTIzNzg2MTUyNzUgOC4wOTQ0MjAwNzkyMTQ2MTggQy02OS40NjcyMTcxMTM3OTcxMiA3Ljg3MDE5ODg1MTQ5MDg2NSwgLTY5LjU3NTE5NjM2NjA2Njc1IDcuNjQ1OTc3NjIzNzY3MTExLCAtNjkuODQ1OTcwOTAyNzc2NzEgNy4wODM3MDg1MDQ2NDE4OTggTS02OS4zNTkyMzc4NjE1Mjc1IDguMDk0NDIwMDc5MjE0NjE4IEMtNjkuNDc0NzIzMzUyOTgwMDUgNy44NTQ2MTE5ODUyMTk3MjQsIC02OS41OTAyMDg4NDQ0MzI2MSA3LjYxNDgwMzg5MTIyNDgyOSwgLTY5Ljg0NTk3MDkwMjc3NjcxIDcuMDgzNzA4NTA0NjQxODk4IE0tNjkuODQ1OTcwOTAyNzc2NzEgNy4wODM3MDg1MDQ2NDE4OTggQy02OS45NTk1OTkzMTY3NjYyNCA2LjgwMzA0NDEyNTIzMTgzNSwgLTcwLjA3MzIyNzczMDc1NTc4IDYuNTIyMzc5NzQ1ODIxNzczLCAtNzAuMjY2OTQ3Mzg1ODcwODEgNi4wNDM4ODg0NTIzNzI4OTQgTS02OS44NDU5NzA5MDI3NzY3MSA3LjA4MzcwODUwNDY0MTg5OCBDLTY5Ljk2NDgyMzM2NTMzOCA2Ljc5MDE0MDYyNDI1OTQ3NiwgLTcwLjA4MzY3NTgyNzg5OTI4IDYuNDk2NTcyNzQzODc3MDU1LCAtNzAuMjY2OTQ3Mzg1ODcwODEgNi4wNDM4ODg0NTIzNzI4OTQgTS03MC4yNjY5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg5NCBDLTcwLjM2MTE2MDg1NzQyNDY2IDUuNzYwMTMyNDg2OTMwODY0LCAtNzAuNDU1Mzc0MzI4OTc4NTEgNS40NzYzNzY1MjE0ODg4MzUsIC03MC42MjA0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2OCBNLTcwLjI2Njk0NzM4NTg3MDgxIDYuMDQzODg4NDUyMzcyODk0IEMtNzAuMzc5MTI3Nzg4NDA0NDYgNS43MDYwMTg5NTM0NjEzOCwgLTcwLjQ5MTMwODE5MDkzODEzIDUuMzY4MTQ5NDU0NTQ5ODY3LCAtNzAuNjIwNDM3NDI4MTQxNTYgNC45NzkyMzI3NjYwNDMwNjggTS03MC42MjA0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2OCBDLTcwLjczMTcyNDExNjE5ODg4IDQuNTU0ODQ4MzkyNTI0ODIyLCAtNzAuODQzMDEwODA0MjU2MTggNC4xMzA0NjQwMTkwMDY1NzcsIC03MC45MDQ5ODg0NjMxODE5MSAzLjg5NDExNjM0NDIzNTUwNjIgTS03MC42MjA0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2OCBDLTcwLjcxNjYwMjYyNDczMTk4IDQuNjEyNTEzMTkzMTgzOTU3LCAtNzAuODEyNzY3ODIxMzIyNCA0LjI0NTc5MzYyMDMyNDg0NiwgLTcwLjkwNDk4ODQ2MzE4MTkxIDMuODk0MTE2MzQ0MjM1NTA2MiBNLTcwLjkwNDk4ODQ2MzE4MTkxIDMuODk0MTE2MzQ0MjM1NTA2MiBDLTcwLjk5MDQzMzAxNDE4ODU0IDMuNDU1Mzc2NjMzNTI4NzA5MywgLTcxLjA3NTg3NzU2NTE5NTE3IDMuMDE2NjM2OTIyODIxOTEyMywgLTcxLjExOTQzMTIwOTc1Mjg4IDIuNzkyOTk4MTYzMDg0MTQ0NyBNLTcwLjkwNDk4ODQ2MzE4MTkxIDMuODk0MTE2MzQ0MjM1NTA2MiBDLTcwLjk1MDA0ODQ0NDQxNjg1IDMuNjYyNzQyODY0MDI0NDc1LCAtNzAuOTk1MTA4NDI1NjUxOCAzLjQzMTM2OTM4MzgxMzQ0NCwgLTcxLjExOTQzMTIwOTc1Mjg4IDIuNzkyOTk4MTYzMDg0MTQ0NyBNLTcxLjExOTQzMTIwOTc1Mjg4IDIuNzkyOTk4MTYzMDg0MTQ0NyBDLTcxLjE3MTI2MTE2MDI4NDYzIDIuMzkxMDE1MzAxNzQxMjEwNiwgLTcxLjIyMzA5MTExMDgxNjM4IDEuOTg5MDMyNDQwMzk4Mjc2NiwgLTcxLjI2Mjg4NDQ3NjYxMDk2IDEuNjgwNDAyOTUzMzg0NDQ0IE0tNzEuMTE5NDMxMjA5NzUyODggMi43OTI5OTgxNjMwODQxNDQ3IEMtNzEuMTYwNTExODg5MDcwOTMgMi40NzQzODQ1MjY1OTA5NzY3LCAtNzEuMjAxNTkyNTY4Mzg4OTkgMi4xNTU3NzA4OTAwOTc4MDg4LCAtNzEuMjYyODg0NDc2NjEwOTYgMS42ODA0MDI5NTMzODQ0NDQgTS03MS4yNjI4ODQ0NzY2MTA5NiAxLjY4MDQwMjk1MzM4NDQ0NCBDLTcxLjI4NjQ4NDk0Nzg5NjcxIDEuMzEyODA2NTYzMTUxMzM1NSwgLTcxLjMxMDA4NTQxOTE4MjQ2IDAuOTQ1MjEwMTcyOTE4MjI3MSwgLTcxLjMzNDc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTY3NiBNLTcxLjI2Mjg4NDQ3NjYxMDk2IDEuNjgwNDAyOTUzMzg0NDQ0IEMtNzEuMjgyODMwMDg5MTY2NCAxLjM2OTczMzkzODAyNDg5MiwgLTcxLjMwMjc3NTcwMTcyMTgzIDEuMDU5MDY0OTIyNjY1MzQwNCwgLTcxLjMzNDc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTY3NiBNLTcxLjMzNDc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTY3NiBDLTcxLjMzNDc1ODc4MzUxMjAzIDAuMjY3OTI0NzAwMTY4MTM4NjMsIC03MS4zMzQ3NTg3ODM1MTIwMyAtMC4wMjUwNTMyMDcxNjc2OTAzMjgsIC03MS4zMzQ3NTg3ODM1MTIwMyAtMC41NjA5MDI2MDc1MDM5NTkgTS03MS4zMzQ3NTg3ODM1MTIwMyAwLjU2MDkwMjYwNzUwMzk2NzYgQy03MS4zMzQ3NTg3ODM1MTIwMyAwLjIzNjkyNjQ5NTYzNzY5NTc0LCAtNzEuMzM0NzU4NzgzNTEyMDMgLTAuMDg3MDQ5NjE2MjI4NTc2MSwgLTcxLjMzNDc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBNLTcxLjMzNDc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBDLTcxLjMxOTMxMzU2OTQ4NjcyIC0wLjgwMTQ3NDI4MzEwMDM5MjMsIC03MS4zMDM4NjgzNTU0NjE0MyAtMS4wNDIwNDU5NTg2OTY4MjU2LCAtNzEuMjYyODg0NDc2NjEwOTYgLTEuNjgwNDAyOTUzMzg0NDE5OCBNLTcxLjMzNDc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBDLTcxLjMxODE1NjA4NjU0MTA4IC0wLjgxOTUwMzAxNDI4MjM4MSwgLTcxLjMwMTU1MzM4OTU3MDEyIC0xLjA3ODEwMzQyMTA2MDgwMzEsIC03MS4yNjI4ODQ0NzY2MTA5NiAtMS42ODA0MDI5NTMzODQ0MTk4IE0tNzEuMjYyODg0NDc2NjEwOTYgLTEuNjgwNDAyOTUzMzg0NDE5OCBDLTcxLjIzMDQ1MDExODU2Nzg3IC0xLjkzMTk1NzQyOTQ3ODE3NTQsIC03MS4xOTgwMTU3NjA1MjQ3OCAtMi4xODM1MTE5MDU1NzE5MzEsIC03MS4xMTk0MzEyMDk3NTI4OCAtMi43OTI5OTgxNjMwODQxMzY3IE0tNzEuMjYyODg0NDc2NjEwOTYgLTEuNjgwNDAyOTUzMzg0NDE5OCBDLTcxLjIwNjIwMDU2NzkzNDU5IC0yLjEyMDAzMjE1NTU3NDU0MSwgLTcxLjE0OTUxNjY1OTI1ODIzIC0yLjU1OTY2MTM1Nzc2NDY2MjUsIC03MS4xMTk0MzEyMDk3NTI4OCAtMi43OTI5OTgxNjMwODQxMzY3IE0tNzEuMTE5NDMxMjA5NzUyODggLTIuNzkyOTk4MTYzMDg0MTM2NyBDLTcxLjAzNDE0MzA1MDI5MTc1IC0zLjIzMDkzNDgzNjI1ODE0MSwgLTcwLjk0ODg1NDg5MDgzMDYyIC0zLjY2ODg3MTUwOTQzMjE0NSwgLTcwLjkwNDk4ODQ2MzE4MTkxIC0zLjg5NDExNjM0NDIzNTQ5OCBNLTcxLjExOTQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDEzNjcgQy03MS4wNDA3MzkyMTIyMDQ2MyAtMy4xOTcwNjQ5Mzg5MzQ4NDQyLCAtNzAuOTYyMDQ3MjE0NjU2MzcgLTMuNjAxMTMxNzE0Nzg1NTUxNywgLTcwLjkwNDk4ODQ2MzE4MTkxIC0zLjg5NDExNjM0NDIzNTQ5OCBNLTcwLjkwNDk4ODQ2MzE4MTkxIC0zLjg5NDExNjM0NDIzNTQ5OCBDLTcwLjc5NzEyMTY1MjA2MzkgLTQuMzA1NDU5MjQ0ODAwMTk0LCAtNzAuNjg5MjU0ODQwOTQ1ODYgLTQuNzE2ODAyMTQ1MzY0ODkxLCAtNzAuNjIwNDM3NDI4MTQxNTcgLTQuOTc5MjMyNzY2MDQzMDU5IE0tNzAuOTA0OTg4NDYzMTgxOTEgLTMuODk0MTE2MzQ0MjM1NDk4IEMtNzAuODM3MTYxNDM1MzMwNjcgLTQuMTUyNzcwMTk3ODUyMTI2LCAtNzAuNzY5MzM0NDA3NDc5NDIgLTQuNDExNDI0MDUxNDY4NzU0LCAtNzAuNjIwNDM3NDI4MTQxNTcgLTQuOTc5MjMyNzY2MDQzMDU5IE0tNzAuNjIwNDM3NDI4MTQxNTcgLTQuOTc5MjMyNzY2MDQzMDU5IEMtNzAuNTAxMjAxNzQwNDE4NjcgLTUuMzM4MzUxNjU5ODM3NTQxLCAtNzAuMzgxOTY2MDUyNjk1NzYgLTUuNjk3NDcwNTUzNjMyMDIzLCAtNzAuMjY2OTQ3Mzg1ODcwODEgLTYuMDQzODg4NDUyMzcyODcxNSBNLTcwLjYyMDQzNzQyODE0MTU3IC00Ljk3OTIzMjc2NjA0MzA1OSBDLTcwLjQ5MzUxMjk5NjczNTEzIC01LjM2MTUwODkzMDc3NzM3OSwgLTcwLjM2NjU4ODU2NTMyODcgLTUuNzQzNzg1MDk1NTExNjk5LCAtNzAuMjY2OTQ3Mzg1ODcwODEgLTYuMDQzODg4NDUyMzcyODcxNSBNLTcwLjI2Njk0NzM4NTg3MDgxIC02LjA0Mzg4ODQ1MjM3Mjg3MTUgQy03MC4xNDY5NTM5MjQzNDYwNSAtNi4zNDAyNzQ2MjIyNTQ3ODgsIC03MC4wMjY5NjA0NjI4MjEyOCAtNi42MzY2NjA3OTIxMzY3MDYsIC02OS44NDU5NzA5MDI3NzY3MSAtNy4wODM3MDg1MDQ2NDE4ODkgTS03MC4yNjY5NDczODU4NzA4MSAtNi4wNDM4ODg0NTIzNzI4NzE1IEMtNzAuMTI2NjkzOTg0NDUyNjQgLTYuMzkwMzE3MDY1NDkwNzk1LCAtNjkuOTg2NDQwNTgzMDM0NDcgLTYuNzM2NzQ1Njc4NjA4NzE4LCAtNjkuODQ1OTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODg5IE0tNjkuODQ1OTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODg5IEMtNjkuNjY2OTE2ODE3MzU3MDggLTcuNDU1NTE4MTQ0MTU5NDY2LCAtNjkuNDg3ODYyNzMxOTM3NDQgLTcuODI3MzI3NzgzNjc3MDQ0LCAtNjkuMzU5MjM3ODYxNTI3NSAtOC4wOTQ0MjAwNzkyMTQ2MTEgTS02OS44NDU5NzA5MDI3NzY3MSAtNy4wODM3MDg1MDQ2NDE4ODkgQy02OS42NjExNjMwMjEwNjcyOCAtNy40Njc0NjYwMjUyNjY3NDUsIC02OS40NzYzNTUxMzkzNTc4NSAtNy44NTEyMjM1NDU4OTE2MDIsIC02OS4zNTkyMzc4NjE1Mjc1IC04LjA5NDQyMDA3OTIxNDYxMSBNLTY5LjM1OTIzNzg2MTUyNzUgLTguMDk0NDIwMDc5MjE0NjExIEMtNjkuMjE1MTczMzI5OTQxMDEgLTguMzUwMjIxMjQzMTYyMTQyLCAtNjkuMDcxMTA4Nzk4MzU0NSAtOC42MDYwMjI0MDcxMDk2NzMsIC02OC44MDg3NDgzNTI1OTM1NSAtOS4wNzE4Njk5NDU0MzQxOTMgTS02OS4zNTkyMzc4NjE1Mjc1IC04LjA5NDQyMDA3OTIxNDYxMSBDLTY5LjIzNzI3Njg5MzU0NjQ4IC04LjMxMDk3NDEyNzc1MjEwNCwgLTY5LjExNTMxNTkyNTU2NTQ1IC04LjUyNzUyODE3NjI4OTU5NiwgLTY4LjgwODc0ODM1MjU5MzU1IC05LjA3MTg2OTk0NTQzNDE5MyBNLTY4LjgwODc0ODM1MjU5MzU1IC05LjA3MTg2OTk0NTQzNDE5MyBDLTY4LjU2NjIxMjQyNDI1NjMyIC05LjQ0NDQ3MDI2MTM3NiwgLTY4LjMyMzY3NjQ5NTkxOTA5IC05LjgxNzA3MDU3NzMxNzgwNywgLTY4LjE5Njc2NDQ1NTQ0NjczIC0xMC4wMTIwNDE1NTIxMzc5NjkgTS02OC44MDg3NDgzNTI1OTM1NSAtOS4wNzE4Njk5NDU0MzQxOTMgQy02OC41ODY3OTA3ODc2Njc3MSAtOS40MTI4NTYzNjkxMTE4MiwgLTY4LjM2NDgzMzIyMjc0MTg1IC05Ljc1Mzg0Mjc5Mjc4OTQ0OSwgLTY4LjE5Njc2NDQ1NTQ0NjczIC0xMC4wMTIwNDE1NTIxMzc5NjkgTS02OC4xOTY3NjQ0NTU0NDY3MyAtMTAuMDEyMDQxNTUyMTM3OTY5IEMtNjguMDYyMjEyNDY0MzkyNjkgLTEwLjE5MjMyODk2MjIxMTgyOCwgLTY3LjkyNzY2MDQ3MzMzODY1IC0xMC4zNzI2MTYzNzIyODU2ODcsIC02Ny41MjU4MDA5NDMxOTA1MiAtMTAuOTExMDcxNTMyNTI3ODM1IE0tNjguMTk2NzY0NDU1NDQ2NzMgLTEwLjAxMjA0MTU1MjEzNzk2OSBDLTY3Ljk2MTk3MzYwNjMyMjg0IC0xMC4zMjY2Mzk5MDAwNzc1OTMsIC02Ny43MjcxODI3NTcxOTg5NSAtMTAuNjQxMjM4MjQ4MDE3MjE3LCAtNjcuNTI1ODAwOTQzMTkwNTIgLTEwLjkxMTA3MTUzMjUyNzgzNSBNLTY3LjUyNTgwMDk0MzE5MDUyIC0xMC45MTEwNzE1MzI1Mjc4MzUgQy02Ny4zNjI3MTE0MDAwNjU3MyAtMTEuMTAyNjQ1Nzg5OTQwMTA5LCAtNjcuMTk5NjIxODU2OTQwOTQgLTExLjI5NDIyMDA0NzM1MjM4MywgLTY2Ljc5ODYxNDk0ODgxODAzIC0xMS43NjUyNjU1Nzk1NzMwMzggTS02Ny41MjU4MDA5NDMxOTA1MiAtMTAuOTExMDcxNTMyNTI3ODM1IEMtNjcuMzAzNDEzMDM5MzcxODMgLTExLjE3MjMwMTAxODU4MzQ3MywgLTY3LjA4MTAyNTEzNTU1MzE1IC0xMS40MzM1MzA1MDQ2MzkxMSwgLTY2Ljc5ODYxNDk0ODgxODAzIC0xMS43NjUyNjU1Nzk1NzMwMzggTS02Ni43OTg2MTQ5NDg4MTgwMyAtMTEuNzY1MjY1NTc5NTczMDM4IEMtNjYuNTE0MjQ1MTk0NzkwMDYgLTEyLjA1ODkwMDY5Nzc5NzkyLCAtNjYuMjI5ODc1NDQwNzYyMDkgLTEyLjM1MjUzNTgxNjAyMjgwMSwgLTY2LjAxODE5NDYzNTU2MTAyIC0xMi41NzExMTM2MjY3MTAyMjQgTS02Ni43OTg2MTQ5NDg4MTgwMyAtMTEuNzY1MjY1NTc5NTczMDM4IEMtNjYuNDk2NzU1MzYxMzM4MDUgLTEyLjA3Njk2MDM4Njc3OTE0NSwgLTY2LjE5NDg5NTc3Mzg1ODA4IC0xMi4zODg2NTUxOTM5ODUyNTQsIC02Ni4wMTgxOTQ2MzU1NjEwMiAtMTIuNTcxMTEzNjI2NzEwMjI0IE0tNjYuMDE4MTk0NjM1NTYxMDIgLTEyLjU3MTExMzYyNjcxMDIyNCBDLTY1LjY5OTYwNTYzMTY0NTExIC0xMi44NjA0NDc3MzA2NjM1MjUsIC02NS4zODEwMTY2Mjc3MjkyMSAtMTMuMTQ5NzgxODM0NjE2ODI4LCAtNjUuMTg3NzQ2OTE3ODg2MzIgLTEzLjMyNTMwNDI3MTQ1OTg0IE0tNjYuMDE4MTk0NjM1NTYxMDIgLTEyLjU3MTExMzYyNjcxMDIyNCBDLTY1LjY4NjIwMjExMTYzNTU3IC0xMi44NzI2MjA0NTI4OTg0ODYsIC02NS4zNTQyMDk1ODc3MTAxMyAtMTMuMTc0MTI3Mjc5MDg2NzQ3LCAtNjUuMTg3NzQ2OTE3ODg2MzIgLTEzLjMyNTMwNDI3MTQ1OTg0IE0tNjUuMTg3NzQ2OTE3ODg2MzIgLTEzLjMyNTMwNDI3MTQ1OTg0IEMtNjQuOTUyODIxMjA3NDUyNjYgLTEzLjUxMjY1MTI3Mzg5NDk3NiwgLTY0LjcxNzg5NTQ5NzAxOSAtMTMuNjk5OTk4Mjc2MzMwMTEsIC02NC4zMTA2ODQyODM1OTYyOSAtMTQuMDI0NzM4MzgyNjg5MjM2IE0tNjUuMTg3NzQ2OTE3ODg2MzIgLTEzLjMyNTMwNDI3MTQ1OTg0IEMtNjQuODc1NDg5MTc4NDI4OSAtMTMuNTc0MzIxNTA5MTQ5NzA1LCAtNjQuNTYzMjMxNDM4OTcxNDggLTEzLjgyMzMzODc0NjgzOTU3LCAtNjQuMzEwNjg0MjgzNTk2MjkgLTE0LjAyNDczODM4MjY4OTIzNiBNLTY0LjMxMDY4NDI4MzU5NjI5IC0xNC4wMjQ3MzgzODI2ODkyMzYgQy02NC4xMDUzNDgyODAzNDM2MiAtMTQuMTY3OTcxODg5NzA1OTgxLCAtNjMuOTAwMDEyMjc3MDkwOTQ0IC0xNC4zMTEyMDUzOTY3MjI3MjcsIC02My4zOTA2MTA3NzExODQ2MSAtMTQuNjY2NTQxODM1NjA3MjA1IE0tNjQuMzEwNjg0MjgzNTk2MjkgLTE0LjAyNDczODM4MjY4OTIzNiBDLTY0LjA2MTU3ODg1MjkwNzk0IC0xNC4xOTg1MDM1NDc1MzcxMjksIC02My44MTI0NzM0MjIyMTk2MSAtMTQuMzcyMjY4NzEyMzg1MDIsIC02My4zOTA2MTA3NzExODQ2MSAtMTQuNjY2NTQxODM1NjA3MjA1IE0tNjMuMzkwNjEwNzcxMTg0NjEgLTE0LjY2NjU0MTgzNTYwNzIwNSBDLTYzLjA5NTM5ODQxOTM4ODgxIC0xNC44NDU1MDEyOTgxMjYxNywgLTYyLjgwMDE4NjA2NzU5Mjk5NiAtMTUuMDI0NDYwNzYwNjQ1MTMyLCAtNjIuNDMxMzA3MTYwMDY4OTEgLTE1LjI0ODA3NzMyMjE1OTMxMyBNLTYzLjM5MDYxMDc3MTE4NDYxIC0xNC42NjY1NDE4MzU2MDcyMDUgQy02My4wMjczMDUxNjE1MzUzMyAtMTQuODg2Nzc5ODMxMTk3MzQ2LCAtNjIuNjYzOTk5NTUxODg2MDUgLTE1LjEwNzAxNzgyNjc4NzQ4NiwgLTYyLjQzMTMwNzE2MDA2ODkxIC0xNS4yNDgwNzczMjIxNTkzMTMgTS02Mi40MzEzMDcxNjAwNjg5MSAtMTUuMjQ4MDc3MzIyMTU5MzEzIEMtNjIuMTQxNzMzMTI3OTU5MDcgLTE1LjM5OTE0NzkwOTIyOTk5OSwgLTYxLjg1MjE1OTA5NTg0OTIyNCAtMTUuNTUwMjE4NDk2MzAwNjgzLCAtNjEuNDM2NzE1NDM0NTU3MjcgLTE1Ljc2Njk1NTE4ODI5MjMzMiBNLTYyLjQzMTMwNzE2MDA2ODkxIC0xNS4yNDgwNzczMjIxNTkzMTMgQy02Mi4yMjk5NzAzMzYzMzAxMjYgLTE1LjM1MzExNDYxNDE0MTQ0NywgLTYyLjAyODYzMzUxMjU5MTM0IC0xNS40NTgxNTE5MDYxMjM1OCwgLTYxLjQzNjcxNTQzNDU1NzI3IC0xNS43NjY5NTUxODgyOTIzMzIgTS02MS40MzY3MTU0MzQ1NTcyNyAtMTUuNzY2OTU1MTg4MjkyMzMyIEMtNjEuMDU2MTcxNDQzNTUyNDkgLTE1LjkzNTQxMDcyNDY3MzczNCwgLTYwLjY3NTYyNzQ1MjU0NzcxNSAtMTYuMTAzODY2MjYxMDU1MTMsIC02MC40MTA5MjI1ODUzODkwNiAtMTYuMjIxMDQzMjUzNTU1Mzc2IE0tNjEuNDM2NzE1NDM0NTU3MjcgLTE1Ljc2Njk1NTE4ODI5MjMzMiBDLTYxLjA2MjQ2NzA4NDc0ODI2IC0xNS45MzI2MjM4MzEwNjk5MjUsIC02MC42ODgyMTg3MzQ5MzkyNiAtMTYuMDk4MjkyNDczODQ3NTIsIC02MC40MTA5MjI1ODUzODkwNiAtMTYuMjIxMDQzMjUzNTU1Mzc2IE0tNjAuNDEwOTIyNTg1Mzg5MDYgLTE2LjIyMTA0MzI1MzU1NTM3NiBDLTYwLjEzNDA2NTE0OTU4MTQzIC0xNi4zMjI5MjkzNDkxNzQ2NjUsIC01OS44NTcyMDc3MTM3NzM4IC0xNi40MjQ4MTU0NDQ3OTM5NTMsIC01OS4zNTgxNDM4MTU0MTMzOCAtMTYuNjA4NDc1NTcyNjg2Njk3IE0tNjAuNDEwOTIyNTg1Mzg5MDYgLTE2LjIyMTA0MzI1MzU1NTM3NiBDLTU5Ljk5NzU1NTI4NDc2NTE2IC0xNi4zNzMxNjYyNDEzMTA0MSwgLTU5LjU4NDE4Nzk4NDE0MTI2NiAtMTYuNTI1Mjg5MjI5MDY1NDQzLCAtNTkuMzU4MTQzODE1NDEzMzggLTE2LjYwODQ3NTU3MjY4NjY5NyBNLTU5LjM1ODE0MzgxNTQxMzM4IC0xNi42MDg0NzU1NzI2ODY2OTcgQy01OS4wODkxODM4NTI0MTQzIC0xNi42ODgzMDE0Nzc5MDUxNjcsIC01OC44MjAyMjM4ODk0MTUyMjUgLTE2Ljc2ODEyNzM4MzEyMzYzNywgLTU4LjI4MjcwNTIxODQxNjM5NiAtMTYuOTI3NjYwMTAzMTgzMDEgTS01OS4zNTgxNDM4MTU0MTMzOCAtMTYuNjA4NDc1NTcyNjg2Njk3IEMtNTguOTQ3OTE2MTY0ODc3MDg2IC0xNi43MzAyMjg5ODYwMzY5ODcsIC01OC41Mzc2ODg1MTQzNDA3OSAtMTYuODUxOTgyMzk5Mzg3MjgyLCAtNTguMjgyNzA1MjE4NDE2Mzk2IC0xNi45Mjc2NjAxMDMxODMwMSBNLTU4LjI4MjcwNTIxODQxNjM5NiAtMTYuOTI3NjYwMTAzMTgzMDEgQy01OC4wMzEwMjQ4MTczMjQwMiAtMTYuOTg1MTA0NTEyMzY0MjM4LCAtNTcuNzc5MzQ0NDE2MjMxNjQgLTE3LjA0MjU0ODkyMTU0NTQ3LCAtNTcuMTg5MDI2MDAyMjc0MDIgLTE3LjE3NzI4NTI0NzM0MzY0IE0tNTguMjgyNzA1MjE4NDE2Mzk2IC0xNi45Mjc2NjAxMDMxODMwMSBDLTU3Ljk1NTk5ODIwNDQ0MDU1IC0xNy4wMDIyMjg4NDcxNjA0ODgsIC01Ny42MjkyOTExOTA0NjQ3IC0xNy4wNzY3OTc1OTExMzc5NjgsIC01Ny4xODkwMjYwMDIyNzQwMiAtMTcuMTc3Mjg1MjQ3MzQzNjQgTS01Ny4xODkwMjYwMDIyNzQwMiAtMTcuMTc3Mjg1MjQ3MzQzNjQgQy01Ni43OTgwNzg2NDgxNjI3MTUgLTE3LjI0MDQ5MDU4MzcxNDM0NCwgLTU2LjQwNzEzMTI5NDA1MTQxIC0xNy4zMDM2OTU5MjAwODUwNSwgLTU2LjA4MTYwMDMyOTQ3ODg3IC0xNy4zNTYzMjUyNDE5MDY4MDYgTS01Ny4xODkwMjYwMDIyNzQwMiAtMTcuMTc3Mjg1MjQ3MzQzNjQgQy01Ni45NTcxNjcyNTA5MTY3MSAtMTcuMjE0NzcwMzcyMTcxNjE4LCAtNTYuNzI1MzA4NDk5NTU5NDA0IC0xNy4yNTIyNTU0OTY5OTk2LCAtNTYuMDgxNjAwMzI5NDc4ODcgLTE3LjM1NjMyNTI0MTkwNjgwNiBNLTU2LjA4MTYwMDMyOTQ3ODg3IC0xNy4zNTYzMjUyNDE5MDY4MDYgQy01NS44MjQ0MzgzMTcxNjA4OCAtMTcuMzgxMTMzMzUxOTUyNTUzLCAtNTUuNTY3Mjc2MzA0ODQyODkgLTE3LjQwNTk0MTQ2MTk5ODMsIC01NC45NjQ5Nzg4NDk2NjI0OCAtMTcuNDY0MDQ0MzczMTMwODg2IE0tNTYuMDgxNjAwMzI5NDc4ODcgLTE3LjM1NjMyNTI0MTkwNjgwNiBDLTU1Ljc5NTU5ODQ3NDQ1MDczNSAtMTcuMzgzOTE1NDk2ODkzODE3LCAtNTUuNTA5NTk2NjE5NDIyNiAtMTcuNDExNTA1NzUxODgwODI0LCAtNTQuOTY0OTc4ODQ5NjYyNDggLTE3LjQ2NDA0NDM3MzEzMDg4NiBNLTU0Ljk2NDk3ODg0OTY2MjQ4IC0xNy40NjQwNDQzNzMxMzA4ODYgQy01NC41NjAxOTA3NjY3MjQzNSAtMTcuNDc3MDI1MTM5MDc4NTA2LCAtNTQuMTU1NDAyNjgzNzg2MjIgLTE3LjQ5MDAwNTkwNTAyNjEyNywgLTUzLjg0Mzc1MDAwMDAwMDAxIC0xNy41IE0tNTQuOTY0OTc4ODQ5NjYyNDggLTE3LjQ2NDA0NDM3MzEzMDg4NiBDLTU0LjU1NjI5ODk4NjMzOTk3NSAtMTcuNDc3MTQ5OTQwOTAwNTQyLCAtNTQuMTQ3NjE5MTIzMDE3NDggLTE3LjQ5MDI1NTUwODY3MDE5NSwgLTUzLjg0Mzc1MDAwMDAwMDAxIC0xNy41IE0tNTMuODQzNzUwMDAwMDAwMDEgLTE3LjUgQy01My44NDM3NTAwMDAwMDAwMSAtMTcuNSwgLTUzLjg0Mzc1MDAwMDAwMDAxIC0xNy41LCAtNTMuODQzNzUgLTE3LjUgTS01My44NDM3NTAwMDAwMDAwMSAtMTcuNSBDLTUzLjg0Mzc1MDAwMDAwMDAxIC0xNy41LCAtNTMuODQzNzUgLTE3LjUsIC01My44NDM3NSAtMTcuNSIgc3Ryb2tlPSIjNjA3OThhIiBzdHJva2Utd2lkdGg9IjEuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLWRhc2hhcnJheT0iMCAwIiBzdHlsZT0iIi8+PC9nPjxnIGNsYXNzPSJsYWJlbCIgc3R5bGU9IiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCwgLTEwKSI+PHJlY3QvPjxnPjxyZWN0IGNsYXNzPSJiYWNrZ3JvdW5kIiBzdHlsZT0ic3Ryb2tlOiBub25lIi8+PHRleHQgeT0iLTEwLjEiIHN0eWxlPSIiPjx0c3BhbiBjbGFzcz0idGV4dC1vdXRlci10c3BhbiByb3ciIHg9IjAiIHk9Ii0wLjFlbSIgZHk9IjEuMWVtIj48dHNwYW4gZm9udC1zdHlsZT0ibm9ybWFsIiBjbGFzcz0idGV4dC1pbm5lci10c3BhbiIgZm9udC13ZWlnaHQ9Im5vcm1hbCI+SWRlYTwvdHNwYW4+PHRzcGFuIGZvbnQtc3R5bGU9Im5vcm1hbCIgY2xhc3M9InRleHQtaW5uZXItdHNwYW4iIGZvbnQtd2VpZ2h0PSJub3JtYWwiPiBvcjwvdHNwYW4+PHRzcGFuIGZvbnQtc3R5bGU9Im5vcm1hbCIgY2xhc3M9InRleHQtaW5uZXItdHNwYW4iIGZvbnQtd2VpZ2h0PSJub3JtYWwiPiBwcm9ibGVtPC90c3Bhbj48L3RzcGFuPjwvdGV4dD48L2c+PC9nPjwvZz48ZyBjbGFzcz0ibm9kZSBkZWZhdWx0IiBpZD0ibXktc3ZnLWZsb3djaGFydC1BdXRob3ItMSIgZGF0YS1sb29rPSJjbGFzc2ljIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzMjUuMzI1Nzc1MTQ2NDg0NCwgNjMpIj48cmVjdCBjbGFzcz0iYmFzaWMgbGFiZWwtY29udGFpbmVyIiBzdHlsZT0iIiB4PSItMTI0LjY1NjI1IiB5PSItMjUiIHdpZHRoPSIyNDkuMzEyNSIgaGVpZ2h0PSI1MCIvPjxnIGNsYXNzPSJsYWJlbCIgc3R5bGU9IiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCwgLTEwKSI+PHJlY3QvPjxnPjxyZWN0IGNsYXNzPSJiYWNrZ3JvdW5kIiBzdHlsZT0ic3Ryb2tlOiBub25lIi8+PHRleHQgeT0iLTEwLjEiIHN0eWxlPSIiPjx0c3BhbiBjbGFzcz0idGV4dC1vdXRlci10c3BhbiByb3ciIHg9IjAiIHk9Ii0wLjFlbSIgZHk9IjEuMWVtIj48dHNwYW4gZm9udC1zdHlsZT0ibm9ybWFsIiBjbGFzcz0idGV4dC1pbm5lci10c3BhbiIgZm9udC13ZWlnaHQ9Im5vcm1hbCI+UFJEPC90c3Bhbj48dHNwYW4gZm9udC1zdHlsZT0ibm9ybWFsIiBjbGFzcz0idGV4dC1pbm5lci10c3BhbiIgZm9udC13ZWlnaHQ9Im5vcm1hbCI+IGF1dGhvcmluZzwvdHNwYW4+PHRzcGFuIGZvbnQtc3R5bGU9Im5vcm1hbCIgY2xhc3M9InRleHQtaW5uZXItdHNwYW4iIGZvbnQtd2VpZ2h0PSJub3JtYWwiPiBvcjwvdHNwYW4+PHRzcGFuIGZvbnQtc3R5bGU9Im5vcm1hbCIgY2xhc3M9InRleHQtaW5uZXItdHNwYW4iIGZvbnQtd2VpZ2h0PSJub3JtYWwiPiAvZGVzaWduPC90c3Bhbj48L3RzcGFuPjwvdGV4dD48L2c+PC9nPjwvZz48ZyBjbGFzcz0ibm9kZSBkZWZhdWx0IiBpZD0ibXktc3ZnLWZsb3djaGFydC1Tb3VyY2UtMyIgZGF0YS1sb29rPSJjbGFzc2ljIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg2MDkuMDIxMDg3NjQ2NDg0NCwgNjMpIj48cmVjdCBjbGFzcz0iYmFzaWMgbGFiZWwtY29udGFpbmVyIiBzdHlsZT0iIiB4PSItMTA5LjAzOTA2MjUiIHk9Ii0yNSIgd2lkdGg9IjIxOC4wNzgxMjUiIGhlaWdodD0iNTAiLz48ZyBjbGFzcz0ibGFiZWwiIHN0eWxlPSIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAsIC0xMCkiPjxyZWN0Lz48Zz48cmVjdCBjbGFzcz0iYmFja2dyb3VuZCIgc3R5bGU9InN0cm9rZTogbm9uZSIvPjx0ZXh0IHk9Ii0xMC4xIiBzdHlsZT0iIj48dHNwYW4gY2xhc3M9InRleHQtb3V0ZXItdHNwYW4gcm93IiB4PSIwIiB5PSItMC4xZW0iIGR5PSIxLjFlbSI+PHRzcGFuIGZvbnQtc3R5bGU9Im5vcm1hbCIgY2xhc3M9InRleHQtaW5uZXItdHNwYW4iIGZvbnQtd2VpZ2h0PSJub3JtYWwiPkNhbm9uaWNhbDwvdHNwYW4+PHRzcGFuIGZvbnQtc3R5bGU9Im5vcm1hbCIgY2xhc3M9InRleHQtaW5uZXItdHNwYW4iIGZvbnQtd2VpZ2h0PSJub3JtYWwiPiBNYXJrZG93bjwvdHNwYW4+PC90c3Bhbj48L3RleHQ+PC9nPjwvZz48L2c+PGcgY2xhc3M9Im5vZGUgZGVmYXVsdCIgaWQ9Im15LXN2Zy1mbG93Y2hhcnQtU2tpbGwtNSIgZGF0YS1sb29rPSJjbGFzc2ljIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg4MzUuMjk0NTI1MTQ2NDg0NCwgMzMpIj48cmVjdCBjbGFzcz0iYmFzaWMgbGFiZWwtY29udGFpbmVyIiBzdHlsZT0iIiB4PSItNjcuMjM0Mzc1IiB5PSItMjUiIHdpZHRoPSIxMzQuNDY4NzUiIGhlaWdodD0iNTAiLz48ZyBjbGFzcz0ibGFiZWwiIHN0eWxlPSIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAsIC0xMCkiPjxyZWN0Lz48Zz48cmVjdCBjbGFzcz0iYmFja2dyb3VuZCIgc3R5bGU9InN0cm9rZTogbm9uZSIvPjx0ZXh0IHk9Ii0xMC4xIiBzdHlsZT0iIj48dHNwYW4gY2xhc3M9InRleHQtb3V0ZXItdHNwYW4gcm93IiB4PSIwIiB5PSItMC4xZW0iIGR5PSIxLjFlbSI+PHRzcGFuIGZvbnQtc3R5bGU9Im5vcm1hbCIgY2xhc3M9InRleHQtaW5uZXItdHNwYW4iIGZvbnQtd2VpZ2h0PSJub3JtYWwiPi9odG1sLWRvYzwvdHNwYW4+PC90c3Bhbj48L3RleHQ+PC9nPjwvZz48L2c+PGcgY2xhc3M9Im5vZGUgZGVmYXVsdCIgaWQ9Im15LXN2Zy1mbG93Y2hhcnQtUGFnZS03IiBkYXRhLWxvb2s9ImNsYXNzaWMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDExNzguMTY5NTI1MTQ2NDg0NCwgMzMpIj48cmVjdCBjbGFzcz0iYmFzaWMgbGFiZWwtY29udGFpbmVyIiBzdHlsZT0iIiB4PSItOTQuODQzNzUiIHk9Ii0yNSIgd2lkdGg9IjE4OS42ODc1IiBoZWlnaHQ9IjUwIi8+PGcgY2xhc3M9ImxhYmVsIiBzdHlsZT0iIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLCAtMTApIj48cmVjdC8+PGc+PHJlY3QgY2xhc3M9ImJhY2tncm91bmQiIHN0eWxlPSJzdHJva2U6IG5vbmUiLz48dGV4dCB5PSItMTAuMSIgc3R5bGU9IiI+PHRzcGFuIGNsYXNzPSJ0ZXh0LW91dGVyLXRzcGFuIHJvdyIgeD0iMCIgeT0iLTAuMWVtIiBkeT0iMS4xZW0iPjx0c3BhbiBmb250LXN0eWxlPSJub3JtYWwiIGNsYXNzPSJ0ZXh0LWlubmVyLXRzcGFuIiBmb250LXdlaWdodD0ibm9ybWFsIj5HZW5lcmF0ZWQ8L3RzcGFuPjx0c3BhbiBmb250LXN0eWxlPSJub3JtYWwiIGNsYXNzPSJ0ZXh0LWlubmVyLXRzcGFuIiBmb250LXdlaWdodD0ibm9ybWFsIj4gSFRNTDwvdHNwYW4+PC90c3Bhbj48L3RleHQ+PC9nPjwvZz48L2c+PGcgY2xhc3M9Im5vZGUgZGVmYXVsdCIgaWQ9Im15LXN2Zy1mbG93Y2hhcnQtUmV2aWV3LTkiIGRhdGEtbG9vaz0iY2xhc3NpYyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTM4OC43MjMwMzc3MTk3MjY2LCA2MykiPjxnIGNsYXNzPSJiYXNpYyBsYWJlbC1jb250YWluZXIgb3V0ZXItcGF0aCI+PHBhdGggZD0iTS00OC4yMTg3NSAtMTcuNSBDLTE1LjE5MTkxMTA5NDE1NTA5NSAtMTcuNSwgMTcuODM0OTI3ODExNjg5ODEgLTE3LjUsIDQ4LjIxODc1IC0xNy41IEM0OC4yMTg3NSAtMTcuNSwgNDguMjE4NzUgLTE3LjUsIDQ4LjIxODc1IC0xNy41IEM0OC41NDg5MTIzNTk1NzQ2MSAtMTcuNDg5NDEyMzM1NzUwNDksIDQ4Ljg3OTA3NDcxOTE0OTIxNiAtMTcuNDc4ODI0NjcxNTAwOTgsIDQ5LjMzOTk3ODg0OTY2MjQ3IC0xNy40NjQwNDQzNzMxMzA4ODYgQzQ5LjY0MDc4NTY1MjEwODg1IC0xNy40MzUwMjU5MDI2NzE5OTIsIDQ5Ljk0MTU5MjQ1NDU1NTI0IC0xNy40MDYwMDc0MzIyMTMxLCA1MC40NTY2MDAzMjk0Nzg4NSAtMTcuMzU2MzI1MjQxOTA2ODEgQzUwLjY4NDU0NzQzNTE1MDYzIC0xNy4zMTk0NzI1MjE2MTgwMDMsIDUwLjkxMjQ5NDU0MDgyMjQgLTE3LjI4MjYxOTgwMTMyOTE5NywgNTEuNTY0MDI2MDAyMjc0MDEgLTE3LjE3NzI4NTI0NzM0MzY0NCBDNTEuOTk5NDM3NTk1Njg5MTkgLTE3LjA3NzkwNTM5MjQ3MjgxLCA1Mi40MzQ4NDkxODkxMDQzNyAtMTYuOTc4NTI1NTM3NjAxOTgyLCA1Mi42NTc3MDUyMTg0MTYzNzUgLTE2LjkyNzY2MDEwMzE4MzAxNSBDNTMuMDA1NjczNTgwNzg1MSAtMTYuODI0Mzg0OTE5NzU1MTgyLCA1My4zNTM2NDE5NDMxNTM4MjUgLTE2LjcyMTEwOTczNjMyNzM1MywgNTMuNzMzMTQzODE1NDEzMzY0IC0xNi42MDg0NzU1NzI2ODY3IEM1NC4wNDE3MDM1ODkzMTc2MyAtMTYuNDk0OTIyNzIzNTk0NjQ4LCA1NC4zNTAyNjMzNjMyMjE5IC0xNi4zODEzNjk4NzQ1MDI1OTIsIDU0Ljc4NTkyMjU4NTM4OTA0NSAtMTYuMjIxMDQzMjUzNTU1MzggQzU1LjAxNTI5MjA2OTI0MTczIC0xNi4xMTk1MDgxODcwNTc3ODYsIDU1LjI0NDY2MTU1MzA5NDQyNCAtMTYuMDE3OTczMTIwNTYwMTkzLCA1NS44MTE3MTU0MzQ1NTcyNjQgLTE1Ljc2Njk1NTE4ODI5MjMzNiBDNTYuMDgwNDgxMDc3MjIxNTQgLTE1LjYyNjc0MDMyNDY2Njk5MiwgNTYuMzQ5MjQ2NzE5ODg1ODMgLTE1LjQ4NjUyNTQ2MTA0MTY0NiwgNTYuODA2MzA3MTYwMDY4OTEgLTE1LjI0ODA3NzMyMjE1OTMxNiBDNTcuMTE2NDMzMjI5MjMzNzkgLTE1LjA2MDA3NzA3NjUyODQ4NiwgNTcuNDI2NTU5Mjk4Mzk4NjcgLTE0Ljg3MjA3NjgzMDg5NzY1NiwgNTcuNzY1NjEwNzcxMTg0NiAtMTQuNjY2NTQxODM1NjA3MjEyIEM1OC4wNDA3MDM1MTc1MTM1IC0xNC40NzQ2NDkwNDQzNDEyMjksIDU4LjMxNTc5NjI2Mzg0MjM5NCAtMTQuMjgyNzU2MjUzMDc1MjQ3LCA1OC42ODU2ODQyODM1OTYyOCAtMTQuMDI0NzM4MzgyNjg5MjQxIEM1OC45ODkzMzcwMDc2MTc3MSAtMTMuNzgyNTgzNDE1ODIwNDkzLCA1OS4yOTI5ODk3MzE2MzkxNSAtMTMuNTQwNDI4NDQ4OTUxNzQ0LCA1OS41NjI3NDY5MTc4ODYyOTQgLTEzLjMyNTMwNDI3MTQ1OTg1NSBDNTkuNzc1Njc1NTIxNzI0MTUgLTEzLjEzMTkyODE0NzIzNjQ0NCwgNTkuOTg4NjA0MTI1NTYyMDEgLTEyLjkzODU1MjAyMzAxMzAzNSwgNjAuMzkzMTk0NjM1NTYxMDEgLTEyLjU3MTExMzYyNjcxMDIzMyBDNjAuNTgyOTE4OTc0MTg5ODkgLTEyLjM3NTIwNzY3MDQxODAzLCA2MC43NzI2NDMzMTI4MTg3NjUgLTEyLjE3OTMwMTcxNDEyNTgzLCA2MS4xNzM2MTQ5NDg4MTgwMiAtMTEuNzY1MjY1NTc5NTczMDQ3IEM2MS4zNjk4NDg2NDM2MSAtMTEuNTM0NzU4MzE1NjU2ODM0LCA2MS41NjYwODIzMzg0MDE5NzYgLTExLjMwNDI1MTA1MTc0MDYyMSwgNjEuOTAwODAwOTQzMTkwNTIgLTEwLjkxMTA3MTUzMjUyNzgzOCBDNjIuMDgzNjgwNTU1NzE1MDMgLTEwLjY2NjAyOTUxMjQyMDQ0LCA2Mi4yNjY1NjAxNjgyMzk1MzYgLTEwLjQyMDk4NzQ5MjMxMzA0LCA2Mi41NzE3NjQ0NTU0NDY3MjYgLTEwLjAxMjA0MTU1MjEzNzk3MyBDNjIuNzYyNDY1ODE3NzYwOTQgLTkuNzE5MDczMDQ5MTM3NDA5LCA2Mi45NTMxNjcxODAwNzUxNiAtOS40MjYxMDQ1NDYxMzY4NDUsIDYzLjE4Mzc0ODM1MjU5MzU1NCAtOS4wNzE4Njk5NDU0MzQxOTEgQzYzLjM3OTQ0Mjc3OTcwNzQ3NSAtOC43MjQzOTQ2NzM4ODM4ODIsIDYzLjU3NTEzNzIwNjgyMTQgLTguMzc2OTE5NDAyMzMzNTcyLCA2My43MzQyMzc4NjE1Mjc1MDQgLTguMDk0NDIwMDc5MjE0NjE3IEM2My44ODU3ODgwNzk2MzgxNyAtNy43Nzk3MjI4MDg2NTI2MTgsIDY0LjAzNzMzODI5Nzc0ODgzIC03LjQ2NTAyNTUzODA5MDYyMSwgNjQuMjIwOTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODk2IEM2NC4zNDE1NjU3NDg3ODkxNSAtNi43ODU4MzY5MDM0NDg0MzUsIDY0LjQ2MjE2MDU5NDgwMTYgLTYuNDg3OTY1MzAyMjU0OTczLCA2NC42NDE5NDczODU4NzA4MSAtNi4wNDM4ODg0NTIzNzI4OTIgQzY0LjcyOTkyODQ4MTA0MDAyIC01Ljc3ODkwMzQxMTYwNzA1NzQsIDY0LjgxNzkwOTU3NjIwOTI1IC01LjUxMzkxODM3MDg0MTIyMywgNjQuOTk1NDM3NDI4MTQxNTYgLTQuOTc5MjMyNzY2MDQzMDczIEM2NS4wODMwMzkyNTA2NDI5NSAtNC42NDUxNjkwNDk5NzUyMjcsIDY1LjE3MDY0MTA3MzE0NDM0IC00LjMxMTEwNTMzMzkwNzM4LCA2NS4yNzk5ODg0NjMxODE5MSAtMy44OTQxMTYzNDQyMzU1MDQgQzY1LjMzMjMwMDE5MzYzMzU0IC0zLjYyNTUwNjY2NDQ1NDQ5MSwgNjUuMzg0NjExOTI0MDg1MTkgLTMuMzU2ODk2OTg0NjczNDc3NywgNjUuNDk0NDMxMjA5NzUyODggLTIuNzkyOTk4MTYzMDg0MTQzIEM2NS41NDg2NDU2NjkyMjYzNSAtMi4zNzI1MjE1MjEyNjM4NjUsIDY1LjYwMjg2MDEyODY5OTggLTEuOTUyMDQ0ODc5NDQzNTg3MiwgNjUuNjM3ODg0NDc2NjEwOTYgLTEuNjgwNDAyOTUzMzg0NDM0IEM2NS42NjAxOTY1NDQ4MTgwMiAtMS4zMzI4NzQ0ODEwODIzMDk5LCA2NS42ODI1MDg2MTMwMjUwNiAtMC45ODUzNDYwMDg3ODAxODU3LCA2NS43MDk3NTg3ODM1MTIwMyAtMC41NjA5MDI2MDc1MDM5NjU0IEM2NS43MDk3NTg3ODM1MTIwMyAtMC4xMjQyNDE0NTIzMjgyMDI2LCA2NS43MDk3NTg3ODM1MTIwMyAwLjMxMjQxOTcwMjg0NzU2MDE1LCA2NS43MDk3NTg3ODM1MTIwMyAwLjU2MDkwMjYwNzUwMzk2MTEgQzY1LjY5NTA3NTEzNzQ3MjU3IDAuNzg5NjEyMjQ2OTk0MjU5NywgNjUuNjgwMzkxNDkxNDMzMTEgMS4wMTgzMjE4ODY0ODQ1NTgyLCA2NS42Mzc4ODQ0NzY2MTA5NiAxLjY4MDQwMjk1MzM4NDQyMiBDNjUuNTgxNDgxMTE4MjU3NTMgMi4xMTc4NTYyNjI2NzA3NjgsIDY1LjUyNTA3Nzc1OTkwNDEgMi41NTUzMDk1NzE5NTcxMTM1LCA2NS40OTQ0MzEyMDk3NTI4OCAyLjc5Mjk5ODE2MzA4NDEzMSBDNjUuNDQwODM2NDQxOTc5NDEgMy4wNjgxOTU5NjgzNDI3MDQ1LCA2NS4zODcyNDE2NzQyMDU5NCAzLjM0MzM5Mzc3MzYwMTI3OCwgNjUuMjc5OTg4NDYzMTgxOTEgMy44OTQxMTYzNDQyMzU1IEM2NS4xOTQ3NjA3MDA0MDE2MyA0LjIxOTEyNjc0MTY2Mjc0MywgNjUuMTA5NTMyOTM3NjIxMzUgNC41NDQxMzcxMzkwODk5ODcsIDY0Ljk5NTQzNzQyODE0MTU2IDQuOTc5MjMyNzY2MDQzMDYxIEM2NC45MTM0NTUzNzAwOTMyMyA1LjIyNjE0OTY2MjgxNzU0OCwgNjQuODMxNDczMzEyMDQ0ODkgNS40NzMwNjY1NTk1OTIwMzYsIDY0LjY0MTk0NzM4NTg3MDgxIDYuMDQzODg4NDUyMzcyODggQzY0LjQ5MjQ2NjU3MDM3ODIxIDYuNDEzMTA4OTU2NjU0NTYzLCA2NC4zNDI5ODU3NTQ4ODU2IDYuNzgyMzI5NDYwOTM2MjQ1LCA2NC4yMjA5NzA5MDI3NzY3MSA3LjA4MzcwODUwNDY0MTg5MTUgQzY0LjA4MzIxMDc1MTA1MjA4IDcuMzY5NzcwNDA3MjkzMTU0LCA2My45NDU0NTA1OTkzMjc0NDQgNy42NTU4MzIzMDk5NDQ0MTYsIDYzLjczNDIzNzg2MTUyNzUwNCA4LjA5NDQyMDA3OTIxNDYxMyBDNjMuNTE0OTI5NzI3MjE4MzE2IDguNDgzODIzODc5MDM3MjYyLCA2My4yOTU2MjE1OTI5MDkxMyA4Ljg3MzIyNzY3ODg1OTkxLCA2My4xODM3NDgzNTI1OTM1NiA5LjA3MTg2OTk0NTQzNDE4NiBDNjMuMDAzMDQ3NjQyMDgzMjMgOS4zNDk0NzQ3NjE3MTI5NTMsIDYyLjgyMjM0NjkzMTU3MjkxIDkuNjI3MDc5NTc3OTkxNzIsIDYyLjU3MTc2NDQ1NTQ0NjczIDEwLjAxMjA0MTU1MjEzNzk2NCBDNjIuMzk5MTQ2Mjc4Njc2NTA0IDEwLjI0MzMzNDE4MzE3MDY1MSwgNjIuMjI2NTI4MTAxOTA2MjggMTAuNDc0NjI2ODE0MjAzMzM4LCA2MS45MDA4MDA5NDMxOTA1MjUgMTAuOTExMDcxNTMyNTI3ODM1IEM2MS42NTQ0MjgzNDQ0NDIzMTYgMTEuMjAwNDc0ODA2MDE1NDg5LCA2MS40MDgwNTU3NDU2OTQxMSAxMS40ODk4NzgwNzk1MDMxNDMsIDYxLjE3MzYxNDk0ODgxODAzIDExLjc2NTI2NTU3OTU3MzAzOCBDNjAuOTQwNjU5NDgyMzMzMDYgMTIuMDA1ODExMjI0NzE4MjYsIDYwLjcwNzcwNDAxNTg0ODA5NCAxMi4yNDYzNTY4Njk4NjM0ODMsIDYwLjM5MzE5NDYzNTU2MTAyIDEyLjU3MTExMzYyNjcxMDIyOSBDNjAuMTk0NTYxODAxMjA4MTQ1IDEyLjc1MTUwNjcxMTMzMjcwNywgNTkuOTk1OTI4OTY2ODU1MjcgMTIuOTMxODk5Nzk1OTU1MTg2LCA1OS41NjI3NDY5MTc4ODYzMSAxMy4zMjUzMDQyNzE0NTk4NDIgQzU5LjIyOTU2NTQ3MzkzMTQ5NCAxMy41OTEwMDc2MDY2ODMyMiwgNTguODk2Mzg0MDI5OTc2NjkgMTMuODU2NzEwOTQxOTA2NTk5LCA1OC42ODU2ODQyODM1OTYyOSAxNC4wMjQ3MzgzODI2ODkyNCBDNTguMzQ0NTM3NTk5NTA5OTkgMTQuMjYyNzA3NTQxNTA1OTA0LCA1OC4wMDMzOTA5MTU0MjM2OTQgMTQuNTAwNjc2NzAwMzIyNTY4LCA1Ny43NjU2MTA3NzExODQ2MSAxNC42NjY1NDE4MzU2MDcyMDcgQzU3LjU3MzQ5NzY0MDA0MTk4NSAxNC43ODMwMDE5NDQ2ODc5NCwgNTcuMzgxMzg0NTA4ODk5MzYgMTQuODk5NDYyMDUzNzY4Njc1LCA1Ni44MDYzMDcxNjAwNjg5MSAxNS4yNDgwNzczMjIxNTkzMTUgQzU2LjYwMDI5OTk0MDQ3MTIyIDE1LjM1NTU1MTE1NjY2OTUxMSwgNTYuMzk0MjkyNzIwODczNTIgMTUuNDYzMDI0OTkxMTc5NzA2LCA1NS44MTE3MTU0MzQ1NTcyNyAxNS43NjY5NTUxODgyOTIzMzIgQzU1LjQyODY3Mjg3MjAxODA1IDE1LjkzNjUxNjc2ODE3NDU0MiwgNTUuMDQ1NjMwMzA5NDc4ODIgMTYuMTA2MDc4MzQ4MDU2NzUsIDU0Ljc4NTkyMjU4NTM4OTA1IDE2LjIyMTA0MzI1MzU1NTM4IEM1NC40ODEzMzI4NzEyMTMwOSAxNi4zMzMxMzUwODM5Njg1ODUsIDU0LjE3Njc0MzE1NzAzNzE0IDE2LjQ0NTIyNjkxNDM4MTc4OCwgNTMuNzMzMTQzODE1NDEzMzcgMTYuNjA4NDc1NTcyNjg2Njk3IEM1My4zNzg5Njg0MzkwNjIzNiAxNi43MTM1OTI5NjUyODMxOSwgNTMuMDI0NzkzMDYyNzExMzUgMTYuODE4NzEwMzU3ODc5Njg0LCA1Mi42NTc3MDUyMTg0MTYzOTYgMTYuOTI3NjYwMTAzMTgzMDEyIEM1Mi4yMzUxMTI1NTI3OTY3NjQgMTcuMDI0MTE0MTIxNDM1ODMzLCA1MS44MTI1MTk4ODcxNzcxMyAxNy4xMjA1NjgxMzk2ODg2NSwgNTEuNTY0MDI2MDAyMjc0MDIgMTcuMTc3Mjg1MjQ3MzQzNjQ0IEM1MS4yODMwNzM0NjcwMDQ1NTYgMTcuMjIyNzA3NDc0NDI2NTYsIDUxLjAwMjEyMDkzMTczNTA5IDE3LjI2ODEyOTcwMTUwOTQ3MywgNTAuNDU2NjAwMzI5NDc4ODcgMTcuMzU2MzI1MjQxOTA2ODA2IEM1MC4xNDY5MjMwMDMyMTE3MyAxNy4zODYxOTk0NDExMzAzMjMsIDQ5LjgzNzI0NTY3Njk0NDU5IDE3LjQxNjA3MzY0MDM1MzgzNywgNDkuMzM5OTc4ODQ5NjYyNDcgMTcuNDY0MDQ0MzczMTMwODg2IEM0OS4wNTY0MjcwNTgxMTk3NyAxNy40NzMxMzczMjcxODU1OCwgNDguNzcyODc1MjY2NTc3MDc0IDE3LjQ4MjIzMDI4MTI0MDI3MywgNDguMjE4NzUgMTcuNSBDNDguMjE4NzUgMTcuNSwgNDguMjE4NzUgMTcuNSwgNDguMjE4NzUgMTcuNSBDMjguMDkyODc5MjQ3NzE4MzgzIDE3LjUsIDcuOTY3MDA4NDk1NDM2NzY1IDE3LjUsIC00OC4yMTg3NSAxNy41IEMtNDguNTM0OTUwNDc2MjM5IDE3LjQ4OTg2MDA2NjE3MzkwNCwgLTQ4Ljg1MTE1MDk1MjQ3Nzk5NCAxNy40Nzk3MjAxMzIzNDc4MSwgLTQ5LjMzOTk3ODg0OTY2MjQ2NSAxNy40NjQwNDQzNzMxMzA4ODYgQy00OS43NTU1Nzk5MzA0NjAyNyAxNy40MjM5NTE4MzY2OTk3NSwgLTUwLjE3MTE4MTAxMTI1ODA4IDE3LjM4Mzg1OTMwMDI2ODYxNSwgLTUwLjQ1NjYwMDMyOTQ3ODg2IDE3LjM1NjMyNTI0MTkwNjgwNiBDLTUwLjY4MzgyODc3OTg2MDgyIDE3LjMxOTU4ODcwODIzMiwgLTUwLjkxMTA1NzIzMDI0Mjc3IDE3LjI4Mjg1MjE3NDU1NzIsIC01MS41NjQwMjYwMDIyNzQwMSAxNy4xNzcyODUyNDczNDM2NDQgQy01MS45MTg1MjAyMjExNzc3NSAxNy4wOTYzNzQyNTUxNjk4MywgLTUyLjI3MzAxNDQ0MDA4MTQ5IDE3LjAxNTQ2MzI2Mjk5NjAyLCAtNTIuNjU3NzA1MjE4NDE2Mzc1IDE2LjkyNzY2MDEwMzE4MzAxNSBDLTUzLjAwNTkyMTM0OTg5OTg1IDE2LjgyNDMxMTM4MzE4MjQ5NCwgLTUzLjM1NDEzNzQ4MTM4MzMyNiAxNi43MjA5NjI2NjMxODE5NywgLTUzLjczMzE0MzgxNTQxMzM2IDE2LjYwODQ3NTU3MjY4NjcwNCBDLTU0LjExNjA4MzIxMjAyMjQ3IDE2LjQ2NzU1MDMzNDg4MTU3MiwgLTU0LjQ5OTAyMjYwODYzMTU4IDE2LjMyNjYyNTA5NzA3NjQ0LCAtNTQuNzg1OTIyNTg1Mzg5MDQ1IDE2LjIyMTA0MzI1MzU1NTM4IEMtNTUuMDk5MzM1MTI4OTM0ODc1IDE2LjA4MjMwNDgxNzU4MDQyLCAtNTUuNDEyNzQ3NjcyNDgwNzA1IDE1Ljk0MzU2NjM4MTYwNTQ2NCwgLTU1LjgxMTcxNTQzNDU1NzI2NCAxNS43NjY5NTUxODgyOTIzMzggQy01Ni4xMDU3MDA1MjMzNDcwNDYgMTUuNjEzNTgzMzU1Nzc3MTQzLCAtNTYuMzk5Njg1NjEyMTM2ODM1IDE1LjQ2MDIxMTUyMzI2MTk0OSwgLTU2LjgwNjMwNzE2MDA2ODkwNCAxNS4yNDgwNzczMjIxNTkzMTggQy01Ny4wNjg1ODY4NjMyMjY1NjQgMTUuMDg5MDgxODI0Nzc4NTI3LCAtNTcuMzMwODY2NTY2Mzg0MjE2IDE0LjkzMDA4NjMyNzM5NzczMywgLTU3Ljc2NTYxMDc3MTE4NDU5IDE0LjY2NjU0MTgzNTYwNzIxOCBDLTU3Ljk5Mzg3MDg4MzMyODUwNSAxNC41MDczMTc0NjI1OTY2MiwgLTU4LjIyMjEzMDk5NTQ3MjQyNiAxNC4zNDgwOTMwODk1ODYwMiwgLTU4LjY4NTY4NDI4MzU5NjI3NCAxNC4wMjQ3MzgzODI2ODkyNDMgQy01OS4wMzQyNzQxMTk0NDU5NiAxMy43NDY3NDcyNjQ5NjQyMzEsIC01OS4zODI4NjM5NTUyOTU2NTUgMTMuNDY4NzU2MTQ3MjM5MjE5LCAtNTkuNTYyNzQ2OTE3ODg2Mjk0IDEzLjMyNTMwNDI3MTQ1OTg1NiBDLTU5Ljc1NTc0Mjg5ODA3ODE3NSAxMy4xNTAwMzA0Mjg2NDM0MDMsIC01OS45NDg3Mzg4NzgyNzAwNTYgMTIuOTc0NzU2NTg1ODI2OTQ3LCAtNjAuMzkzMTk0NjM1NTYxIDEyLjU3MTExMzYyNjcxMDI0MSBDLTYwLjY3MDI5MjY1NzY3NDg5IDEyLjI4NDk4NzE2ODcwNjk0MywgLTYwLjk0NzM5MDY3OTc4ODc4IDExLjk5ODg2MDcxMDcwMzY0NCwgLTYxLjE3MzYxNDk0ODgxODAzIDExLjc2NTI2NTU3OTU3MzA0MyBDLTYxLjQ1Nzk2NjgwNjg2MjQgMTEuNDMxMjQ5NzA3MDM1MDMsIC02MS43NDIzMTg2NjQ5MDY3OCAxMS4wOTcyMzM4MzQ0OTcwMTgsIC02MS45MDA4MDA5NDMxOTA1MiAxMC45MTEwNzE1MzI1Mjc4NCBDLTYyLjEyMzA4MDU1NDQwNjA0IDEwLjYxMzIzNzEwMzU4ODIxMiwgLTYyLjM0NTM2MDE2NTYyMTU2IDEwLjMxNTQwMjY3NDY0ODU4NSwgLTYyLjU3MTc2NDQ1NTQ0NjcyNiAxMC4wMTIwNDE1NTIxMzc5NzQgQy02Mi43MTU0MzY0NDM3MDA4MSA5Ljc5MTMyMjc5Njg0ODk2MywgLTYyLjg1OTEwODQzMTk1NDg5IDkuNTcwNjA0MDQxNTU5OTUzLCAtNjMuMTgzNzQ4MzUyNTkzNTU0IDkuMDcxODY5OTQ1NDM0MTk4IEMtNjMuMzA0NDg5NzQxMzY5NDE2IDguODU3NDgxMzgzMjcxMjU4LCAtNjMuNDI1MjMxMTMwMTQ1MjggOC42NDMwOTI4MjExMDgzMTgsIC02My43MzQyMzc4NjE1Mjc1MDQgOC4wOTQ0MjAwNzkyMTQ2MTggQy02My44NzY0NTExMDM1ODMzIDcuNzk5MTExMjM5MjA5ODM2LCAtNjQuMDE4NjY0MzQ1NjM5MSA3LjUwMzgwMjM5OTIwNTA1MywgLTY0LjIyMDk3MDkwMjc3NjcxIDcuMDgzNzA4NTA0NjQxODk4IEMtNjQuMzEzMTgzMTg1NTU2NzEgNi44NTU5NDIzODMzNzIxMTQsIC02NC40MDUzOTU0NjgzMzY2OSA2LjYyODE3NjI2MjEwMjMzLCAtNjQuNjQxOTQ3Mzg1ODcwODEgNi4wNDM4ODg0NTIzNzI4OTQgQy02NC43NjY5OTg0NjQyODg2NSA1LjY2NzI1NDUyODM2MTkzNSwgLTY0Ljg5MjA0OTU0MjcwNjQ5IDUuMjkwNjIwNjA0MzUwOTc2LCAtNjQuOTk1NDM3NDI4MTQxNTYgNC45NzkyMzI3NjYwNDMwNjggQy02NS4wNjMwNDExNzc4MTQwMSA0LjcyMTQzMDM2ODg5MTUzMywgLTY1LjEzMDY0NDkyNzQ4NjQ3IDQuNDYzNjI3OTcxNzM5OTk4NSwgLTY1LjI3OTk4ODQ2MzE4MTkxIDMuODk0MTE2MzQ0MjM1NTA2MiBDLTY1LjMzMzcwNDkyNjY5NDQ4IDMuNjE4MjkzNjU3MDc3MDAxNywgLTY1LjM4NzQyMTM5MDIwNzA3IDMuMzQyNDcwOTY5OTE4NDk3LCAtNjUuNDk0NDMxMjA5NzUyODggMi43OTI5OTgxNjMwODQxNDQ3IEMtNjUuNTM0MDQwNzUxMDY3NjEgMi40ODU3OTQzODI0MzU3NTI3LCAtNjUuNTczNjUwMjkyMzgyMzMgMi4xNzg1OTA2MDE3ODczNjA2LCAtNjUuNjM3ODg0NDc2NjEwOTYgMS42ODA0MDI5NTMzODQ0NDQgQy02NS42NjYwOTY5MDY2NzMwOSAxLjI0MDk3MTU4MjUwMzIzMSwgLTY1LjY5NDMwOTMzNjczNTIgMC44MDE1NDAyMTE2MjIwMTgzLCAtNjUuNzA5NzU4NzgzNTEyMDMgMC41NjA5MDI2MDc1MDM5Njc2IEMtNjUuNzA5NzU4NzgzNTEyMDMgMC4xNjY0MzM4MTA4MjU0Nzc2LCAtNjUuNzA5NzU4NzgzNTEyMDMgLTAuMjI4MDM0OTg1ODUzMDEyNCwgLTY1LjcwOTc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBDLTY1LjY5MDc3OTIyNTM0OTczIC0wLjg1NjUyNDU0NTkwNTQ2NiwgLTY1LjY3MTc5OTY2NzE4NzQxIC0xLjE1MjE0NjQ4NDMwNjk3MjksIC02NS42Mzc4ODQ0NzY2MTA5NiAtMS42ODA0MDI5NTMzODQ0MTk4IEMtNjUuNTk2ODkyMDg3NTkyMiAtMS45OTgzMzE4Mjc3NTEyMjcsIC02NS41NTU4OTk2OTg1NzM0MSAtMi4zMTYyNjA3MDIxMTgwMzQsIC02NS40OTQ0MzEyMDk3NTI4OCAtMi43OTI5OTgxNjMwODQxMzY3IEMtNjUuNDEzMDI0ODU2OTIxODIgLTMuMjExMDAyNTc5NjMyODI2MywgLTY1LjMzMTYxODUwNDA5MDc3IC0zLjYyOTAwNjk5NjE4MTUxNiwgLTY1LjI3OTk4ODQ2MzE4MTkxIC0zLjg5NDExNjM0NDIzNTQ5OCBDLTY1LjE5MDE2Nzk2OTgzOTE3IC00LjIzNjY0MDgxMzc5OTQzMSwgLTY1LjEwMDM0NzQ3NjQ5NjQ0IC00LjU3OTE2NTI4MzM2MzM2NDUsIC02NC45OTU0Mzc0MjgxNDE1NyAtNC45NzkyMzI3NjYwNDMwNTkgQy02NC44ODU2MDk0NDA4MzE2NyAtNS4zMTAwMTcxNjUxMDcwNjEsIC02NC43NzU3ODE0NTM1MjE3NyAtNS42NDA4MDE1NjQxNzEwNjIsIC02NC42NDE5NDczODU4NzA4MSAtNi4wNDM4ODg0NTIzNzI4NzE1IEMtNjQuNDgwODE0NTQ4MzY3MDYgLTYuNDQxODg5Njc2Mjk4NTkzLCAtNjQuMzE5NjgxNzEwODYzMzIgLTYuODM5ODkwOTAwMjI0MzE0LCAtNjQuMjIwOTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODg5IEMtNjQuMTAzMzc4NTU2NDQ2OTYgLTcuMzI3ODkxNTI3ODY4Nzc1LCAtNjMuOTg1Nzg2MjEwMTE3MjA1IC03LjU3MjA3NDU1MTA5NTY2LCAtNjMuNzM0MjM3ODYxNTI3NTA0IC04LjA5NDQyMDA3OTIxNDYxMSBDLTYzLjU2MzI1NzMyNjgzODk0IC04LjM5ODAxMzMzMjIxMDcyNywgLTYzLjM5MjI3Njc5MjE1MDM3IC04LjcwMTYwNjU4NTIwNjg0MSwgLTYzLjE4Mzc0ODM1MjU5MzU1NCAtOS4wNzE4Njk5NDU0MzQxOTMgQy02My4wMjcyMDU2MDc3OTkwNzUgLTkuMzEyMzYxNjM5MDUxMzEyLCAtNjIuODcwNjYyODYzMDA0NTkgLTkuNTUyODUzMzMyNjY4NDMyLCAtNjIuNTcxNzY0NDU1NDQ2NzI2IC0xMC4wMTIwNDE1NTIxMzc5NjkgQy02Mi4zODk2NTk3MjI2ODQxNCAtMTAuMjU2MDQ1MzAzOTU3Mzk2LCAtNjIuMjA3NTU0OTg5OTIxNTUgLTEwLjUwMDA0OTA1NTc3NjgyNCwgLTYxLjkwMDgwMDk0MzE5MDUyNSAtMTAuOTExMDcxNTMyNTI3ODM1IEMtNjEuNjIzOTk2MzMwMzU4OTIgLTExLjIzNjIyMTk4MTM4ODUwMiwgLTYxLjM0NzE5MTcxNzUyNzMxNiAtMTEuNTYxMzcyNDMwMjQ5MTcsIC02MS4xNzM2MTQ5NDg4MTgwMyAtMTEuNzY1MjY1NTc5NTczMDM4IEMtNjAuOTI5NTkzMzU3MTQ3MzEgLTEyLjAxNzIzNzkwNzUxODMyMywgLTYwLjY4NTU3MTc2NTQ3NjU5NSAtMTIuMjY5MjEwMjM1NDYzNjA3LCAtNjAuMzkzMTk0NjM1NTYxMDI0IC0xMi41NzExMTM2MjY3MTAyMjQgQy02MC4yMTAwMTc5ODY0Mzg5MyAtMTIuNzM3NDY5ODEyODU0MzYsIC02MC4wMjY4NDEzMzczMTY4MyAtMTIuOTAzODI1OTk4OTk4NSwgLTU5LjU2Mjc0NjkxNzg4NjMxNSAtMTMuMzI1MzA0MjcxNDU5ODQgQy01OS4yOTQzNjc1NTcwNjY4MiAtMTMuNTM5MzI5NjY5ODM4NjU4LCAtNTkuMDI1OTg4MTk2MjQ3MzIgLTEzLjc1MzM1NTA2ODIxNzQ3NSwgLTU4LjY4NTY4NDI4MzU5NjI5IC0xNC4wMjQ3MzgzODI2ODkyMzYgQy01OC40ODQ1NDIwMTA1NjEwNCAtMTQuMTY1MDQ2NTI1MDQ5OTYxLCAtNTguMjgzMzk5NzM3NTI1NzkgLTE0LjMwNTM1NDY2NzQxMDY4OCwgLTU3Ljc2NTYxMDc3MTE4NDYxIC0xNC42NjY1NDE4MzU2MDcyMDUgQy01Ny41NTg4Mzk0MTExNTkzIC0xNC43OTE4ODc4NDkxNzc5NCwgLTU3LjM1MjA2ODA1MTEzMzk4IC0xNC45MTcyMzM4NjI3NDg2NzIsIC01Ni44MDYzMDcxNjAwNjg5MSAtMTUuMjQ4MDc3MzIyMTU5MzEzIEMtNTYuNDIzNjQzMDI4MjE1NzM2IC0xNS40NDc3MTI5NTQ2MzkwNCwgLTU2LjA0MDk3ODg5NjM2MjU2IC0xNS42NDczNDg1ODcxMTg3NywgLTU1LjgxMTcxNTQzNDU1NzI3IC0xNS43NjY5NTUxODgyOTIzMzIgQy01NS41MzUzNDc5NDU1MTMyOTQgLTE1Ljg4OTI5NDg3NzU0MTgyLCAtNTUuMjU4OTgwNDU2NDY5MzEgLTE2LjAxMTYzNDU2Njc5MTMwOCwgLTU0Ljc4NTkyMjU4NTM4OTA2IC0xNi4yMjEwNDMyNTM1NTUzNzYgQy01NC40Njc0ODM3ODM5MjMzIC0xNi4zMzgyMzE2NzYxMTA3ODcsIC01NC4xNDkwNDQ5ODI0NTc1NCAtMTYuNDU1NDIwMDk4NjY2MiwgLTUzLjczMzE0MzgxNTQxMzM4IC0xNi42MDg0NzU1NzI2ODY2OTcgQy01My4zNTQ1OTg2ODEwMzE1NzUgLTE2LjcyMDgyNTc4MTU0NzI1NSwgLTUyLjk3NjA1MzU0NjY0OTc3IC0xNi44MzMxNzU5OTA0MDc4MTcsIC01Mi42NTc3MDUyMTg0MTYzOTYgLTE2LjkyNzY2MDEwMzE4MzAxIEMtNTIuMzc1MTU1NjQxNjg3OSAtMTYuOTkyMTUwMjAwMjYyOTg3LCAtNTIuMDkyNjA2MDY0OTU5MzkgLTE3LjA1NjY0MDI5NzM0Mjk2NiwgLTUxLjU2NDAyNjAwMjI3NDAyIC0xNy4xNzcyODUyNDczNDM2NCBDLTUxLjI1NjQ1Njk2MjY1MzE0IC0xNy4yMjcwMTA2MjQ0MzYwMiwgLTUwLjk0ODg4NzkyMzAzMjI2IC0xNy4yNzY3MzYwMDE1Mjg0LCAtNTAuNDU2NjAwMzI5NDc4ODcgLTE3LjM1NjMyNTI0MTkwNjgwNiBDLTUwLjE0NTU3NTA3MjY2MTggLTE3LjM4NjMyOTQ3NDM2OTM1LCAtNDkuODM0NTQ5ODE1ODQ0NzMgLTE3LjQxNjMzMzcwNjgzMTg5MiwgLTQ5LjMzOTk3ODg0OTY2MjQ4IC0xNy40NjQwNDQzNzMxMzA4ODYgQy00OS4wODk2OTE1NDE1NjA4MyAtMTcuNDcyMDcwNTk5OTQ3MDEzLCAtNDguODM5NDA0MjMzNDU5MTg0IC0xNy40ODAwOTY4MjY3NjMxNCwgLTQ4LjIxODc1MDAwMDAwMDAxIC0xNy41IEMtNDguMjE4NzUwMDAwMDAwMDEgLTE3LjUsIC00OC4yMTg3NSAtMTcuNSwgLTQ4LjIxODc1IC0xNy41IiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMCIgZmlsbD0iI2RiZTVlYyIgc3R5bGU9IiIvPjxwYXRoIGQ9Ik0tNDguMjE4NzUgLTE3LjUgQy0yNS43NTkxNjY4MTY5NTUzOSAtMTcuNSwgLTMuMjk5NTgzNjMzOTEwNzc4MiAtMTcuNSwgNDguMjE4NzUgLTE3LjUgTS00OC4yMTg3NSAtMTcuNSBDLTIxLjE3MzY2Mzc3MjYzNDI1NiAtMTcuNSwgNS44NzE0MjI0NTQ3MzE0ODcgLTE3LjUsIDQ4LjIxODc1IC0xNy41IE00OC4yMTg3NSAtMTcuNSBDNDguMjE4NzUgLTE3LjUsIDQ4LjIxODc1IC0xNy41LCA0OC4yMTg3NSAtMTcuNSBNNDguMjE4NzUgLTE3LjUgQzQ4LjIxODc1IC0xNy41LCA0OC4yMTg3NSAtMTcuNSwgNDguMjE4NzUgLTE3LjUgTTQ4LjIxODc1IC0xNy41IEM0OC41Njc2MzIyMTE0MzE2NCAtMTcuNDg4ODEyMDI2NTM3NDE3LCA0OC45MTY1MTQ0MjI4NjMyOSAtMTcuNDc3NjI0MDUzMDc0ODMsIDQ5LjMzOTk3ODg0OTY2MjQ3IC0xNy40NjQwNDQzNzMxMzA4ODYgTTQ4LjIxODc1IC0xNy41IEM0OC42MzM4NjMwMDQxNTE0NSAtMTcuNDg2Njg4MTMzOTI1MzEsIDQ5LjA0ODk3NjAwODMwMjkgLTE3LjQ3MzM3NjI2Nzg1MDYxOCwgNDkuMzM5OTc4ODQ5NjYyNDcgLTE3LjQ2NDA0NDM3MzEzMDg4NiBNNDkuMzM5OTc4ODQ5NjYyNDcgLTE3LjQ2NDA0NDM3MzEzMDg4NiBDNDkuNzUzMDY1OTYxODg0NyAtMTcuNDI0MTk0MzU2MjI0NzQ2LCA1MC4xNjYxNTMwNzQxMDY5MyAtMTcuMzg0MzQ0MzM5MzE4NjA2LCA1MC40NTY2MDAzMjk0Nzg4NSAtMTcuMzU2MzI1MjQxOTA2ODEgTTQ5LjMzOTk3ODg0OTY2MjQ3IC0xNy40NjQwNDQzNzMxMzA4ODYgQzQ5LjY5MTk4NDM4ODE5NTcgLTE3LjQzMDA4NjgyMjE3NzE4NCwgNTAuMDQzOTg5OTI2NzI4OTI2IC0xNy4zOTYxMjkyNzEyMjM0ODMsIDUwLjQ1NjYwMDMyOTQ3ODg1IC0xNy4zNTYzMjUyNDE5MDY4MSBNNTAuNDU2NjAwMzI5NDc4ODUgLTE3LjM1NjMyNTI0MTkwNjgxIEM1MC43NzM4NjEzODAwNTM3MiAtMTcuMzA1MDMyOTM1NjQ2MDU3LCA1MS4wOTExMjI0MzA2Mjg1OSAtMTcuMjUzNzQwNjI5Mzg1MzA1LCA1MS41NjQwMjYwMDIyNzQwMSAtMTcuMTc3Mjg1MjQ3MzQzNjQ0IE01MC40NTY2MDAzMjk0Nzg4NSAtMTcuMzU2MzI1MjQxOTA2ODEgQzUwLjgwODM4NTY2OTMxMDAxIC0xNy4yOTk0NTEzMTYyOTg5NjMsIDUxLjE2MDE3MTAwOTE0MTE2NiAtMTcuMjQyNTc3MzkwNjkxMTE0LCA1MS41NjQwMjYwMDIyNzQwMSAtMTcuMTc3Mjg1MjQ3MzQzNjQ0IE01MS41NjQwMjYwMDIyNzQwMSAtMTcuMTc3Mjg1MjQ3MzQzNjQ0IEM1MS44MDEwODMzNDA5Njc0MSAtMTcuMTIzMTc4NDU2NzMwNTc4LCA1Mi4wMzgxNDA2Nzk2NjA4MSAtMTcuMDY5MDcxNjY2MTE3NTE2LCA1Mi42NTc3MDUyMTg0MTYzNzUgLTE2LjkyNzY2MDEwMzE4MzAxNSBNNTEuNTY0MDI2MDAyMjc0MDEgLTE3LjE3NzI4NTI0NzM0MzY0NCBDNTEuNzg3NzE4OTk3MzI3OTEgLTE3LjEyNjIyODc4MDk1NTgwNiwgNTIuMDExNDExOTkyMzgxNzk1IC0xNy4wNzUxNzIzMTQ1Njc5NjUsIDUyLjY1NzcwNTIxODQxNjM3NSAtMTYuOTI3NjYwMTAzMTgzMDE1IE01Mi42NTc3MDUyMTg0MTYzNzUgLTE2LjkyNzY2MDEwMzE4MzAxNSBDNTMuMDc4Njc0OTkzNzgyMTIgLTE2LjgwMjcxODQ4MzU2OTkwNSwgNTMuNDk5NjQ0NzY5MTQ3ODY0IC0xNi42Nzc3NzY4NjM5NTY3OTQsIDUzLjczMzE0MzgxNTQxMzM2NCAtMTYuNjA4NDc1NTcyNjg2NyBNNTIuNjU3NzA1MjE4NDE2Mzc1IC0xNi45Mjc2NjAxMDMxODMwMTUgQzUzLjAwNDgwMDg1NzgxODAyIC0xNi44MjQ2NDM5MzkzNTA4LCA1My4zNTE4OTY0OTcyMTk2NiAtMTYuNzIxNjI3Nzc1NTE4NTgsIDUzLjczMzE0MzgxNTQxMzM2NCAtMTYuNjA4NDc1NTcyNjg2NyBNNTMuNzMzMTQzODE1NDEzMzY0IC0xNi42MDg0NzU1NzI2ODY3IEM1My45ODAxMjg1MTQ3MDU2MSAtMTYuNTE3NTgyOTIwMjQ1NjIsIDU0LjIyNzExMzIxMzk5Nzg2IC0xNi40MjY2OTAyNjc4MDQ1NCwgNTQuNzg1OTIyNTg1Mzg5MDQ1IC0xNi4yMjEwNDMyNTM1NTUzOCBNNTMuNzMzMTQzODE1NDEzMzY0IC0xNi42MDg0NzU1NzI2ODY3IEM1My45Nzk0Nzk2NDA5MTgyOCAtMTYuNTE3ODIxNzExNzk3NDgsIDU0LjIyNTgxNTQ2NjQyMzIgLTE2LjQyNzE2Nzg1MDkwODI2MiwgNTQuNzg1OTIyNTg1Mzg5MDQ1IC0xNi4yMjEwNDMyNTM1NTUzOCBNNTQuNzg1OTIyNTg1Mzg5MDQ1IC0xNi4yMjEwNDMyNTM1NTUzOCBDNTUuMTU1MzY0MDIxNjM2OTkgLTE2LjA1NzUwMjQ4ODgxOTI0MiwgNTUuNTI0ODA1NDU3ODg0OTQ1IC0xNS44OTM5NjE3MjQwODMxMDcsIDU1LjgxMTcxNTQzNDU1NzI2NCAtMTUuNzY2OTU1MTg4MjkyMzM2IE01NC43ODU5MjI1ODUzODkwNDUgLTE2LjIyMTA0MzI1MzU1NTM4IEM1NS4wNzQ4NzE4ODQ1NTkyOCAtMTYuMDkzMTMzOTcwMTg5MTM2LCA1NS4zNjM4MjExODM3Mjk1MSAtMTUuOTY1MjI0Njg2ODIyODkxLCA1NS44MTE3MTU0MzQ1NTcyNjQgLTE1Ljc2Njk1NTE4ODI5MjMzNiBNNTUuODExNzE1NDM0NTU3MjY0IC0xNS43NjY5NTUxODgyOTIzMzYgQzU2LjA4NzMyMzY1NDUxMzA3IC0xNS42MjMxNzA1NTY0NzY4OCwgNTYuMzYyOTMxODc0NDY4ODg1IC0xNS40NzkzODU5MjQ2NjE0MjcsIDU2LjgwNjMwNzE2MDA2ODkxIC0xNS4yNDgwNzczMjIxNTkzMTYgTTU1LjgxMTcxNTQzNDU1NzI2NCAtMTUuNzY2OTU1MTg4MjkyMzM2IEM1Ni4wMjM5NDc1NjIyMjcyMTQgLTE1LjY1NjIzMzgyMzIyODA5LCA1Ni4yMzYxNzk2ODk4OTcxNTYgLTE1LjU0NTUxMjQ1ODE2Mzg0NSwgNTYuODA2MzA3MTYwMDY4OTEgLTE1LjI0ODA3NzMyMjE1OTMxNiBNNTYuODA2MzA3MTYwMDY4OTEgLTE1LjI0ODA3NzMyMjE1OTMxNiBDNTcuMDEyNjgzNzQxMTg3ODUgLTE1LjEyMjk3MDYyNTg4MTYwNSwgNTcuMjE5MDYwMzIyMzA2NzkgLTE0Ljk5Nzg2MzkyOTYwMzg5MywgNTcuNzY1NjEwNzcxMTg0NiAtMTQuNjY2NTQxODM1NjA3MjEyIE01Ni44MDYzMDcxNjAwNjg5MSAtMTUuMjQ4MDc3MzIyMTU5MzE2IEM1Ny4wNDg4Mzk3MTkzNDc3NiAtMTUuMTAxMDUyNjU5NDQ0OTU1LCA1Ny4yOTEzNzIyNzg2MjY2MSAtMTQuOTU0MDI3OTk2NzMwNTkxLCA1Ny43NjU2MTA3NzExODQ2IC0xNC42NjY1NDE4MzU2MDcyMTIgTTU3Ljc2NTYxMDc3MTE4NDYgLTE0LjY2NjU0MTgzNTYwNzIxMiBDNTguMTEyNjcyNDQyNDM3MDcgLTE0LjQyNDQ0NjYzNzc5OTA5LCA1OC40NTk3MzQxMTM2ODk1NSAtMTQuMTgyMzUxNDM5OTkwOTY3LCA1OC42ODU2ODQyODM1OTYyOCAtMTQuMDI0NzM4MzgyNjg5MjQxIE01Ny43NjU2MTA3NzExODQ2IC0xNC42NjY1NDE4MzU2MDcyMTIgQzU4LjA1ODE4NTIyNTM2NDk0IC0xNC40NjI0NTQ1NjE3MTUsIDU4LjM1MDc1OTY3OTU0NTI3IC0xNC4yNTgzNjcyODc4MjI3OTEsIDU4LjY4NTY4NDI4MzU5NjI4IC0xNC4wMjQ3MzgzODI2ODkyNDEgTTU4LjY4NTY4NDI4MzU5NjI4IC0xNC4wMjQ3MzgzODI2ODkyNDEgQzU5LjAxMjQyMDIwODUzNzY4IC0xMy43NjQxNzUxNzczNTY1OTksIDU5LjMzOTE1NjEzMzQ3OTA3IC0xMy41MDM2MTE5NzIwMjM5NTYsIDU5LjU2Mjc0NjkxNzg4NjI5NCAtMTMuMzI1MzA0MjcxNDU5ODU1IE01OC42ODU2ODQyODM1OTYyOCAtMTQuMDI0NzM4MzgyNjg5MjQxIEM1OC45MDA1NTkzMTAzMDMwNSAtMTMuODUzMzgxMjY2OTU1MTk2LCA1OS4xMTU0MzQzMzcwMDk4MTYgLTEzLjY4MjAyNDE1MTIyMTE1MSwgNTkuNTYyNzQ2OTE3ODg2Mjk0IC0xMy4zMjUzMDQyNzE0NTk4NTUgTTU5LjU2Mjc0NjkxNzg4NjI5NCAtMTMuMzI1MzA0MjcxNDU5ODU1IEM1OS43OTE4OTMyMzEwNzcyNCAtMTMuMTE3MTk5NjUyNjk5MDQ4LCA2MC4wMjEwMzk1NDQyNjgxODQgLTEyLjkwOTA5NTAzMzkzODI0MSwgNjAuMzkzMTk0NjM1NTYxMDEgLTEyLjU3MTExMzYyNjcxMDIzMyBNNTkuNTYyNzQ2OTE3ODg2Mjk0IC0xMy4zMjUzMDQyNzE0NTk4NTUgQzU5Ljc3MzIyNzkyNTkwMTIyNCAtMTMuMTM0MTUwOTg5MDAyOTkxLCA1OS45ODM3MDg5MzM5MTYxNTUgLTEyLjk0Mjk5NzcwNjU0NjEzLCA2MC4zOTMxOTQ2MzU1NjEwMSAtMTIuNTcxMTEzNjI2NzEwMjMzIE02MC4zOTMxOTQ2MzU1NjEwMSAtMTIuNTcxMTEzNjI2NzEwMjMzIEM2MC42ODU4MTM2Mzc3OTE0NTUgLTEyLjI2ODk2MDQ4MjQ0MDQyNSwgNjAuOTc4NDMyNjQwMDIxODkgLTExLjk2NjgwNzMzODE3MDYxNiwgNjEuMTczNjE0OTQ4ODE4MDIgLTExLjc2NTI2NTU3OTU3MzA0NyBNNjAuMzkzMTk0NjM1NTYxMDEgLTEyLjU3MTExMzYyNjcxMDIzMyBDNjAuNTc4MTQwOTk3NzU1MjggLTEyLjM4MDE0MTMyMzM2NTkyOCwgNjAuNzYzMDg3MzU5OTQ5NTQgLTEyLjE4OTE2OTAyMDAyMTYyMywgNjEuMTczNjE0OTQ4ODE4MDIgLTExLjc2NTI2NTU3OTU3MzA0NyBNNjEuMTczNjE0OTQ4ODE4MDIgLTExLjc2NTI2NTU3OTU3MzA0NyBDNjEuMzg1ODE3NzY5MTY0NTMgLTExLjUxNjAwMDA3MjExMTQ5NCwgNjEuNTk4MDIwNTg5NTExMDQ0IC0xMS4yNjY3MzQ1NjQ2NDk5NDIsIDYxLjkwMDgwMDk0MzE5MDUyIC0xMC45MTEwNzE1MzI1Mjc4MzggTTYxLjE3MzYxNDk0ODgxODAyIC0xMS43NjUyNjU1Nzk1NzMwNDcgQzYxLjM4NTY2NzU5MTAxODEyIC0xMS41MTYxNzY0Nzk5MDc2NDYsIDYxLjU5NzcyMDIzMzIxODIyNiAtMTEuMjY3MDg3MzgwMjQyMjQ1LCA2MS45MDA4MDA5NDMxOTA1MiAtMTAuOTExMDcxNTMyNTI3ODM4IE02MS45MDA4MDA5NDMxOTA1MiAtMTAuOTExMDcxNTMyNTI3ODM4IEM2Mi4wNDE2NDY2MTMwNjI5MSAtMTAuNzIyMzUxMTY2MjAzMzI4LCA2Mi4xODI0OTIyODI5MzUzIC0xMC41MzM2MzA3OTk4Nzg4MTgsIDYyLjU3MTc2NDQ1NTQ0NjcyNiAtMTAuMDEyMDQxNTUyMTM3OTczIE02MS45MDA4MDA5NDMxOTA1MiAtMTAuOTExMDcxNTMyNTI3ODM4IEM2Mi4xNDgyNDgzNjA3NjM2NzQgLTEwLjU3OTUxNDUzNTkwMzMwOSwgNjIuMzk1Njk1Nzc4MzM2ODIgLTEwLjI0Nzk1NzUzOTI3ODc3OCwgNjIuNTcxNzY0NDU1NDQ2NzI2IC0xMC4wMTIwNDE1NTIxMzc5NzMgTTYyLjU3MTc2NDQ1NTQ0NjcyNiAtMTAuMDEyMDQxNTUyMTM3OTczIEM2Mi43MDMwNzMzNDcxNTg4NyAtOS44MTAzMTU4MzMwOTM2MzQsIDYyLjgzNDM4MjIzODg3MTAxNSAtOS42MDg1OTAxMTQwNDkyOTYsIDYzLjE4Mzc0ODM1MjU5MzU1NCAtOS4wNzE4Njk5NDU0MzQxOTEgTTYyLjU3MTc2NDQ1NTQ0NjcyNiAtMTAuMDEyMDQxNTUyMTM3OTczIEM2Mi43MzQ5OTM2NDAxOTA0MSAtOS43NjEyNzc2OTExOTgzNDMsIDYyLjg5ODIyMjgyNDkzNDEgLTkuNTEwNTEzODMwMjU4NzExLCA2My4xODM3NDgzNTI1OTM1NTQgLTkuMDcxODY5OTQ1NDM0MTkxIE02My4xODM3NDgzNTI1OTM1NTQgLTkuMDcxODY5OTQ1NDM0MTkxIEM2My4zMDk3ODQ5MTg3MjU0ODQgLTguODQ4MDc5MjU5NjgwNzA0LCA2My40MzU4MjE0ODQ4NTc0MTQgLTguNjI0Mjg4NTczOTI3MjE3LCA2My43MzQyMzc4NjE1Mjc1MDQgLTguMDk0NDIwMDc5MjE0NjE3IE02My4xODM3NDgzNTI1OTM1NTQgLTkuMDcxODY5OTQ1NDM0MTkxIEM2My4zMTE5MzQ5MDgxMjkyMiAtOC44NDQyNjE3MzU3ODQzNDEsIDYzLjQ0MDEyMTQ2MzY2NDg4IC04LjYxNjY1MzUyNjEzNDQ5MiwgNjMuNzM0MjM3ODYxNTI3NTA0IC04LjA5NDQyMDA3OTIxNDYxNyBNNjMuNzM0MjM3ODYxNTI3NTA0IC04LjA5NDQyMDA3OTIxNDYxNyBDNjMuODQ3MzI3OTU4NTc4MjEgLTcuODU5NTg2MDcyOTQ4MzcxLCA2My45NjA0MTgwNTU2Mjg5MyAtNy42MjQ3NTIwNjY2ODIxMjUsIDY0LjIyMDk3MDkwMjc3NjcxIC03LjA4MzcwODUwNDY0MTg5NiBNNjMuNzM0MjM3ODYxNTI3NTA0IC04LjA5NDQyMDA3OTIxNDYxNyBDNjMuODk4ODAwMDQzMzg0NzQ2IC03Ljc1MjcwMzE4NzUyMTQyNDUsIDY0LjA2MzM2MjIyNTI0MTk5IC03LjQxMDk4NjI5NTgyODIzMiwgNjQuMjIwOTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODk2IE02NC4yMjA5NzA5MDI3NzY3MSAtNy4wODM3MDg1MDQ2NDE4OTYgQzY0LjM0MTQ0NzExMDc5ODA0IC02Ljc4NjEyOTk0MTU4MDE4NiwgNjQuNDYxOTIzMzE4ODE5MzcgLTYuNDg4NTUxMzc4NTE4NDc1LCA2NC42NDE5NDczODU4NzA4MSAtNi4wNDM4ODg0NTIzNzI4OTIgTTY0LjIyMDk3MDkwMjc3NjcxIC03LjA4MzcwODUwNDY0MTg5NiBDNjQuMzc2ODM2ODE4MzQ0MTUgLTYuNjk4NzE2Njc5NzI3ODcwNSwgNjQuNTMyNzAyNzMzOTExNTggLTYuMzEzNzI0ODU0ODEzODQ0LCA2NC42NDE5NDczODU4NzA4MSAtNi4wNDM4ODg0NTIzNzI4OTIgTTY0LjY0MTk0NzM4NTg3MDgxIC02LjA0Mzg4ODQ1MjM3Mjg5MiBDNjQuNzgyNzg3MDg2ODk2NDMgLTUuNjE5NzAxNzEyNjQyNjc3LCA2NC45MjM2MjY3ODc5MjIwNiAtNS4xOTU1MTQ5NzI5MTI0NjQsIDY0Ljk5NTQzNzQyODE0MTU2IC00Ljk3OTIzMjc2NjA0MzA3MyBNNjQuNjQxOTQ3Mzg1ODcwODEgLTYuMDQzODg4NDUyMzcyODkyIEM2NC43NTQwODMyMTU4MDQ5NSAtNS43MDYxNTMxOTkwMjk0MTcsIDY0Ljg2NjIxOTA0NTczOTExIC01LjM2ODQxNzk0NTY4NTk0MywgNjQuOTk1NDM3NDI4MTQxNTYgLTQuOTc5MjMyNzY2MDQzMDczIE02NC45OTU0Mzc0MjgxNDE1NiAtNC45NzkyMzI3NjYwNDMwNzMgQzY1LjA1NjQ2OTc1NDQyNzQzIC00Ljc0NjQ5MDA1NDMzNzUyOCwgNjUuMTE3NTAyMDgwNzEzMyAtNC41MTM3NDczNDI2MzE5ODIsIDY1LjI3OTk4ODQ2MzE4MTkxIC0zLjg5NDExNjM0NDIzNTUwNCBNNjQuOTk1NDM3NDI4MTQxNTYgLTQuOTc5MjMyNzY2MDQzMDczIEM2NS4wOTE0MTEwNjI5NDY2NiAtNC42MTMyNDM3MDEyOTQ3NywgNjUuMTg3Mzg0Njk3NzUxNzcgLTQuMjQ3MjU0NjM2NTQ2NDY1LCA2NS4yNzk5ODg0NjMxODE5MSAtMy44OTQxMTYzNDQyMzU1MDQgTTY1LjI3OTk4ODQ2MzE4MTkxIC0zLjg5NDExNjM0NDIzNTUwNCBDNjUuMzY0ODQwNjYxNDgxNTIgLTMuNDU4NDE4MjM5NDg1NDQxLCA2NS40NDk2OTI4NTk3ODExNCAtMy4wMjI3MjAxMzQ3MzUzNzgsIDY1LjQ5NDQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDE0MyBNNjUuMjc5OTg4NDYzMTgxOTEgLTMuODk0MTE2MzQ0MjM1NTA0IEM2NS4zMzA2NTY3ODYxMDI1NyAtMy42MzM5NDUyMTQ3OTE3NzM1LCA2NS4zODEzMjUxMDkwMjMyMiAtMy4zNzM3NzQwODUzNDgwNDI1LCA2NS40OTQ0MzEyMDk3NTI4OCAtMi43OTI5OTgxNjMwODQxNDMgTTY1LjQ5NDQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDE0MyBDNjUuNTUwOTM0NTYzNDQ0MzMgLTIuMzU0NzY5MzA5NzAyNDQwNywgNjUuNjA3NDM3OTE3MTM1NzggLTEuOTE2NTQwNDU2MzIwNzM4LCA2NS42Mzc4ODQ0NzY2MTA5NiAtMS42ODA0MDI5NTMzODQ0MzQgTTY1LjQ5NDQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDE0MyBDNjUuNTM1MTQwMDIwODE2NTcgLTIuNDc3MjY4NjYzMzM4MTA0LCA2NS41NzU4NDg4MzE4ODAyNiAtMi4xNjE1MzkxNjM1OTIwNjUsIDY1LjYzNzg4NDQ3NjYxMDk2IC0xLjY4MDQwMjk1MzM4NDQzNCBNNjUuNjM3ODg0NDc2NjEwOTYgLTEuNjgwNDAyOTUzMzg0NDM0IEM2NS42NTQ3Mjk4MjMzMDgwNyAtMS40MTgwMjMwODEyNTc4NjE2LCA2NS42NzE1NzUxNzAwMDUxOCAtMS4xNTU2NDMyMDkxMzEyODkyLCA2NS43MDk3NTg3ODM1MTIwMyAtMC41NjA5MDI2MDc1MDM5NjU0IE02NS42Mzc4ODQ0NzY2MTA5NiAtMS42ODA0MDI5NTMzODQ0MzQgQzY1LjY1NjU0NDA1MjczMTIgLTEuMzg5NzY0OTkzNTcyODU3OCwgNjUuNjc1MjAzNjI4ODUxNDUgLTEuMDk5MTI3MDMzNzYxMjgxNSwgNjUuNzA5NzU4NzgzNTEyMDMgLTAuNTYwOTAyNjA3NTAzOTY1NCBNNjUuNzA5NzU4NzgzNTEyMDMgLTAuNTYwOTAyNjA3NTAzOTY1NCBDNjUuNzA5NzU4NzgzNTEyMDMgLTAuMTE4MzMzNDg2NTEwODU1MDcsIDY1LjcwOTc1ODc4MzUxMjAzIDAuMzI0MjM1NjM0NDgyMjU1MjMsIDY1LjcwOTc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTYxMSBNNjUuNzA5NzU4NzgzNTEyMDMgLTAuNTYwOTAyNjA3NTAzOTY1NCBDNjUuNzA5NzU4NzgzNTEyMDMgLTAuMjg0NDE5NjEwMzQ4MjA0NywgNjUuNzA5NzU4NzgzNTEyMDMgLTAuMDA3OTM2NjEzMTkyNDQzOTg2LCA2NS43MDk3NTg3ODM1MTIwMyAwLjU2MDkwMjYwNzUwMzk2MTEgTTY1LjcwOTc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTYxMSBDNjUuNjg5MTEwOTk5MzA5MjkgMC44ODI1MDg1MTMwNTMwODM0LCA2NS42Njg0NjMyMTUxMDY1NiAxLjIwNDExNDQxODYwMjIwNiwgNjUuNjM3ODg0NDc2NjEwOTYgMS42ODA0MDI5NTMzODQ0MjIgTTY1LjcwOTc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTYxMSBDNjUuNjk0NjQ1NTYyMTQ4OSAwLjc5NjMwMzIyOTQwNzIyNTYsIDY1LjY3OTUzMjM0MDc4NTggMS4wMzE3MDM4NTEzMTA0OTAxLCA2NS42Mzc4ODQ0NzY2MTA5NiAxLjY4MDQwMjk1MzM4NDQyMiBNNjUuNjM3ODg0NDc2NjEwOTYgMS42ODA0MDI5NTMzODQ0MjIgQzY1LjU4NjU2MzU3NzQxNTEyIDIuMDc4NDM3NzEzMDg5NjA5MiwgNjUuNTM1MjQyNjc4MjE5MjYgMi40NzY0NzI0NzI3OTQ3OTYsIDY1LjQ5NDQzMTIwOTc1Mjg4IDIuNzkyOTk4MTYzMDg0MTMxIE02NS42Mzc4ODQ0NzY2MTA5NiAxLjY4MDQwMjk1MzM4NDQyMiBDNjUuNTg4MzYzOTg3NzY5MiAyLjA2NDQ3NDA4NTkxNDYwNzYsIDY1LjUzODg0MzQ5ODkyNzQyIDIuNDQ4NTQ1MjE4NDQ0NzkzLCA2NS40OTQ0MzEyMDk3NTI4OCAyLjc5Mjk5ODE2MzA4NDEzMSBNNjUuNDk0NDMxMjA5NzUyODggMi43OTI5OTgxNjMwODQxMzEgQzY1LjQxNDM4MDYyNDc5MTAyIDMuMjA0MDQwOTk4MTY2MTQsIDY1LjMzNDMzMDAzOTgyOTE1IDMuNjE1MDgzODMzMjQ4MTQ5LCA2NS4yNzk5ODg0NjMxODE5MSAzLjg5NDExNjM0NDIzNTUgTTY1LjQ5NDQzMTIwOTc1Mjg4IDIuNzkyOTk4MTYzMDg0MTMxIEM2NS40MTE3NjcwMTY5ODAzNiAzLjIxNzQ2MTMyMTg4NzYxMjcsIDY1LjMyOTEwMjgyNDIwNzg3IDMuNjQxOTI0NDgwNjkxMDk0LCA2NS4yNzk5ODg0NjMxODE5MSAzLjg5NDExNjM0NDIzNTUgTTY1LjI3OTk4ODQ2MzE4MTkxIDMuODk0MTE2MzQ0MjM1NSBDNjUuMTc2NTU4MTQwOTQ1OTYgNC4yODg1NDA5ODk5MDY0MSwgNjUuMDczMTI3ODE4NzEgNC42ODI5NjU2MzU1NzczMiwgNjQuOTk1NDM3NDI4MTQxNTYgNC45NzkyMzI3NjYwNDMwNjEgTTY1LjI3OTk4ODQ2MzE4MTkxIDMuODk0MTE2MzQ0MjM1NSBDNjUuMjIyNzU5MDMxMjQ0NTEgNC4xMTIzNTY5NzE2MDU0ODYsIDY1LjE2NTUyOTU5OTMwNzEyIDQuMzMwNTk3NTk4OTc1NDcyLCA2NC45OTU0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2MSBNNjQuOTk1NDM3NDI4MTQxNTYgNC45NzkyMzI3NjYwNDMwNjEgQzY0Ljg1NTMzMTIyMTcwMTUgNS40MDEyMTAzMzY5NDgwMDcsIDY0LjcxNTIyNTAxNTI2MTQ1IDUuODIzMTg3OTA3ODUyOTU0LCA2NC42NDE5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg4IE02NC45OTU0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2MSBDNjQuOTIxNTc5NTYxMjg0NjkgNS4yMDE2ODA4OTMzNjI5NTgsIDY0Ljg0NzcyMTY5NDQyNzgyIDUuNDI0MTI5MDIwNjgyODU1LCA2NC42NDE5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg4IE02NC42NDE5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg4IEM2NC40NzQ2MzgxNDA3MjMwNiA2LjQ1NzE0NTUyMjU5MjAxNSwgNjQuMzA3MzI4ODk1NTc1MzEgNi44NzA0MDI1OTI4MTExNSwgNjQuMjIwOTcwOTAyNzc2NzEgNy4wODM3MDg1MDQ2NDE4OTE1IE02NC42NDE5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg4IEM2NC41MjU5MDkxNTY3NjE2OCA2LjMzMDUwNTEyMTcxODk1MiwgNjQuNDA5ODcwOTI3NjUyNTYgNi42MTcxMjE3OTEwNjUwMjQsIDY0LjIyMDk3MDkwMjc3NjcxIDcuMDgzNzA4NTA0NjQxODkxNSBNNjQuMjIwOTcwOTAyNzc2NzEgNy4wODM3MDg1MDQ2NDE4OTE1IEM2NC4wNjQ2NDU3NDc2NTczMiA3LjQwODMyMTAzNDA2OTc5ODUsIDYzLjkwODMyMDU5MjUzNzkzIDcuNzMyOTMzNTYzNDk3NzA2LCA2My43MzQyMzc4NjE1Mjc1MDQgOC4wOTQ0MjAwNzkyMTQ2MTMgTTY0LjIyMDk3MDkwMjc3NjcxIDcuMDgzNzA4NTA0NjQxODkxNSBDNjQuMDUwMzIwNDU5MDQ2NyA3LjQzODA2NzgwMjM4MTgyMiwgNjMuODc5NjcwMDE1MzE2NyA3Ljc5MjQyNzEwMDEyMTc1MiwgNjMuNzM0MjM3ODYxNTI3NTA0IDguMDk0NDIwMDc5MjE0NjEzIE02My43MzQyMzc4NjE1Mjc1MDQgOC4wOTQ0MjAwNzkyMTQ2MTMgQzYzLjUzODA5MTUxOTY1NDM2IDguNDQyNjk3NzcxMTgxMjU1LCA2My4zNDE5NDUxNzc3ODEyMSA4Ljc5MDk3NTQ2MzE0Nzg5NSwgNjMuMTgzNzQ4MzUyNTkzNTYgOS4wNzE4Njk5NDU0MzQxODYgTTYzLjczNDIzNzg2MTUyNzUwNCA4LjA5NDQyMDA3OTIxNDYxMyBDNjMuNjA4OTQwNzMxNTExMjIgOC4zMTY4OTc4MjEyNjg3NTMsIDYzLjQ4MzY0MzYwMTQ5NDkzIDguNTM5Mzc1NTYzMzIyODk0LCA2My4xODM3NDgzNTI1OTM1NiA5LjA3MTg2OTk0NTQzNDE4NiBNNjMuMTgzNzQ4MzUyNTkzNTYgOS4wNzE4Njk5NDU0MzQxODYgQzYzLjAwNDgyMTQwNzU4Nzg2IDkuMzQ2NzQ5NzgxNTc1MTE4LCA2Mi44MjU4OTQ0NjI1ODIxNTYgOS42MjE2Mjk2MTc3MTYwNTMsIDYyLjU3MTc2NDQ1NTQ0NjczIDEwLjAxMjA0MTU1MjEzNzk2NCBNNjMuMTgzNzQ4MzUyNTkzNTYgOS4wNzE4Njk5NDU0MzQxODYgQzYyLjk5MTUyNTI4OTAwNzc0IDkuMzY3MTc2MTkwMjIxOTMzLCA2Mi43OTkzMDIyMjU0MjE5MjYgOS42NjI0ODI0MzUwMDk2ODIsIDYyLjU3MTc2NDQ1NTQ0NjczIDEwLjAxMjA0MTU1MjEzNzk2NCBNNjIuNTcxNzY0NDU1NDQ2NzMgMTAuMDEyMDQxNTUyMTM3OTY0IEM2Mi40MTI1MDY4Njk0NjQxOCAxMC4yMjU0MzIyMDg2OTAwMjUsIDYyLjI1MzI0OTI4MzQ4MTY0IDEwLjQzODgyMjg2NTI0MjA4NiwgNjEuOTAwODAwOTQzMTkwNTI1IDEwLjkxMTA3MTUzMjUyNzgzNSBNNjIuNTcxNzY0NDU1NDQ2NzMgMTAuMDEyMDQxNTUyMTM3OTY0IEM2Mi4zMDc5ODU2ODMwNTI2MiAxMC4zNjU0ODEwNzY0MDU1NTEsIDYyLjA0NDIwNjkxMDY1ODUxIDEwLjcxODkyMDYwMDY3MzEzOSwgNjEuOTAwODAwOTQzMTkwNTI1IDEwLjkxMTA3MTUzMjUyNzgzNSBNNjEuOTAwODAwOTQzMTkwNTI1IDEwLjkxMTA3MTUzMjUyNzgzNSBDNjEuNzExNTg0MTg3OTkzODUgMTEuMTMzMzM2Mjk5OTIwMjI0LCA2MS41MjIzNjc0MzI3OTcxOCAxMS4zNTU2MDEwNjczMTI2MTIsIDYxLjE3MzYxNDk0ODgxODAzIDExLjc2NTI2NTU3OTU3MzAzOCBNNjEuOTAwODAwOTQzMTkwNTI1IDEwLjkxMTA3MTUzMjUyNzgzNSBDNjEuNjQ1MDcxNzY2NTgzNSAxMS4yMTE0NjU1NzQ3NzI4MjIsIDYxLjM4OTM0MjU4OTk3NjQ2NSAxMS41MTE4NTk2MTcwMTc4MSwgNjEuMTczNjE0OTQ4ODE4MDMgMTEuNzY1MjY1NTc5NTczMDM4IE02MS4xNzM2MTQ5NDg4MTgwMyAxMS43NjUyNjU1Nzk1NzMwMzggQzYwLjk5OTIyNDAxMDAxODI0NiAxMS45NDUzMzg1NDE2NDYxNiwgNjAuODI0ODMzMDcxMjE4NDcgMTIuMTI1NDExNTAzNzE5MjgxLCA2MC4zOTMxOTQ2MzU1NjEwMiAxMi41NzExMTM2MjY3MTAyMjkgTTYxLjE3MzYxNDk0ODgxODAzIDExLjc2NTI2NTU3OTU3MzAzOCBDNjEuMDE0NzI4MjgxNDY2NjI0IDExLjkyOTMyOTEwODQ1MTM1LCA2MC44NTU4NDE2MTQxMTUyMyAxMi4wOTMzOTI2MzczMjk2NjMsIDYwLjM5MzE5NDYzNTU2MTAyIDEyLjU3MTExMzYyNjcxMDIyOSBNNjAuMzkzMTk0NjM1NTYxMDIgMTIuNTcxMTEzNjI2NzEwMjI5IEM2MC4yMTM1MDcxNDYyOTMxNiAxMi43MzQzMDEwNTAxOTI4NTYsIDYwLjAzMzgxOTY1NzAyNTMwNSAxMi44OTc0ODg0NzM2NzU0ODQsIDU5LjU2Mjc0NjkxNzg4NjMxIDEzLjMyNTMwNDI3MTQ1OTg0MiBNNjAuMzkzMTk0NjM1NTYxMDIgMTIuNTcxMTEzNjI2NzEwMjI5IEM2MC4wODk2MTgyNzE1NDc2MTQgMTIuODQ2ODEzNjQ4MzE2NzYxLCA1OS43ODYwNDE5MDc1MzQyMSAxMy4xMjI1MTM2Njk5MjMyOTIsIDU5LjU2Mjc0NjkxNzg4NjMxIDEzLjMyNTMwNDI3MTQ1OTg0MiBNNTkuNTYyNzQ2OTE3ODg2MzEgMTMuMzI1MzA0MjcxNDU5ODQyIEM1OS4zMjEzMTQ0ODkyODY0NSAxMy41MTc4NDAyMDg0ODE0OCwgNTkuMDc5ODgyMDYwNjg2NTkgMTMuNzEwMzc2MTQ1NTAzMTE5LCA1OC42ODU2ODQyODM1OTYyOSAxNC4wMjQ3MzgzODI2ODkyNCBNNTkuNTYyNzQ2OTE3ODg2MzEgMTMuMzI1MzA0MjcxNDU5ODQyIEM1OS4zMTk3MTI4MTIxOTUyNSAxMy41MTkxMTc1MDMzMzkyOTUsIDU5LjA3NjY3ODcwNjUwNDE5IDEzLjcxMjkzMDczNTIxODc1LCA1OC42ODU2ODQyODM1OTYyOSAxNC4wMjQ3MzgzODI2ODkyNCBNNTguNjg1Njg0MjgzNTk2MjkgMTQuMDI0NzM4MzgyNjg5MjQgQzU4LjM1MDg1NDAzOTgxMzMzNSAxNC4yNTgzMDE0NjYxODQ1ODUsIDU4LjAxNjAyMzc5NjAzMDM4IDE0LjQ5MTg2NDU0OTY3OTkzMywgNTcuNzY1NjEwNzcxMTg0NjEgMTQuNjY2NTQxODM1NjA3MjA3IE01OC42ODU2ODQyODM1OTYyOSAxNC4wMjQ3MzgzODI2ODkyNCBDNTguNDUwMDc4ODcxOTU3NzQgMTQuMTg5MDg2NTE4NjU0NDAzLCA1OC4yMTQ0NzM0NjAzMTkxOSAxNC4zNTM0MzQ2NTQ2MTk1NjYsIDU3Ljc2NTYxMDc3MTE4NDYxIDE0LjY2NjU0MTgzNTYwNzIwNyBNNTcuNzY1NjEwNzcxMTg0NjEgMTQuNjY2NTQxODM1NjA3MjA3IEM1Ny41MTUwMzI2MDgzNDg3NTQgMTQuODE4NDQzNzkwNDc5MDQyLCA1Ny4yNjQ0NTQ0NDU1MTI4OSAxNC45NzAzNDU3NDUzNTA4NzYsIDU2LjgwNjMwNzE2MDA2ODkxIDE1LjI0ODA3NzMyMjE1OTMxNSBNNTcuNzY1NjEwNzcxMTg0NjEgMTQuNjY2NTQxODM1NjA3MjA3IEM1Ny41MTIwODc4NTQwODUxNyAxNC44MjAyMjg5MTc4MTg5MTgsIDU3LjI1ODU2NDkzNjk4NTc0IDE0Ljk3MzkxNjAwMDAzMDYyOSwgNTYuODA2MzA3MTYwMDY4OTEgMTUuMjQ4MDc3MzIyMTU5MzE1IE01Ni44MDYzMDcxNjAwNjg5MSAxNS4yNDgwNzczMjIxNTkzMTUgQzU2LjU0NDE4MTYwMTcxMTc1IDE1LjM4NDgyODA1ODA1NDgxNSwgNTYuMjgyMDU2MDQzMzU0NTggMTUuNTIxNTc4NzkzOTUwMzEzLCA1NS44MTE3MTU0MzQ1NTcyNyAxNS43NjY5NTUxODgyOTIzMzIgTTU2LjgwNjMwNzE2MDA2ODkxIDE1LjI0ODA3NzMyMjE1OTMxNSBDNTYuNTE2MzQ1NDg1MTYzMDYgMTUuMzk5MzUwMTQyMjI4MzgyLCA1Ni4yMjYzODM4MTAyNTcyMDQgMTUuNTUwNjIyOTYyMjk3NDUsIDU1LjgxMTcxNTQzNDU1NzI3IDE1Ljc2Njk1NTE4ODI5MjMzMiBNNTUuODExNzE1NDM0NTU3MjcgMTUuNzY2OTU1MTg4MjkyMzMyIEM1NS40MDUyNjk2ODA0ODk0OTYgMTUuOTQ2ODc2NjY2ODMzMjIxLCA1NC45OTg4MjM5MjY0MjE3MiAxNi4xMjY3OTgxNDUzNzQxMSwgNTQuNzg1OTIyNTg1Mzg5MDUgMTYuMjIxMDQzMjUzNTU1MzggTTU1LjgxMTcxNTQzNDU1NzI3IDE1Ljc2Njk1NTE4ODI5MjMzMiBDNTUuNDYxMjk0ODQ5NjA0NTEgMTUuOTIyMDc1OTg2MzkzNTk0LCA1NS4xMTA4NzQyNjQ2NTE3NiAxNi4wNzcxOTY3ODQ0OTQ4NTYsIDU0Ljc4NTkyMjU4NTM4OTA1IDE2LjIyMTA0MzI1MzU1NTM4IE01NC43ODU5MjI1ODUzODkwNSAxNi4yMjEwNDMyNTM1NTUzOCBDNTQuNTAxNDU4ODE3NDM1NDA2IDE2LjMyNTcyODU0OTcxNjU2NSwgNTQuMjE2OTk1MDQ5NDgxNzYgMTYuNDMwNDEzODQ1ODc3NzUsIDUzLjczMzE0MzgxNTQxMzM3IDE2LjYwODQ3NTU3MjY4NjY5NyBNNTQuNzg1OTIyNTg1Mzg5MDUgMTYuMjIxMDQzMjUzNTU1MzggQzU0LjQxOTQ1ODI1NDQ0OTAzIDE2LjM1NTkwNTUxNDkwMDQ0NiwgNTQuMDUyOTkzOTIzNTA5MDE0IDE2LjQ5MDc2Nzc3NjI0NTUxMiwgNTMuNzMzMTQzODE1NDEzMzcgMTYuNjA4NDc1NTcyNjg2Njk3IE01My43MzMxNDM4MTU0MTMzNyAxNi42MDg0NzU1NzI2ODY2OTcgQzUzLjQ3ODcxOTYzMTQzMTc4IDE2LjY4Mzk4NzMzNDk5MjY0LCA1My4yMjQyOTU0NDc0NTAxOSAxNi43NTk0OTkwOTcyOTg1ODMsIDUyLjY1NzcwNTIxODQxNjM5NiAxNi45Mjc2NjAxMDMxODMwMTIgTTUzLjczMzE0MzgxNTQxMzM3IDE2LjYwODQ3NTU3MjY4NjY5NyBDNTMuMzQzODc5MTM5NDk4ODQgMTYuNzI0MDA3Mjg1MjA2MTUyLCA1Mi45NTQ2MTQ0NjM1ODQzMDYgMTYuODM5NTM4OTk3NzI1NjA4LCA1Mi42NTc3MDUyMTg0MTYzOTYgMTYuOTI3NjYwMTAzMTgzMDEyIE01Mi42NTc3MDUyMTg0MTYzOTYgMTYuOTI3NjYwMTAzMTgzMDEyIEM1Mi40MTM4NzI5MjY5MTk4MTUgMTYuOTgzMzEzMjMyNTYyNzA0LCA1Mi4xNzAwNDA2MzU0MjMyMzQgMTcuMDM4OTY2MzYxOTQyMzk2LCA1MS41NjQwMjYwMDIyNzQwMiAxNy4xNzcyODUyNDczNDM2NDQgTTUyLjY1NzcwNTIxODQxNjM5NiAxNi45Mjc2NjAxMDMxODMwMTIgQzUyLjI2OTA0MzQ3NTIzMDA4IDE3LjAxNjM2OTYwOTgxMDM5LCA1MS44ODAzODE3MzIwNDM3NiAxNy4xMDUwNzkxMTY0Mzc3NjgsIDUxLjU2NDAyNjAwMjI3NDAyIDE3LjE3NzI4NTI0NzM0MzY0NCBNNTEuNTY0MDI2MDAyMjc0MDIgMTcuMTc3Mjg1MjQ3MzQzNjQ0IEM1MS4yMTE2MDc1MDM2NDE3OSAxNy4yMzQyNjE1MzcxNTYyMywgNTAuODU5MTg5MDA1MDA5NTUgMTcuMjkxMjM3ODI2OTY4ODE0LCA1MC40NTY2MDAzMjk0Nzg4NyAxNy4zNTYzMjUyNDE5MDY4MDYgTTUxLjU2NDAyNjAwMjI3NDAyIDE3LjE3NzI4NTI0NzM0MzY0NCBDNTEuMTQwMzAxMDc1OTc0NjYgMTcuMjQ1Nzg5ODA3MzkxODQ0LCA1MC43MTY1NzYxNDk2NzUzIDE3LjMxNDI5NDM2NzQ0MDA0NSwgNTAuNDU2NjAwMzI5NDc4ODcgMTcuMzU2MzI1MjQxOTA2ODA2IE01MC40NTY2MDAzMjk0Nzg4NyAxNy4zNTYzMjUyNDE5MDY4MDYgQzUwLjA5NzA2NTk1NzMwNDk2IDE3LjM5MTAwOTA5MDM4NzA3NiwgNDkuNzM3NTMxNTg1MTMxMDUgMTcuNDI1NjkyOTM4ODY3MzUsIDQ5LjMzOTk3ODg0OTY2MjQ3IDE3LjQ2NDA0NDM3MzEzMDg4NiBNNTAuNDU2NjAwMzI5NDc4ODcgMTcuMzU2MzI1MjQxOTA2ODA2IEM1MC4wNzU4Nzg4NTMyNTg3NiAxNy4zOTMwNTI5ODQ4MzMxOTQsIDQ5LjY5NTE1NzM3NzAzODY0IDE3LjQyOTc4MDcyNzc1OTU4LCA0OS4zMzk5Nzg4NDk2NjI0NyAxNy40NjQwNDQzNzMxMzA4ODYgTTQ5LjMzOTk3ODg0OTY2MjQ3IDE3LjQ2NDA0NDM3MzEzMDg4NiBDNDguOTMwMDk1MjcxNzA3NTYgMTcuNDc3MTg4NTQxNjg1OTE2LCA0OC41MjAyMTE2OTM3NTI2NCAxNy40OTAzMzI3MTAyNDA5NDIsIDQ4LjIxODc1IDE3LjUgTTQ5LjMzOTk3ODg0OTY2MjQ3IDE3LjQ2NDA0NDM3MzEzMDg4NiBDNDkuMDY1NjAwNDc3NDI1MjM1IDE3LjQ3Mjg0MzE1MzQ4MzQzLCA0OC43OTEyMjIxMDUxODggMTcuNDgxNjQxOTMzODM1OTc3LCA0OC4yMTg3NSAxNy41IE00OC4yMTg3NSAxNy41IEM0OC4yMTg3NSAxNy41LCA0OC4yMTg3NSAxNy41LCA0OC4yMTg3NSAxNy41IE00OC4yMTg3NSAxNy41IEM0OC4yMTg3NSAxNy41LCA0OC4yMTg3NSAxNy41LCA0OC4yMTg3NSAxNy41IE00OC4yMTg3NSAxNy41IEMyMS4wNzQzOTAyMjk5Mjk2OTggMTcuNSwgLTYuMDY5OTY5NTQwMTQwNjA1IDE3LjUsIC00OC4yMTg3NSAxNy41IE00OC4yMTg3NSAxNy41IEMyMy4zMjMyOTIwNjQxNDEzNTIgMTcuNSwgLTEuNTcyMTY1ODcxNzE3Mjk1NyAxNy41LCAtNDguMjE4NzUgMTcuNSBNLTQ4LjIxODc1IDE3LjUgQy00OC40OTYxNzg1NjM3MTU3OCAxNy40OTExMDM0MDU5NDM1NzYsIC00OC43NzM2MDcxMjc0MzE1NiAxNy40ODIyMDY4MTE4ODcxNSwgLTQ5LjMzOTk3ODg0OTY2MjQ2NSAxNy40NjQwNDQzNzMxMzA4ODYgTS00OC4yMTg3NSAxNy41IEMtNDguNDc0NjU0MzQ3OTk1MjUgMTcuNDkxNzkzNjQ1NjQ3Mzg3LCAtNDguNzMwNTU4Njk1OTkwNDk2IDE3LjQ4MzU4NzI5MTI5NDc4LCAtNDkuMzM5OTc4ODQ5NjYyNDY1IDE3LjQ2NDA0NDM3MzEzMDg4NiBNLTQ5LjMzOTk3ODg0OTY2MjQ2NSAxNy40NjQwNDQzNzMxMzA4ODYgQy00OS42ODgwMjQ0MjMzMzQ4MjQgMTcuNDMwNDY4ODM1MjI0NzU4LCAtNTAuMDM2MDY5OTk3MDA3MTc1IDE3LjM5Njg5MzI5NzMxODYyNywgLTUwLjQ1NjYwMDMyOTQ3ODg2IDE3LjM1NjMyNTI0MTkwNjgwNiBNLTQ5LjMzOTk3ODg0OTY2MjQ2NSAxNy40NjQwNDQzNzMxMzA4ODYgQy00OS42NzcwMDc1NTIwODA0MjYgMTcuNDMxNTMxNjE5NTQ0OTQsIC01MC4wMTQwMzYyNTQ0OTgzODYgMTcuMzk5MDE4ODY1OTU5LCAtNTAuNDU2NjAwMzI5NDc4ODYgMTcuMzU2MzI1MjQxOTA2ODA2IE0tNTAuNDU2NjAwMzI5NDc4ODYgMTcuMzU2MzI1MjQxOTA2ODA2IEMtNTAuNzI3NDI0NDc4NDgwMTQgMTcuMzEyNTQwNDkzNzY4OTIsIC01MC45OTgyNDg2Mjc0ODE0MTYgMTcuMjY4NzU1NzQ1NjMxMDQsIC01MS41NjQwMjYwMDIyNzQwMSAxNy4xNzcyODUyNDczNDM2NDQgTS01MC40NTY2MDAzMjk0Nzg4NiAxNy4zNTYzMjUyNDE5MDY4MDYgQy01MC43MzcwOTI3NDYwOTAzNzYgMTcuMzEwOTc3NDAzMjQwMjMzLCAtNTEuMDE3NTg1MTYyNzAxODg0IDE3LjI2NTYyOTU2NDU3MzY2NSwgLTUxLjU2NDAyNjAwMjI3NDAxIDE3LjE3NzI4NTI0NzM0MzY0NCBNLTUxLjU2NDAyNjAwMjI3NDAxIDE3LjE3NzI4NTI0NzM0MzY0NCBDLTUxLjk3MjUyMTE5MjUxOTAzIDE3LjA4NDA0ODg4NTg1MDQ1NCwgLTUyLjM4MTAxNjM4Mjc2NDA1IDE2Ljk5MDgxMjUyNDM1NzI2NywgLTUyLjY1NzcwNTIxODQxNjM3NSAxNi45Mjc2NjAxMDMxODMwMTUgTS01MS41NjQwMjYwMDIyNzQwMSAxNy4xNzcyODUyNDczNDM2NDQgQy01MS44NzgwMTI5NTA2NTM5MDQgMTcuMTA1NjE5Nzc1MzMyMjU4LCAtNTIuMTkxOTk5ODk5MDMzNzk2IDE3LjAzMzk1NDMwMzMyMDg3LCAtNTIuNjU3NzA1MjE4NDE2Mzc1IDE2LjkyNzY2MDEwMzE4MzAxNSBNLTUyLjY1NzcwNTIxODQxNjM3NSAxNi45Mjc2NjAxMDMxODMwMTUgQy01My4wNTQwODU1MDQ4MzM3NiAxNi44MTAwMTY1MTQ4MTY5MiwgLTUzLjQ1MDQ2NTc5MTI1MTE0IDE2LjY5MjM3MjkyNjQ1MDgyMiwgLTUzLjczMzE0MzgxNTQxMzM2IDE2LjYwODQ3NTU3MjY4NjcwNCBNLTUyLjY1NzcwNTIxODQxNjM3NSAxNi45Mjc2NjAxMDMxODMwMTUgQy01Mi44Nzc2MDI0OTM5NDA0OSAxNi44NjIzOTU3NDYwNzE4MSwgLTUzLjA5NzQ5OTc2OTQ2NDYwNSAxNi43OTcxMzEzODg5NjA2MDgsIC01My43MzMxNDM4MTU0MTMzNiAxNi42MDg0NzU1NzI2ODY3MDQgTS01My43MzMxNDM4MTU0MTMzNiAxNi42MDg0NzU1NzI2ODY3MDQgQy01My45NjIwMTUwODY5Mjk2NyAxNi41MjQyNDg4MjkxMDU4NTgsIC01NC4xOTA4ODYzNTg0NDU5OCAxNi40NDAwMjIwODU1MjUwMTIsIC01NC43ODU5MjI1ODUzODkwNDUgMTYuMjIxMDQzMjUzNTU1MzggTS01My43MzMxNDM4MTU0MTMzNiAxNi42MDg0NzU1NzI2ODY3MDQgQy01NC4wNjYyOTM1Njg0MDE4NCAxNi40ODU4NzMzODM5ODQzODQsIC01NC4zOTk0NDMzMjEzOTAzMiAxNi4zNjMyNzExOTUyODIwNjQsIC01NC43ODU5MjI1ODUzODkwNDUgMTYuMjIxMDQzMjUzNTU1MzggTS01NC43ODU5MjI1ODUzODkwNDUgMTYuMjIxMDQzMjUzNTU1MzggQy01NS4wNjExNjM4NDE0NTEyNyAxNi4wOTkyMDIxMTQyMzg0MDIsIC01NS4zMzY0MDUwOTc1MTM0OSAxNS45NzczNjA5NzQ5MjE0MjMsIC01NS44MTE3MTU0MzQ1NTcyNjQgMTUuNzY2OTU1MTg4MjkyMzM4IE0tNTQuNzg1OTIyNTg1Mzg5MDQ1IDE2LjIyMTA0MzI1MzU1NTM4IEMtNTUuMTE4NTQzMDcyMTk0NTUgMTYuMDczODAyMDMwODgyNzU2LCAtNTUuNDUxMTYzNTU5MDAwMDUgMTUuOTI2NTYwODA4MjEwMTMyLCAtNTUuODExNzE1NDM0NTU3MjY0IDE1Ljc2Njk1NTE4ODI5MjMzOCBNLTU1LjgxMTcxNTQzNDU1NzI2NCAxNS43NjY5NTUxODgyOTIzMzggQy01Ni4wMzI1NDYxODczMTY2NTUgMTUuNjUxNzQ3OTI2MDI2NjEsIC01Ni4yNTMzNzY5NDAwNzYwNSAxNS41MzY1NDA2NjM3NjA4ODMsIC01Ni44MDYzMDcxNjAwNjg5MDQgMTUuMjQ4MDc3MzIyMTU5MzE4IE0tNTUuODExNzE1NDM0NTU3MjY0IDE1Ljc2Njk1NTE4ODI5MjMzOCBDLTU2LjE0ODg0NDY0NjczMjg2IDE1LjU5MTA3NTA5NDI0MTg5NiwgLTU2LjQ4NTk3Mzg1ODkwODQ1IDE1LjQxNTE5NTAwMDE5MTQ1NSwgLTU2LjgwNjMwNzE2MDA2ODkwNCAxNS4yNDgwNzczMjIxNTkzMTggTS01Ni44MDYzMDcxNjAwNjg5MDQgMTUuMjQ4MDc3MzIyMTU5MzE4IEMtNTcuMTE3Mjg0Nzc4MjUwNjYgMTUuMDU5NTYwODYyNTEwMjA3LCAtNTcuNDI4MjYyMzk2NDMyNCAxNC44NzEwNDQ0MDI4NjEwOTUsIC01Ny43NjU2MTA3NzExODQ1OSAxNC42NjY1NDE4MzU2MDcyMTggTS01Ni44MDYzMDcxNjAwNjg5MDQgMTUuMjQ4MDc3MzIyMTU5MzE4IEMtNTcuMDQ4NDE5MzY0Njc4MTggMTUuMTAxMzA3NDgwOTE1OTMxLCAtNTcuMjkwNTMxNTY5Mjg3NDYgMTQuOTU0NTM3NjM5NjcyNTQ0LCAtNTcuNzY1NjEwNzcxMTg0NTkgMTQuNjY2NTQxODM1NjA3MjE4IE0tNTcuNzY1NjEwNzcxMTg0NTkgMTQuNjY2NTQxODM1NjA3MjE4IEMtNTguMDkxMTA0NjUyNDEzMiAxNC40Mzk0OTEzOTQ0NjUxNjMsIC01OC40MTY1OTg1MzM2NDE4IDE0LjIxMjQ0MDk1MzMyMzEwOCwgLTU4LjY4NTY4NDI4MzU5NjI3NCAxNC4wMjQ3MzgzODI2ODkyNDMgTS01Ny43NjU2MTA3NzExODQ1OSAxNC42NjY1NDE4MzU2MDcyMTggQy01Ny45NTYxNjE0MjE3MzIwNCAxNC41MzM2MjE5NTA1OTAwMywgLTU4LjE0NjcxMjA3MjI3OTQ5IDE0LjQwMDcwMjA2NTU3Mjg0NCwgLTU4LjY4NTY4NDI4MzU5NjI3NCAxNC4wMjQ3MzgzODI2ODkyNDMgTS01OC42ODU2ODQyODM1OTYyNzQgMTQuMDI0NzM4MzgyNjg5MjQzIEMtNTguODcwNTIyNjk4MDE2NTM2IDEzLjg3NzMzNDY2NTk0NTg2OSwgLTU5LjA1NTM2MTExMjQzNjggMTMuNzI5OTMwOTQ5MjAyNDkyLCAtNTkuNTYyNzQ2OTE3ODg2Mjk0IDEzLjMyNTMwNDI3MTQ1OTg1NiBNLTU4LjY4NTY4NDI4MzU5NjI3NCAxNC4wMjQ3MzgzODI2ODkyNDMgQy01OC45ODQ0MDU2NjA3NTcwNzYgMTMuNzg2NTE2MDMzNzEzMiwgLTU5LjI4MzEyNzAzNzkxNzg4IDEzLjU0ODI5MzY4NDczNzE1NywgLTU5LjU2Mjc0NjkxNzg4NjI5NCAxMy4zMjUzMDQyNzE0NTk4NTYgTS01OS41NjI3NDY5MTc4ODYyOTQgMTMuMzI1MzA0MjcxNDU5ODU2IEMtNTkuNzM3NTIzNzcwOTYyNDU0IDEzLjE2NjU3NjU1NzgzODIxMiwgLTU5LjkxMjMwMDYyNDAzODYxNSAxMy4wMDc4NDg4NDQyMTY1NjgsIC02MC4zOTMxOTQ2MzU1NjEgMTIuNTcxMTEzNjI2NzEwMjQxIE0tNTkuNTYyNzQ2OTE3ODg2Mjk0IDEzLjMyNTMwNDI3MTQ1OTg1NiBDLTU5Ljc1NDU0MzU1NDI3NjI2IDEzLjE1MTExOTY0MDk1MTQwMiwgLTU5Ljk0NjM0MDE5MDY2NjIzNCAxMi45NzY5MzUwMTA0NDI5NDcsIC02MC4zOTMxOTQ2MzU1NjEgMTIuNTcxMTEzNjI2NzEwMjQxIE0tNjAuMzkzMTk0NjM1NTYxIDEyLjU3MTExMzYyNjcxMDI0MSBDLTYwLjYxMTU3MTU4OTkxMDk4IDEyLjM0NTYyMTQ5MjI2MjUwNiwgLTYwLjgyOTk0ODU0NDI2MDk1IDEyLjEyMDEyOTM1NzgxNDc3MiwgLTYxLjE3MzYxNDk0ODgxODAzIDExLjc2NTI2NTU3OTU3MzA0MyBNLTYwLjM5MzE5NDYzNTU2MSAxMi41NzExMTM2MjY3MTAyNDEgQy02MC42MTMzMjI4MDc0NzI4IDEyLjM0MzgxMzIxNjM1MjI5MywgLTYwLjgzMzQ1MDk3OTM4NDU5NCAxMi4xMTY1MTI4MDU5OTQzNDMsIC02MS4xNzM2MTQ5NDg4MTgwMyAxMS43NjUyNjU1Nzk1NzMwNDMgTS02MS4xNzM2MTQ5NDg4MTgwMyAxMS43NjUyNjU1Nzk1NzMwNDMgQy02MS4zMjQzNDkyNjY4MzQ1MiAxMS41ODgyMDQ0NzI2MDUxOTcsIC02MS40NzUwODM1ODQ4NTEwMSAxMS40MTExNDMzNjU2MzczNTIsIC02MS45MDA4MDA5NDMxOTA1MiAxMC45MTEwNzE1MzI1Mjc4NCBNLTYxLjE3MzYxNDk0ODgxODAzIDExLjc2NTI2NTU3OTU3MzA0MyBDLTYxLjQxNTU4NDY3MzE4NjUyIDExLjQ4MTAzNDE3Mjg2MjQ0NCwgLTYxLjY1NzU1NDM5NzU1NTAyIDExLjE5NjgwMjc2NjE1MTg0NiwgLTYxLjkwMDgwMDk0MzE5MDUyIDEwLjkxMTA3MTUzMjUyNzg0IE0tNjEuOTAwODAwOTQzMTkwNTIgMTAuOTExMDcxNTMyNTI3ODQgQy02Mi4xMDc2ODE5NTEzNjgyNiAxMC42MzM4Njk4Mjg4MTcyNDUsIC02Mi4zMTQ1NjI5NTk1NDU5OSAxMC4zNTY2NjgxMjUxMDY2NDgsIC02Mi41NzE3NjQ0NTU0NDY3MjYgMTAuMDEyMDQxNTUyMTM3OTc0IE0tNjEuOTAwODAwOTQzMTkwNTIgMTAuOTExMDcxNTMyNTI3ODQgQy02Mi4xNTY0NzY4NjE2MzE2MiAxMC41Njg0ODkwOTQzNzIxMTUsIC02Mi40MTIxNTI3ODAwNzI3MSAxMC4yMjU5MDY2NTYyMTYzOSwgLTYyLjU3MTc2NDQ1NTQ0NjcyNiAxMC4wMTIwNDE1NTIxMzc5NzQgTS02Mi41NzE3NjQ0NTU0NDY3MjYgMTAuMDEyMDQxNTUyMTM3OTc0IEMtNjIuNzAwMzk0ODIzODIwMTggOS44MTQ0MzA3NjQyMjYwOTIsIC02Mi44MjkwMjUxOTIxOTM2MyA5LjYxNjgxOTk3NjMxNDIxMSwgLTYzLjE4Mzc0ODM1MjU5MzU1NCA5LjA3MTg2OTk0NTQzNDE5OCBNLTYyLjU3MTc2NDQ1NTQ0NjcyNiAxMC4wMTIwNDE1NTIxMzc5NzQgQy02Mi44MTI1MzI3MjkxOTk2OSA5LjY0MjE1NjgyODMxOTMxNywgLTYzLjA1MzMwMTAwMjk1MjY2IDkuMjcyMjcyMTA0NTAwNjYsIC02My4xODM3NDgzNTI1OTM1NTQgOS4wNzE4Njk5NDU0MzQxOTggTS02My4xODM3NDgzNTI1OTM1NTQgOS4wNzE4Njk5NDU0MzQxOTggQy02My4zNzgyNjE2NDAwNDAzMTQgOC43MjY0OTE5MDY5NjYyOTcsIC02My41NzI3NzQ5Mjc0ODcwNzUgOC4zODExMTM4Njg0OTgzOTYsIC02My43MzQyMzc4NjE1Mjc1MDQgOC4wOTQ0MjAwNzkyMTQ2MTggTS02My4xODM3NDgzNTI1OTM1NTQgOS4wNzE4Njk5NDU0MzQxOTggQy02My4zODAyMzQ1MDU5Njk1NyA4LjcyMjk4ODg4MzczNDU2OSwgLTYzLjU3NjcyMDY1OTM0NTU4IDguMzc0MTA3ODIyMDM0OTM4LCAtNjMuNzM0MjM3ODYxNTI3NTA0IDguMDk0NDIwMDc5MjE0NjE4IE0tNjMuNzM0MjM3ODYxNTI3NTA0IDguMDk0NDIwMDc5MjE0NjE4IEMtNjMuODU2NjM3NzI5NjI1MDQgNy44NDAyNTQxMzQxNzI0NTIsIC02My45NzkwMzc1OTc3MjI1NzQgNy41ODYwODgxODkxMzAyODQsIC02NC4yMjA5NzA5MDI3NzY3MSA3LjA4MzcwODUwNDY0MTg5OCBNLTYzLjczNDIzNzg2MTUyNzUwNCA4LjA5NDQyMDA3OTIxNDYxOCBDLTYzLjg2NTI0MjE1NzQ2MTAzIDcuODIyMzg2ODU1NjY1NzQ4LCAtNjMuOTk2MjQ2NDUzMzk0NTYgNy41NTAzNTM2MzIxMTY4NzcsIC02NC4yMjA5NzA5MDI3NzY3MSA3LjA4MzcwODUwNDY0MTg5OCBNLTY0LjIyMDk3MDkwMjc3NjcxIDcuMDgzNzA4NTA0NjQxODk4IEMtNjQuMzM0NTQ2NjE0MjI4NDIgNi44MDMxNzQzMDE1MTkxODYsIC02NC40NDgxMjIzMjU2ODAxMyA2LjUyMjY0MDA5ODM5NjQ3NCwgLTY0LjY0MTk0NzM4NTg3MDgxIDYuMDQzODg4NDUyMzcyODk0IE0tNjQuMjIwOTcwOTAyNzc2NzEgNy4wODM3MDg1MDQ2NDE4OTggQy02NC4zNjE3ODA1ODA0OTc4IDYuNzM1OTA1ODc4MzAwOTI0LCAtNjQuNTAyNTkwMjU4MjE4ODcgNi4zODgxMDMyNTE5NTk5NTEsIC02NC42NDE5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg5NCBNLTY0LjY0MTk0NzM4NTg3MDgxIDYuMDQzODg4NDUyMzcyODk0IEMtNjQuNzQwMTYzNzM4NjA5MTMgNS43NDgwNzY0NDY1NzU3MzEsIC02NC44MzgzODAwOTEzNDc0NiA1LjQ1MjI2NDQ0MDc3ODU3LCAtNjQuOTk1NDM3NDI4MTQxNTYgNC45NzkyMzI3NjYwNDMwNjggTS02NC42NDE5NDczODU4NzA4MSA2LjA0Mzg4ODQ1MjM3Mjg5NCBDLTY0Ljc2ODk5MDkxNzQ1NjI5IDUuNjYxMjUzNTc2ODc1MjkzLCAtNjQuODk2MDM0NDQ5MDQxNzggNS4yNzg2MTg3MDEzNzc2OTIsIC02NC45OTU0Mzc0MjgxNDE1NiA0Ljk3OTIzMjc2NjA0MzA2OCBNLTY0Ljk5NTQzNzQyODE0MTU2IDQuOTc5MjMyNzY2MDQzMDY4IEMtNjUuMDk4NTAzMTg4NTAyMjIgNC41ODYxOTgzNTI4MDQ3NTQsIC02NS4yMDE1Njg5NDg4NjI4OSA0LjE5MzE2MzkzOTU2NjQzOSwgLTY1LjI3OTk4ODQ2MzE4MTkxIDMuODk0MTE2MzQ0MjM1NTA2MiBNLTY0Ljk5NTQzNzQyODE0MTU2IDQuOTc5MjMyNzY2MDQzMDY4IEMtNjUuMDcwOTE2MTkxMjE3MzUgNC42OTEzOTk1Mjk3MzIyMjQsIC02NS4xNDYzOTQ5NTQyOTMxNCA0LjQwMzU2NjI5MzQyMTM4LCAtNjUuMjc5OTg4NDYzMTgxOTEgMy44OTQxMTYzNDQyMzU1MDYyIE0tNjUuMjc5OTg4NDYzMTgxOTEgMy44OTQxMTYzNDQyMzU1MDYyIEMtNjUuMzU1Mjc3NjMwMjg2MzcgMy41MDc1MjIzODM1MjUyMzU0LCAtNjUuNDMwNTY2Nzk3MzkwODIgMy4xMjA5Mjg0MjI4MTQ5NjQ1LCAtNjUuNDk0NDMxMjA5NzUyODggMi43OTI5OTgxNjMwODQxNDQ3IE0tNjUuMjc5OTg4NDYzMTgxOTEgMy44OTQxMTYzNDQyMzU1MDYyIEMtNjUuMzM2MzQ5MjIxODQxNjQgMy42MDQ3MTU3NjAzNjgzNDU3LCAtNjUuMzkyNzA5OTgwNTAxMzggMy4zMTUzMTUxNzY1MDExODUsIC02NS40OTQ0MzEyMDk3NTI4OCAyLjc5Mjk5ODE2MzA4NDE0NDcgTS02NS40OTQ0MzEyMDk3NTI4OCAyLjc5Mjk5ODE2MzA4NDE0NDcgQy02NS41MzM1ODg2MTc4MDM5NiAyLjQ4OTMwMTAzODc0NDc0NCwgLTY1LjU3Mjc0NjAyNTg1NTA0IDIuMTg1NjAzOTE0NDA1MzQ0LCAtNjUuNjM3ODg0NDc2NjEwOTYgMS42ODA0MDI5NTMzODQ0NDQgTS02NS40OTQ0MzEyMDk3NTI4OCAyLjc5Mjk5ODE2MzA4NDE0NDcgQy02NS41NDgzNTc1MTc1NTgyMiAyLjM3NDc1NjM2ODY5OTkwMTQsIC02NS42MDIyODM4MjUzNjM1NCAxLjk1NjUxNDU3NDMxNTY1NzYsIC02NS42Mzc4ODQ0NzY2MTA5NiAxLjY4MDQwMjk1MzM4NDQ0NCBNLTY1LjYzNzg4NDQ3NjYxMDk2IDEuNjgwNDAyOTUzMzg0NDQ0IEMtNjUuNjU2NDA2NzgzNDIzNTUgMS4zOTE5MDMwNzM4NDE0MTM4LCAtNjUuNjc0OTI5MDkwMjM2MTMgMS4xMDM0MDMxOTQyOTgzODM3LCAtNjUuNzA5NzU4NzgzNTEyMDMgMC41NjA5MDI2MDc1MDM5Njc2IE0tNjUuNjM3ODg0NDc2NjEwOTYgMS42ODA0MDI5NTMzODQ0NDQgQy02NS42NTY0Nzk5ODMyMzI4MyAxLjM5MDc2MjkyNzcyNjEzMywgLTY1LjY3NTA3NTQ4OTg1NDY5IDEuMTAxMTIyOTAyMDY3ODIyNCwgLTY1LjcwOTc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTY3NiBNLTY1LjcwOTc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTY3NiBDLTY1LjcwOTc1ODc4MzUxMjAzIDAuMTc3NjYwMzI4NTcxMzM0OTYsIC02NS43MDk3NTg3ODM1MTIwMyAtMC4yMDU1ODE5NTAzNjEyOTc2NywgLTY1LjcwOTc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBNLTY1LjcwOTc1ODc4MzUxMjAzIDAuNTYwOTAyNjA3NTAzOTY3NiBDLTY1LjcwOTc1ODc4MzUxMjAzIDAuMTkxODA5NTA4MTQyNDc5ODIsIC02NS43MDk3NTg3ODM1MTIwMyAtMC4xNzcyODM1OTEyMTkwMDc5NCwgLTY1LjcwOTc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBNLTY1LjcwOTc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBDLTY1LjY4MjU2MDc1OTQ2OTg4IC0wLjk4NDUzMzc4NTgxMDM1MDQsIC02NS42NTUzNjI3MzU0Mjc3MyAtMS40MDgxNjQ5NjQxMTY3NDE3LCAtNjUuNjM3ODg0NDc2NjEwOTYgLTEuNjgwNDAyOTUzMzg0NDE5OCBNLTY1LjcwOTc1ODc4MzUxMjAzIC0wLjU2MDkwMjYwNzUwMzk1OSBDLTY1LjY4ODM1ODQ4Mjc1MTkxIC0wLjg5NDIyOTU2NTg1NDY5NDgsIC02NS42NjY5NTgxODE5OTE3OSAtMS4yMjc1NTY1MjQyMDU0MzA3LCAtNjUuNjM3ODg0NDc2NjEwOTYgLTEuNjgwNDAyOTUzMzg0NDE5OCBNLTY1LjYzNzg4NDQ3NjYxMDk2IC0xLjY4MDQwMjk1MzM4NDQxOTggQy02NS41ODY2NzY5MDIwNzg2OCAtMi4wNzc1NTg3ODkzNzc0OTI1LCAtNjUuNTM1NDY5MzI3NTQ2NCAtMi40NzQ3MTQ2MjUzNzA1NjU2LCAtNjUuNDk0NDMxMjA5NzUyODggLTIuNzkyOTk4MTYzMDg0MTM2NyBNLTY1LjYzNzg4NDQ3NjYxMDk2IC0xLjY4MDQwMjk1MzM4NDQxOTggQy02NS41ODk2OTkxNDI3NTY0OSAtMi4wNTQxMTg4ODc0ODkzMDgsIC02NS41NDE1MTM4MDg5MDIwMSAtMi40Mjc4MzQ4MjE1OTQxOTY1LCAtNjUuNDk0NDMxMjA5NzUyODggLTIuNzkyOTk4MTYzMDg0MTM2NyBNLTY1LjQ5NDQzMTIwOTc1Mjg4IC0yLjc5Mjk5ODE2MzA4NDEzNjcgQy02NS40MTA4NjczOTMzNzEwOSAtMy4yMjIwODA2OTg5ODU3Mzg3LCAtNjUuMzI3MzAzNTc2OTg5MzEgLTMuNjUxMTYzMjM0ODg3MzQsIC02NS4yNzk5ODg0NjMxODE5MSAtMy44OTQxMTYzNDQyMzU0OTggTS02NS40OTQ0MzEyMDk3NTI4OCAtMi43OTI5OTgxNjMwODQxMzY3IEMtNjUuNDQ1NzQ3ODg0NjAyMTQgLTMuMDQyOTc2NzQ4NTA4NzI4NywgLTY1LjM5NzA2NDU1OTQ1MTQxIC0zLjI5Mjk1NTMzMzkzMzMyLCAtNjUuMjc5OTg4NDYzMTgxOTEgLTMuODk0MTE2MzQ0MjM1NDk4IE0tNjUuMjc5OTg4NDYzMTgxOTEgLTMuODk0MTE2MzQ0MjM1NDk4IEMtNjUuMTk5NjYzMjc4NzYyMzYgLTQuMjAwNDMxMDg1NTgyMzg1LCAtNjUuMTE5MzM4MDk0MzQyODIgLTQuNTA2NzQ1ODI2OTI5MjcxLCAtNjQuOTk1NDM3NDI4MTQxNTcgLTQuOTc5MjMyNzY2MDQzMDU5IE0tNjUuMjc5OTg4NDYzMTgxOTEgLTMuODk0MTE2MzQ0MjM1NDk4IEMtNjUuMjE1NDUyNjI3NDQ0MjYgLTQuMTQwMjE5NDU1OTExMjY1LCAtNjUuMTUwOTE2NzkxNzA2NjMgLTQuMzg2MzIyNTY3NTg3MDMyLCAtNjQuOTk1NDM3NDI4MTQxNTcgLTQuOTc5MjMyNzY2MDQzMDU5IE0tNjQuOTk1NDM3NDI4MTQxNTcgLTQuOTc5MjMyNzY2MDQzMDU5IEMtNjQuODk1NDY5NTk3MzM4NzcgLTUuMjgwMzE5OTQ0NzEwMjcyLCAtNjQuNzk1NTAxNzY2NTM1OTYgLTUuNTgxNDA3MTIzMzc3NDg1LCAtNjQuNjQxOTQ3Mzg1ODcwODEgLTYuMDQzODg4NDUyMzcyODcxNSBNLTY0Ljk5NTQzNzQyODE0MTU3IC00Ljk3OTIzMjc2NjA0MzA1OSBDLTY0Ljg2ODYxMTA4MDczNzk1IC01LjM2MTIxMzUxNzM4ODQ2NjUsIC02NC43NDE3ODQ3MzMzMzQzMyAtNS43NDMxOTQyNjg3MzM4NzQsIC02NC42NDE5NDczODU4NzA4MSAtNi4wNDM4ODg0NTIzNzI4NzE1IE0tNjQuNjQxOTQ3Mzg1ODcwODEgLTYuMDQzODg4NDUyMzcyODcxNSBDLTY0LjQ3NTg2OTIxOTcxNDYxIC02LjQ1NDEwNDczMzY4MTU3LCAtNjQuMzA5NzkxMDUzNTU4NDMgLTYuODY0MzIxMDE0OTkwMjY4LCAtNjQuMjIwOTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODg5IE0tNjQuNjQxOTQ3Mzg1ODcwODEgLTYuMDQzODg4NDUyMzcyODcxNSBDLTY0LjQ3NDE2NzIzMzA5NzEgLTYuNDU4MzA4NjczNTMyNTAyLCAtNjQuMzA2Mzg3MDgwMzIzMzkgLTYuODcyNzI4ODk0NjkyMTMzLCAtNjQuMjIwOTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODg5IE0tNjQuMjIwOTcwOTAyNzc2NzEgLTcuMDgzNzA4NTA0NjQxODg5IEMtNjQuMTE1MTczNzUwMzA3NzggLTcuMzAzMzk4NTU1NDQwMDc3LCAtNjQuMDA5Mzc2NTk3ODM4ODIgLTcuNTIzMDg4NjA2MjM4MjY0NSwgLTYzLjczNDIzNzg2MTUyNzUwNCAtOC4wOTQ0MjAwNzkyMTQ2MTEgTS02NC4yMjA5NzA5MDI3NzY3MSAtNy4wODM3MDg1MDQ2NDE4ODkgQy02NC4wNDA1NTg5OTIyNzYxOSAtNy40NTgzMzc2OTY5OTI3MzcsIC02My44NjAxNDcwODE3NzU2NiAtNy44MzI5NjY4ODkzNDM1ODQsIC02My43MzQyMzc4NjE1Mjc1MDQgLTguMDk0NDIwMDc5MjE0NjExIE0tNjMuNzM0MjM3ODYxNTI3NTA0IC04LjA5NDQyMDA3OTIxNDYxMSBDLTYzLjU2MTIzMDUwNjI3MjA2IC04LjQwMTYxMjE1NzM2NTA2LCAtNjMuMzg4MjIzMTUxMDE2NjEgLTguNzA4ODA0MjM1NTE1NTA4LCAtNjMuMTgzNzQ4MzUyNTkzNTU0IC05LjA3MTg2OTk0NTQzNDE5MyBNLTYzLjczNDIzNzg2MTUyNzUwNCAtOC4wOTQ0MjAwNzkyMTQ2MTEgQy02My42MTk1NTA3MDYxNjI3IC04LjI5ODA1ODczNjg5ODYwNywgLTYzLjUwNDg2MzU1MDc5NzkgLTguNTAxNjk3Mzk0NTgyNjAzLCAtNjMuMTgzNzQ4MzUyNTkzNTU0IC05LjA3MTg2OTk0NTQzNDE5MyBNLTYzLjE4Mzc0ODM1MjU5MzU1NCAtOS4wNzE4Njk5NDU0MzQxOTMgQy02My4wMjQxNzUyNjY1MzkwMSAtOS4zMTcwMTcwNTY5ODczMzYsIC02Mi44NjQ2MDIxODA0ODQ0NyAtOS41NjIxNjQxNjg1NDA0NzksIC02Mi41NzE3NjQ0NTU0NDY3MjYgLTEwLjAxMjA0MTU1MjEzNzk2OSBNLTYzLjE4Mzc0ODM1MjU5MzU1NCAtOS4wNzE4Njk5NDU0MzQxOTMgQy02Mi45ODUxOTkxOTg3MDg1IC05LjM3Njg5NDc2MzcxNDY2NSwgLTYyLjc4NjY1MDA0NDgyMzQ0NiAtOS42ODE5MTk1ODE5OTUxMzksIC02Mi41NzE3NjQ0NTU0NDY3MjYgLTEwLjAxMjA0MTU1MjEzNzk2OSBNLTYyLjU3MTc2NDQ1NTQ0NjcyNiAtMTAuMDEyMDQxNTUyMTM3OTY5IEMtNjIuMzMxODc2ODQxMjAzNzYgLTEwLjMzMzQ2OTEwMTAxMjMwMywgLTYyLjA5MTk4OTIyNjk2MDc5IC0xMC42NTQ4OTY2NDk4ODY2NCwgLTYxLjkwMDgwMDk0MzE5MDUyNSAtMTAuOTExMDcxNTMyNTI3ODM1IE0tNjIuNTcxNzY0NDU1NDQ2NzI2IC0xMC4wMTIwNDE1NTIxMzc5NjkgQy02Mi4zNjU0NzkxMDU5NTk3MSAtMTAuMjg4NDQ1MTI3NDY4NjI3LCAtNjIuMTU5MTkzNzU2NDcyNjkgLTEwLjU2NDg0ODcwMjc5OTI4NSwgLTYxLjkwMDgwMDk0MzE5MDUyNSAtMTAuOTExMDcxNTMyNTI3ODM1IE0tNjEuOTAwODAwOTQzMTkwNTI1IC0xMC45MTEwNzE1MzI1Mjc4MzUgQy02MS42MjI3MTA1NjA5NTU0NiAtMTEuMjM3NzMyMzE5MjkyMTYsIC02MS4zNDQ2MjAxNzg3MjA0IC0xMS41NjQzOTMxMDYwNTY0ODQsIC02MS4xNzM2MTQ5NDg4MTgwMyAtMTEuNzY1MjY1NTc5NTczMDM4IE0tNjEuOTAwODAwOTQzMTkwNTI1IC0xMC45MTEwNzE1MzI1Mjc4MzUgQy02MS42MjM3OTcxNjQ3OTE1MyAtMTEuMjM2NDU1OTMyNTk2OCwgLTYxLjM0Njc5MzM4NjM5MjU0IC0xMS41NjE4NDAzMzI2NjU3NjIsIC02MS4xNzM2MTQ5NDg4MTgwMyAtMTEuNzY1MjY1NTc5NTczMDM4IE0tNjEuMTczNjE0OTQ4ODE4MDMgLTExLjc2NTI2NTU3OTU3MzAzOCBDLTYxLjAwMTQ2NzE1NTA3OTQyNSAtMTEuOTQzMDIyMzEwMjA0ODU2LCAtNjAuODI5MzE5MzYxMzQwODMgLTEyLjEyMDc3OTA0MDgzNjY3NywgLTYwLjM5MzE5NDYzNTU2MTAyNCAtMTIuNTcxMTEzNjI2NzEwMjI0IE0tNjEuMTczNjE0OTQ4ODE4MDMgLTExLjc2NTI2NTU3OTU3MzAzOCBDLTYwLjk2NjY4NjUyODI3NTE1NCAtMTEuOTc4OTM2MTYyOTIyODMzLCAtNjAuNzU5NzU4MTA3NzMyMjkgLTEyLjE5MjYwNjc0NjI3MjYzLCAtNjAuMzkzMTk0NjM1NTYxMDI0IC0xMi41NzExMTM2MjY3MTAyMjQgTS02MC4zOTMxOTQ2MzU1NjEwMjQgLTEyLjU3MTExMzYyNjcxMDIyNCBDLTYwLjEzOTEwNTU2MzUwMDkgLTEyLjgwMTg3MDU5OTEyNjc4MSwgLTU5Ljg4NTAxNjQ5MTQ0MDc4IC0xMy4wMzI2Mjc1NzE1NDMzMzksIC01OS41NjI3NDY5MTc4ODYzMTUgLTEzLjMyNTMwNDI3MTQ1OTg0IE0tNjAuMzkzMTk0NjM1NTYxMDI0IC0xMi41NzExMTM2MjY3MTAyMjQgQy02MC4wNzM5ODUxODQ2NjUxNTUgLTEyLjg2MTAxMTIwNDE5NDU5NywgLTU5Ljc1NDc3NTczMzc2OTI5IC0xMy4xNTA5MDg3ODE2Nzg5NjgsIC01OS41NjI3NDY5MTc4ODYzMTUgLTEzLjMyNTMwNDI3MTQ1OTg0IE0tNTkuNTYyNzQ2OTE3ODg2MzE1IC0xMy4zMjUzMDQyNzE0NTk4NCBDLTU5LjI4MTM1OTg1MDEzMzMzIC0xMy41NDk3MDI5Njk5Njg1LCAtNTguOTk5OTcyNzgyMzgwMzMgLTEzLjc3NDEwMTY2ODQ3NzE2MiwgLTU4LjY4NTY4NDI4MzU5NjI5IC0xNC4wMjQ3MzgzODI2ODkyMzYgTS01OS41NjI3NDY5MTc4ODYzMTUgLTEzLjMyNTMwNDI3MTQ1OTg0IEMtNTkuMjc2ODU5MzYzMTUxMjI1IC0xMy41NTMyOTE5ODg1NzM3MzgsIC01OC45OTA5NzE4MDg0MTYxMzQgLTEzLjc4MTI3OTcwNTY4NzYzNCwgLTU4LjY4NTY4NDI4MzU5NjI5IC0xNC4wMjQ3MzgzODI2ODkyMzYgTS01OC42ODU2ODQyODM1OTYyOSAtMTQuMDI0NzM4MzgyNjg5MjM2IEMtNTguMzIxODA1ODI5NTUxNjUgLTE0LjI3ODU2NDI0MDE4NjM4LCAtNTcuOTU3OTI3Mzc1NTA3MDA1IC0xNC41MzIzOTAwOTc2ODM1MjUsIC01Ny43NjU2MTA3NzExODQ2MSAtMTQuNjY2NTQxODM1NjA3MjA1IE0tNTguNjg1Njg0MjgzNTk2MjkgLTE0LjAyNDczODM4MjY4OTIzNiBDLTU4LjM5MzQ4OTI1OTA0OTkzIC0xNC4yMjg1NjA5ODI4OTQwMzEsIC01OC4xMDEyOTQyMzQ1MDM1NiAtMTQuNDMyMzgzNTgzMDk4ODI2LCAtNTcuNzY1NjEwNzcxMTg0NjEgLTE0LjY2NjU0MTgzNTYwNzIwNSBNLTU3Ljc2NTYxMDc3MTE4NDYxIC0xNC42NjY1NDE4MzU2MDcyMDUgQy01Ny40ODg4OTEwODcxMjQ1NjQgLTE0LjgzNDI5MDkzNDI2OTc3MiwgLTU3LjIxMjE3MTQwMzA2NDUyIC0xNS4wMDIwNDAwMzI5MzIzMzksIC01Ni44MDYzMDcxNjAwNjg5MSAtMTUuMjQ4MDc3MzIyMTU5MzEzIE0tNTcuNzY1NjEwNzcxMTg0NjEgLTE0LjY2NjU0MTgzNTYwNzIwNSBDLTU3LjQ5ODI5MjI1MTMzODU1IC0xNC44Mjg1OTE4OTMyNzU4ODEsIC01Ny4yMzA5NzM3MzE0OTI0OSAtMTQuOTkwNjQxOTUwOTQ0NTU3LCAtNTYuODA2MzA3MTYwMDY4OTEgLTE1LjI0ODA3NzMyMjE1OTMxMyBNLTU2LjgwNjMwNzE2MDA2ODkxIC0xNS4yNDgwNzczMjIxNTkzMTMgQy01Ni42MDA3NTE2ODM0ODE5NiAtMTUuMzU1MzE1NDgyNjMwMTU3LCAtNTYuMzk1MTk2MjA2ODk1MDE1IC0xNS40NjI1NTM2NDMxMDEwMDMsIC01NS44MTE3MTU0MzQ1NTcyNyAtMTUuNzY2OTU1MTg4MjkyMzMyIE0tNTYuODA2MzA3MTYwMDY4OTEgLTE1LjI0ODA3NzMyMjE1OTMxMyBDLTU2LjU0MTI1NzA2NDI2NDA2NiAtMTUuMzg2MzUzNzg3MzY4MDEyLCAtNTYuMjc2MjA2OTY4NDU5MjIgLTE1LjUyNDYzMDI1MjU3NjcxMywgLTU1LjgxMTcxNTQzNDU1NzI3IC0xNS43NjY5NTUxODgyOTIzMzIgTS01NS44MTE3MTU0MzQ1NTcyNyAtMTUuNzY2OTU1MTg4MjkyMzMyIEMtNTUuNTc5MjY5MTY5MjkxMDQ1IC0xNS44Njk4NTIyNTQ2NTIyMjEsIC01NS4zNDY4MjI5MDQwMjQ4MiAtMTUuOTcyNzQ5MzIxMDEyMTEsIC01NC43ODU5MjI1ODUzODkwNiAtMTYuMjIxMDQzMjUzNTU1Mzc2IE0tNTUuODExNzE1NDM0NTU3MjcgLTE1Ljc2Njk1NTE4ODI5MjMzMiBDLTU1LjUwMjcxNjIxNTEwMjA1NSAtMTUuOTAzNzM5OTc2NjA4OTg0LCAtNTUuMTkzNzE2OTk1NjQ2ODQ1IC0xNi4wNDA1MjQ3NjQ5MjU2MzUsIC01NC43ODU5MjI1ODUzODkwNiAtMTYuMjIxMDQzMjUzNTU1Mzc2IE0tNTQuNzg1OTIyNTg1Mzg5MDYgLTE2LjIyMTA0MzI1MzU1NTM3NiBDLTU0LjQ2MDAyNzYwNDI3ODcyIC0xNi4zNDA5NzU2MTkxNDQxNjQsIC01NC4xMzQxMzI2MjMxNjgzOCAtMTYuNDYwOTA3OTg0NzMyOTUyLCAtNTMuNzMzMTQzODE1NDEzMzggLTE2LjYwODQ3NTU3MjY4NjY5NyBNLTU0Ljc4NTkyMjU4NTM4OTA2IC0xNi4yMjEwNDMyNTM1NTUzNzYgQy01NC41MDQ5Mjk3NTA1MDc1ODYgLTE2LjMyNDQ1MTIxNDI2MTA1LCAtNTQuMjIzOTM2OTE1NjI2MTEgLTE2LjQyNzg1OTE3NDk2NjcyNCwgLTUzLjczMzE0MzgxNTQxMzM4IC0xNi42MDg0NzU1NzI2ODY2OTcgTS01My43MzMxNDM4MTU0MTMzOCAtMTYuNjA4NDc1NTcyNjg2Njk3IEMtNTMuNDUxNDE5MzM5NzIzOTUgLTE2LjY5MjA4OTkxODI2OTM2NywgLTUzLjE2OTY5NDg2NDAzNDUyIC0xNi43NzU3MDQyNjM4NTIwNCwgLTUyLjY1NzcwNTIxODQxNjM5NiAtMTYuOTI3NjYwMTAzMTgzMDEgTS01My43MzMxNDM4MTU0MTMzOCAtMTYuNjA4NDc1NTcyNjg2Njk3IEMtNTMuNDg3NDI3OTQzOTg3NDIgLTE2LjY4MTQwMjc1MzUzNjk5LCAtNTMuMjQxNzEyMDcyNTYxNDYgLTE2Ljc1NDMyOTkzNDM4NzI4NiwgLTUyLjY1NzcwNTIxODQxNjM5NiAtMTYuOTI3NjYwMTAzMTgzMDEgTS01Mi42NTc3MDUyMTg0MTYzOTYgLTE2LjkyNzY2MDEwMzE4MzAxIEMtNTIuMjgzMjY0OTM3OTE0NiAtMTcuMDEzMTIzNjUzNzU2MzYsIC01MS45MDg4MjQ2NTc0MTI4MSAtMTcuMDk4NTg3MjA0MzI5NzE0LCAtNTEuNTY0MDI2MDAyMjc0MDIgLTE3LjE3NzI4NTI0NzM0MzY0IE0tNTIuNjU3NzA1MjE4NDE2Mzk2IC0xNi45Mjc2NjAxMDMxODMwMSBDLTUyLjM0NzY2OTYyNTM4MTMgLTE2Ljk5ODQyMzcwNDEyMTk1LCAtNTIuMDM3NjM0MDMyMzQ2MjA1IC0xNy4wNjkxODczMDUwNjA4OSwgLTUxLjU2NDAyNjAwMjI3NDAyIC0xNy4xNzcyODUyNDczNDM2NCBNLTUxLjU2NDAyNjAwMjI3NDAyIC0xNy4xNzcyODUyNDczNDM2NCBDLTUxLjI2NjM3ODExMjUwNzYzIC0xNy4yMjU0MDY2NDk4NjcyMSwgLTUwLjk2ODczMDIyMjc0MTI1IC0xNy4yNzM1MjgwNTIzOTA3OCwgLTUwLjQ1NjYwMDMyOTQ3ODg3IC0xNy4zNTYzMjUyNDE5MDY4MDYgTS01MS41NjQwMjYwMDIyNzQwMiAtMTcuMTc3Mjg1MjQ3MzQzNjQgQy01MS4yNjc3MDA0OTkzMDk5MiAtMTcuMjI1MTkyODU2NjI0MjgyLCAtNTAuOTcxMzc0OTk2MzQ1ODEgLTE3LjI3MzEwMDQ2NTkwNDkyLCAtNTAuNDU2NjAwMzI5NDc4ODcgLTE3LjM1NjMyNTI0MTkwNjgwNiBNLTUwLjQ1NjYwMDMyOTQ3ODg3IC0xNy4zNTYzMjUyNDE5MDY4MDYgQy01MC4yMDI2NTg3OTc2MDMyODQgLTE3LjM4MDgyMjY3NjA3NzQ2OCwgLTQ5Ljk0ODcxNzI2NTcyNzcxIC0xNy40MDUzMjAxMTAyNDgxMywgLTQ5LjMzOTk3ODg0OTY2MjQ4IC0xNy40NjQwNDQzNzMxMzA4ODYgTS01MC40NTY2MDAzMjk0Nzg4NyAtMTcuMzU2MzI1MjQxOTA2ODA2IEMtNTAuMTQ4NDQ4MDU1OTkxMTQgLTE3LjM4NjA1MjMyMTEyMjgzNiwgLTQ5Ljg0MDI5NTc4MjUwMzQxIC0xNy40MTU3Nzk0MDAzMzg4NjcsIC00OS4zMzk5Nzg4NDk2NjI0OCAtMTcuNDY0MDQ0MzczMTMwODg2IE0tNDkuMzM5OTc4ODQ5NjYyNDggLTE3LjQ2NDA0NDM3MzEzMDg4NiBDLTQ4Ljg5NTM3NDIxMDAyNTI1IC0xNy40NzgzMDE5Nzg1NTM2MiwgLTQ4LjQ1MDc2OTU3MDM4ODAyIC0xNy40OTI1NTk1ODM5NzYzNSwgLTQ4LjIxODc1MDAwMDAwMDAxIC0xNy41IE0tNDkuMzM5OTc4ODQ5NjYyNDggLTE3LjQ2NDA0NDM3MzEzMDg4NiBDLTQ4LjkyNTU4MzI0OTUzMDQ1IC0xNy40NzczMzMyMzM0NTUwMTcsIC00OC41MTExODc2NDkzOTg0MTYgLTE3LjQ5MDYyMjA5Mzc3OTE0OCwgLTQ4LjIxODc1MDAwMDAwMDAxIC0xNy41IE0tNDguMjE4NzUwMDAwMDAwMDEgLTE3LjUgQy00OC4yMTg3NTAwMDAwMDAwMSAtMTcuNSwgLTQ4LjIxODc1MDAwMDAwMDAxIC0xNy41LCAtNDguMjE4NzUgLTE3LjUgTS00OC4yMTg3NTAwMDAwMDAwMSAtMTcuNSBDLTQ4LjIxODc1MDAwMDAwMDAxIC0xNy41LCAtNDguMjE4NzUwMDAwMDAwMDEgLTE3LjUsIC00OC4yMTg3NSAtMTcuNSIgc3Ryb2tlPSIjNjA3OThhIiBzdHJva2Utd2lkdGg9IjEuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLWRhc2hhcnJheT0iMCAwIiBzdHlsZT0iIi8+PC9nPjxnIGNsYXNzPSJsYWJlbCIgc3R5bGU9IiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCwgLTEwKSI+PHJlY3QvPjxnPjxyZWN0IGNsYXNzPSJiYWNrZ3JvdW5kIiBzdHlsZT0ic3Ryb2tlOiBub25lIi8+PHRleHQgeT0iLTEwLjEiIHN0eWxlPSIiPjx0c3BhbiBjbGFzcz0idGV4dC1vdXRlci10c3BhbiByb3ciIHg9IjAiIHk9Ii0wLjFlbSIgZHk9IjEuMWVtIj48dHNwYW4gZm9udC1zdHlsZT0ibm9ybWFsIiBjbGFzcz0idGV4dC1pbm5lci10c3BhbiIgZm9udC13ZWlnaHQ9Im5vcm1hbCI+SHVtYW48L3RzcGFuPjx0c3BhbiBmb250LXN0eWxlPSJub3JtYWwiIGNsYXNzPSJ0ZXh0LWlubmVyLXRzcGFuIiBmb250LXdlaWdodD0ibm9ybWFsIj4gcmV2aWV3PC90c3Bhbj48L3RzcGFuPjwvdGV4dD48L2c+PC9nPjwvZz48L2c+PC9nPjwvZz48ZGVmcz48ZmlsdGVyIGlkPSJteS1zdmctZHJvcC1zaGFkb3ciIGhlaWdodD0iMTMwJSIgd2lkdGg9IjEzMCUiPjxmZURyb3BTaGFkb3cgZHg9IjQiIGR5PSI0IiBzdGREZXZpYXRpb249IjAiIGZsb29kLW9wYWNpdHk9IjAuMDYiIGZsb29kLWNvbG9yPSIjMDAwMDAwIi8+PC9maWx0ZXI+PC9kZWZzPjxkZWZzPjxmaWx0ZXIgaWQ9Im15LXN2Zy1kcm9wLXNoYWRvdy1zbWFsbCIgaGVpZ2h0PSIxNTAlIiB3aWR0aD0iMTUwJSI+PGZlRHJvcFNoYWRvdyBkeD0iMiIgZHk9IjIiIHN0ZERldmlhdGlvbj0iMCIgZmxvb2Qtb3BhY2l0eT0iMC4wNiIgZmxvb2QtY29sb3I9IiMwMDAwMDAiLz48L2ZpbHRlcj48L2RlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJteS1zdmctZ3JhZGllbnQiIGdyYWRpZW50VW5pdHM9Im9iamVjdEJvdW5kaW5nQm94IiB4MT0iMCUiIHkxPSIwJSIgeDI9IjEwMCUiIHkyPSIwJSI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzYwNzk4YSIgc3RvcC1vcGFjaXR5PSIxIi8+PHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSJoc2woMjAyLjUsIDAlLCA4NC41MDk4MDM5MjE2JSkiIHN0b3Atb3BhY2l0eT0iMSIvPjwvbGluZWFyR3JhZGllbnQ+PC9zdmc+"><figcaption>Diagram 1</figcaption><details><summary>View Mermaid source</summary><pre><code class="language-mermaid">flowchart LR
+    Brief([Idea or problem]) --&gt; Author[&quot;PRD authoring or /design&quot;]
+    Author --&gt; Source[&quot;Canonical Markdown&quot;]
+    Source --&gt; Skill[&quot;/html-doc&quot;]
+    Skill --&gt; Page[&quot;Generated HTML&quot;]
+    Page --&gt; Review([Human review])
+    Review --&gt;|content changes| Source</code></pre></details></figure>
+<div class="source-block" data-source-block="12"
+data-source-sha256="44ec31f330152b56e9dc6cb5eaa161f6a3b19e1700e34ff734de5857c8765d71">
 <p>The authoring step owns meaning. <code>/html-doc</code> owns
 presentation. Review comments that change behavior, scope, requirements,
 or decisions go back into the Markdown source before the page is
 regenerated.</p>
-</section>
-<section id="4-proposed-design" class="level2">
+</div>
+<section id="4-proposed-design" class="source-block"
+data-source-block="13"
+data-source-sha256="cb43280d884b7bd10ddfe1c903a3a3ffc221ebb65bc3295cbb6d512812e2ddb1">
 <h2>4. Proposed design</h2>
-<section id="how-it-works" class="level3">
+</section>
+<section id="how-it-works" class="source-block" data-source-block="14"
+data-source-sha256="e248d7da23aef6704ac43f3f639e0b91f6c326e9ecb982e008905e4785a6b4ed">
 <h3>How it works</h3>
-<p>A user invokes <code>/html-doc</code> with a Markdown path and may
-state whether it is a PRD or design document. The skill reads the
-complete source and detects the kind only when the user did not provide
-it. It refuses to guess when the structure is ambiguous.</p>
+</section>
+<div class="source-block" data-source-block="15"
+data-source-sha256="2fe1073536e46101e5280af5f12749a32a509b3ad485096ba235d517218d5d28">
+<p>A user invokes <code>/html-doc</code> with a Markdown path and states
+whether it is a PRD or design document. The kind may be omitted only
+when the source basename is exactly <code>prd.md</code> or
+<code>design.md</code>. The skill does not infer the kind from headings
+or prose.</p>
+</div>
+<div class="source-block" data-source-block="16"
+data-source-sha256="edfe4419212b8b9e067fabacf2f2b8f906fc0b2e420f43fdac20686fc9dc7ff4">
 <p>The skill copies the bundled HTML template to a sibling output such
 as <code>docs/payments/prd.html</code>. It maps the source into semantic
 HTML in the same order. It adds a document header, status and source
 metadata, a linked table of contents, and presentation treatments based
 on section meaning. Unknown sections remain normal sections and are
 never dropped.</p>
+</div>
+<div class="source-block" data-source-block="17"
+data-source-sha256="b675d9f30affe73d58af34a235b8e60c0dc6560a1ac1304a32de50f5034343e1">
 <p>The page uses semantic HTML, inline CSS, and no runtime JavaScript.
-Mermaid diagrams become sanitized inline SVG during generation and
-retain an accessible text description. The result works as a local file
-without a server or network connection.</p>
+During generation, the exact dependency tree recorded in the skill
+lockfile renders Mermaid blocks with
+<code>@mermaid-js/mermaid-cli@11.16.0</code> and Puppeteer
+<code>25.5.0</code>. The generator rejects resource-bearing Mermaid
+source before rendering, runs Chromium with network resolution and proxy
+access denied, validates each SVG against an allowlist, embeds it as a
+base64 data image, and keeps the exact Mermaid source in a disclosure
+below the image. The result works as a local file without a server or
+network connection.</p>
+</div>
+<div class="source-block" data-source-block="18"
+data-source-sha256="256e885cda3eeb370d335ba18e0940080b1cea211b9f355d4107bca8e6997356">
 <p>The skill opens the result in a real browser. It checks desktop and
 mobile widths, keyboard navigation, diagrams, long tables, code blocks,
 links, and print preview. It compares the rendered content with the
 source. It fixes presentation defects in the generated file or template,
 but sends content defects back to the source.</p>
-</section>
-<section id="page-structure" class="level3">
+</div>
+<section id="page-structure" class="source-block" data-source-block="19"
+data-source-sha256="dfef279c4fb7f3b6c1d6411df9f048547b3fdd9231bcaaa5db9175c518cd2ae5">
 <h3>Page structure</h3>
+</section>
+<div class="source-block" data-source-block="20"
+data-source-sha256="2601de14700901ccb48f25b3d7925aa0fd95170a744352f2de605db3c0610f3a">
 <pre class="text"><code>+------------------------------------------------------------------+
 | Document kind  Status                          Source and revision |
 | Title                                                            |
@@ -653,14 +375,21 @@ but sends content defects back to the source.</p>
 +-------------------+----------------------------------------------+
 | Source path and generator version                                |
 +------------------------------------------------------------------+</code></pre>
+</div>
+<div class="source-block" data-source-block="21"
+data-source-sha256="00f13739cd8a2a2b4e1631dfb61f258de0145cd628b79f949622e111a64f271a">
 <p>On narrow screens, the contents move above the document and the page
 becomes one column. Print hides navigation and source-control details
 that do not help the paper reader. Visual callouts use a label, border,
 icon or shape, and text so color is never the only signal.</p>
-</section>
-<section id="components-and-responsibilities" class="level3">
+</div>
+<section id="components-and-responsibilities" class="source-block"
+data-source-block="22"
+data-source-sha256="ec9a76783795a31c5a8fa78eb007e1288ed67056f6e893afc753006cc7f2e898">
 <h3>Components and responsibilities</h3>
-<div class="table-wrap" role="region" aria-label="Scrollable table" tabindex="0">
+</section>
+<div class="source-block table-wrap" data-source-block="23"
+data-source-sha256="e70ce4f7b5799aa9acf8b0742e4165e2015c6b33444daaa343240c799ab3b6be">
 <table>
 <thead>
 <tr>
@@ -686,6 +415,13 @@ accessibility defaults</td>
 <td>Document content</td>
 </tr>
 <tr>
+<td>Render script</td>
+<td>Markdown conversion, diagram rendering, sanitization, metadata, and
+structural checks</td>
+<td>Pandoc, Node.js, and pinned Mermaid CLI and Puppeteer packages</td>
+<td>Content decisions or browser proof</td>
+</tr>
+<tr>
 <td>Generated HTML</td>
 <td>One reviewable view of one source revision</td>
 <td>Markdown source and template</td>
@@ -700,64 +436,162 @@ accessibility defaults</td>
 </tbody>
 </table>
 </div>
-</section>
-<section id="decisions" class="level3">
+<section id="decisions" class="source-block role-decisions"
+data-source-block="24"
+data-source-sha256="5a6a5f0f1903f8ea343148136e7bb0710d2555ca216504d9bf9d9b532157aa00">
 <h3>Decisions</h3>
+</section>
+<div class="source-block" data-source-block="25"
+data-source-sha256="5eadc5936d71529c53c14d64a14f9f13bc6f02f4836aecfedf9ca921fde7d81f">
 <p><strong>Keep Markdown canonical.</strong> A paired Markdown and HTML
 document makes writing, diffing, and agent review simple while giving
 humans a better reading surface. Making HTML canonical would improve
 direct presentation but make content changes harder to inspect and
 merge.</p>
+</div>
+<div class="source-block" data-source-block="26"
+data-source-sha256="b50a352b52298cc1ad259b9ce22e1373c07c898276a1a38820a897e905d5d987">
 <p><strong>Make the skill presentation-only.</strong>
 <code>/design</code> already owns technical design in this repository.
 Letting <code>/html-doc</code> also settle requirements or architecture
 would create two conflicting workflows. A user with only a rough idea
 must first supply or create the source document.</p>
+</div>
+<div class="source-block" data-source-block="27"
+data-source-sha256="241f5538460f9656a04eb6f2f36671ff5c5a24bf8d2640b072decf271bb3e4ae">
 <p><strong>Generate a static, offline page.</strong> The output uses
-inline CSS and generated inline SVG with no fonts, scripts, images, or
-style sheets fetched at runtime. This makes a file easy to share and
-avoids broken pages behind network or content-security restrictions. It
-costs more generation work than loading a web framework.</p>
+inline CSS and sanitized, base64-embedded SVG images with no fonts,
+scripts, images, or style sheets fetched at runtime. This makes a file
+easy to share and avoids broken pages behind network or content-security
+restrictions. It costs more generation work than loading a web
+framework.</p>
+</div>
+<div class="source-block" data-source-block="28"
+data-source-sha256="a9152aa861faae8f0d7752a27731d060efb646285a9f856cd11e51757d8f02ab">
+<p><strong>Lock the Mermaid renderer.</strong> Generation uses
+<code>@mermaid-js/mermaid-cli@11.16.0</code> with Puppeteer
+<code>25.5.0</code>, Node.js 22.12 or newer, and Pandoc 3 or newer. The
+complete Node dependency tree is checked into the skill as
+<code>package-lock.json</code> and installed with <code>npm ci</code>.
+Mermaid CLI provides broad Mermaid compatibility and renders locally.
+Its Chromium dependency makes the first render slower and larger than a
+hand-written SVG path, but it does not become part of the output
+file.</p>
+</div>
+<div class="source-block" data-source-block="29"
+data-source-sha256="e8192fde89d6e59e22293f87c7da1e7b0da1804c84368bf2604b4c8a49e386c3">
+<p><strong>Deny renderer network access.</strong> Before invoking
+Mermaid CLI, the generator rejects Mermaid source containing remote or
+local resource syntax, Mermaid initialization directives, icon-pack
+syntax, CSS <code>url()</code> or <code>@import</code>, HTML image or
+link elements, protocol-relative URLs, and <code>http:</code>,
+<code>https:</code>, <code>file:</code>, or <code>data:</code> URLs.
+Chromium keeps its sandbox enabled and starts with a deny-all proxy plus
+host resolution rules that map every host to failure. Remote
+configuration and icon packs are not loaded. After rendering, a
+parser-based SVG allowlist either accepts the whole diagram or rejects
+it. It never edits an unsafe diagram into a different one.</p>
+</div>
+<div class="source-block" data-source-block="30"
+data-source-sha256="b287fe0724e3011782e389b5faaf0f9c74db7c80221fca41049e81c4a36e5a6f">
+<p><strong>Fail the whole candidate when a diagram fails.</strong> A
+missing renderer, Mermaid parse error, sanitizer rejection, or browser
+failure is a generation failure. The skill reports the failing diagram
+and keeps the previous valid HTML byte-for-byte unchanged. Publishing a
+code-block fallback was rejected because readers could mistake a
+degraded page for a verified result.</p>
+</div>
+<div class="source-block" data-source-block="31"
+data-source-sha256="f6239bbea6e347c4a60372e4b05376add457eb4d1e1763b10be459afa42aad20">
 <p><strong>Use one restrained visual system for both document
 kinds.</strong> Both layouts share typography, spacing, navigation,
 metadata, tables, code, and print behavior. PRDs emphasize users, goals,
 requirements, and measures. Designs emphasize system context, decisions,
 invariants, interfaces, failures, and risks. Separate templates would
 drift and add little value.</p>
+</div>
+<div class="source-block" data-source-block="32"
+data-source-sha256="528a1b9215c5596e9ba99b9b88443d946fba1329aa8aaa139d3b8244c543d1e7">
 <p><strong>Preserve source order and wording.</strong> Presentation
 treatments may group a heading with its own content, but may not
 summarize, rewrite, rank, or omit source claims. This keeps the HTML
 trustworthy. A separate executive overview may appear only when that
 overview exists in the source.</p>
-</section>
-</section>
-<section id="5-invariants-and-requirements" class="level2">
+</div>
+<div class="source-block" data-source-block="33"
+data-source-sha256="d233a1797f1ce9d102a462cb4a38be357542cb9edc569956f4984bc0e3666a43">
+<p><strong>Define parity over canonical content.</strong> Parity
+compares the Markdown abstract syntax tree with the canonical
+document-content subtree inside <code>main</code>. It excludes
+navigation, machine metadata, visible source metadata, and derived
+accessibility text because those repeat or describe source content. Each
+top-level Markdown block maps to one signed content node in source
+order, with its nested content kept inside that node. A Mermaid block
+maps to one <code>figure</code>; its exact source appears once in a
+disclosure and its rendered image has a useful alternative derived from
+diagram labels.</p>
+</div>
+<div class="source-block" data-source-block="34"
+data-source-sha256="3372b60b5d3c3ae5564cbab55f68f226f2ad931f3b594dd610c3eb0f2a52985d">
+<p><strong>Finalize atomically.</strong> Generation creates a uniquely
+named candidate beside the output and takes an exclusive lock for that
+output. Only one render may target an output at a time. After structural
+and browser checks pass, one atomic replace operation installs the
+candidate without deleting the old output first. Normal failures and
+cancellation clean up the candidate and lock. A forced process kill may
+leave stale state, which the next run reports and requires the user to
+discard explicitly.</p>
+</div>
+<section id="5-invariants-and-requirements" class="source-block"
+data-source-block="35"
+data-source-sha256="a564a89ef16d655f45f32b2298c33c4d79e1b4129c3a882f233e5c6d85b55fc2">
 <h2>5. Invariants and requirements</h2>
-<section id="invariants" class="level3">
-<h3>Invariants</h3>
-<ol type="1">
-<li>Every source heading and content block appears once in the HTML and
-in the same order.</li>
-<li>The HTML introduces no new requirement, decision, claim, priority,
-or status.</li>
-<li>Content changes happen in Markdown, followed by regeneration.
-Generated HTML is not hand-edited.</li>
-<li>The generated page needs no network connection at read time.</li>
-<li>Navigation, reading order, and meaning remain usable without color,
-a mouse, or a wide screen.</li>
-<li>The page identifies the exact source content revision from which it
-was generated.</li>
-</ol>
 </section>
-<section id="requirements" class="level3">
+<section id="invariants" class="source-block role-invariants"
+data-source-block="36"
+data-source-sha256="41701f368993e3f63ab599cb3ebcf32756d56c298bf06612195e918bf86cd6b4">
+<h3>Invariants</h3>
+</section>
+<div class="source-block" data-source-block="37"
+data-source-sha256="702fddea4fe5fc25931aa970d724a09a38118cdc7eb5a79505b785dd280ba0ab">
+<ul>
+<li><code>INV-1</code>: Every top-level Markdown abstract-syntax-tree
+block maps to one signed canonical content node in the HTML and remains
+in source order, with nested content kept inside its parent and the
+documented Mermaid figure mapping as the only compound
+presentation.</li>
+<li><code>INV-2</code>: The HTML introduces no new requirement,
+decision, claim, priority, or status.</li>
+<li><code>INV-3</code>: Content changes happen in Markdown, followed by
+regeneration. Generated HTML is not hand-edited.</li>
+<li><code>INV-4</code>: The generated page needs no network connection
+at read time.</li>
+<li><code>INV-5</code>: Navigation, reading order, and meaning remain
+usable without color, a mouse, or a wide screen.</li>
+<li><code>INV-6</code>: The page identifies the exact source content
+revision from which it was generated.</li>
+<li><code>INV-7</code>: A failed diagram, structural check, browser
+check, or final replacement never changes the previous valid
+output.</li>
+<li><code>INV-8</code>: Only one active render may target an output, and
+every normal failure or cancellation removes its candidate and
+lock.</li>
+</ul>
+</div>
+<section id="requirements" class="source-block role-requirements"
+data-source-block="38"
+data-source-sha256="d58a3741c408d72bf8e99cb9c99f055d7cabeda3c3b4d006597446e8412a7e76">
 <h3>Requirements</h3>
+</section>
+<div class="source-block" data-source-block="39"
+data-source-sha256="407b41436a48af4ddb0a1051d1e292a9977809b7215a1432b6e9b0c83586ab43">
 <ul>
 <li>Accept a repository-relative or absolute Markdown path. Also accept
 exact inline Markdown when the user explicitly provides the full
 document.</li>
 <li>Support <code>prd</code> and <code>design</code> document kinds.
-Prefer an explicit kind and use heading-based detection only when
-unambiguous.</li>
+Require an explicit kind except when the source basename is exactly
+<code>prd.md</code> or <code>design.md</code>.</li>
 <li>Write <code>&lt;source-basename&gt;.html</code> beside the source by
 default. Accept an explicit output path.</li>
 <li>Leave the Markdown source unchanged.</li>
@@ -767,6 +601,8 @@ SHA-256 source hash in the page header.</li>
 headings.</li>
 <li>Give stable, readable anchor IDs to headings and deduplicate
 repeated headings with numeric suffixes.</li>
+<li>Ensure every emitted DOM ID is unique. Repeated desktop and mobile
+navigation must not duplicate IDs.</li>
 <li>Render Markdown paragraphs, emphasis, links, lists, tasks, tables,
 blockquotes, code, and fenced diagrams without data loss.</li>
 <li>Use specific treatments for summary, goals, non-goals, requirements,
@@ -778,152 +614,284 @@ stylesheet for A4 and US Letter.</li>
 <li>Verify the result in a real browser before reporting
 completion.</li>
 </ul>
-</section>
-</section>
-<section id="6-interfaces-and-data" class="level2">
+</div>
+<section id="6-interfaces-and-data" class="source-block"
+data-source-block="40"
+data-source-sha256="c031b53bb441f0ffee3273a73ce9f61efab706f92df0957046bc404cf8ffd544">
 <h2>6. Interfaces and data</h2>
+</section>
+<div class="source-block" data-source-block="41"
+data-source-sha256="701f676b7d592ce3acb056de0ac3287f8913d04c39d53605b0831b214dfd166c">
 <p>The skill accepts these request shapes:</p>
+</div>
+<div class="source-block" data-source-block="42"
+data-source-sha256="8444af08ece1309ac2c0f16941dfaa16d692877bc1d9ad1ddbf6e8dbb350096f">
 <pre class="text"><code>/html-doc docs/billing/prd.md
 /html-doc docs/billing/design.md as design
 /html-doc docs/billing/design.md --out artifacts/billing-design.html</code></pre>
+</div>
+<div class="source-block" data-source-block="43"
+data-source-sha256="df2e0f991fe223bb09c8d7136b326900e5a150de7613c04750fe060625968b24">
 <p>The syntax describes intent rather than a shell command. The skill
 resolves paths from the repository root, unless the user gives an
 absolute path.</p>
+</div>
+<div class="source-block" data-source-block="44"
+data-source-sha256="ab61ba53227b5370212ab54b2bbca61f22e3ff988ffe8281afe31578ffea70d8">
 <p>The generated page includes machine-readable metadata:</p>
-<div class="sourceCode" id="cb3"><pre
-class="sourceCode html"><code class="sourceCode html"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="dt">&lt;</span><span class="kw">meta</span><span class="ot"> name</span><span class="op">=</span><span class="st">&quot;document-kind&quot;</span><span class="ot"> content</span><span class="op">=</span><span class="st">&quot;design&quot;</span><span class="dt">&gt;</span></span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="dt">&lt;</span><span class="kw">meta</span><span class="ot"> name</span><span class="op">=</span><span class="st">&quot;source-path&quot;</span><span class="ot"> content</span><span class="op">=</span><span class="st">&quot;docs/billing/design.md&quot;</span><span class="dt">&gt;</span></span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="dt">&lt;</span><span class="kw">meta</span><span class="ot"> name</span><span class="op">=</span><span class="st">&quot;source-sha256&quot;</span><span class="ot"> content</span><span class="op">=</span><span class="st">&quot;...&quot;</span><span class="dt">&gt;</span></span>
-<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a><span class="dt">&lt;</span><span class="kw">meta</span><span class="ot"> name</span><span class="op">=</span><span class="st">&quot;generator&quot;</span><span class="ot"> content</span><span class="op">=</span><span class="st">&quot;blueprint/html-doc@1&quot;</span><span class="dt">&gt;</span></span></code></pre></div>
+</div>
+<div class="source-block" data-source-block="45"
+data-source-sha256="0a3d579bf484592f6a1440727510f4637ce4c813d12a66a55a64e00460e1166c">
+<pre class="html"><code>&lt;meta name=&quot;document-kind&quot; content=&quot;design&quot;&gt;
+&lt;meta name=&quot;source-path&quot; content=&quot;docs/billing/design.md&quot;&gt;
+&lt;meta name=&quot;source-sha256&quot; content=&quot;...&quot;&gt;
+&lt;meta name=&quot;generator&quot; content=&quot;blueprint/html-doc@1&quot;&gt;</code></pre>
+</div>
+<div class="source-block" data-source-block="46"
+data-source-sha256="e585cc5a8079a92adc102dfc7a41f969613031007a18e99ef2633ecb2925eeae">
 <p>The visible header repeats the document kind, source path, and source
-status. It does not show a generation time because timestamps create
-noisy diffs without proving content identity.</p>
+status. V1 recognizes status only from an exact leading blockquote in
+the form <code>&gt; **Status:** &lt;value&gt;</code>. When that field is
+absent, the visible status is omitted. It does not show a generation
+time because timestamps create noisy diffs without proving content
+identity.</p>
+</div>
+<div class="source-block" data-source-block="47"
+data-source-sha256="04c62926f0d9762a923521aa86ff407e7ca4f0b56017a268b33c2b3a6d0a81c2">
+<p>The <code>document-kind</code> metadata value is always the canonical
+lowercase value <code>prd</code> or <code>design</code>. The visible
+header may show the human labels <code>PRD</code> or
+<code>Technical design</code>.</p>
+</div>
+<div class="source-block" data-source-block="48"
+data-source-sha256="e05bdf160cf6cff903a4097315db828b6719b6db418419ad24fde00793640397">
 <p>Heading IDs use a lowercase ASCII slug made from visible heading
 text. Runs of other characters become one hyphen. Leading and trailing
 hyphens are removed. An empty result becomes <code>section</code>.
 Repeated IDs receive <code>-2</code>, <code>-3</code>, and so on in
-source order. Existing explicit IDs are preserved when they are valid
-and unique.</p>
-<section id="naming-and-identity" class="level3">
+source order. Explicit source IDs are not supported in V1 because they
+are not part of the selected GitHub-Flavored Markdown input
+contract.</p>
+</div>
+<section id="naming-and-identity" class="source-block"
+data-source-block="49"
+data-source-sha256="8d3d7b7a1af98b0dfa8eb94237680e19b796bb68dc456be15450d239907cc0ab">
 <h3>Naming and identity</h3>
+</section>
+<div class="source-block" data-source-block="50"
+data-source-sha256="17905b2f4dc8c9f56079e528efe1e1aeedac2faddcecb37b17491384b7b5e3d8">
 <p>The source file path identifies the document. Its SHA-256 hash
 identifies the rendered revision. Renaming the source changes the
 default output path but not its content identity. If the source is
 missing or unreadable, the skill creates no output. Inline Markdown has
 no durable source path, so the skill requires an explicit output path
 and records <code>inline-input</code> as the source.</p>
-</section>
-</section>
-<section id="7-failure-behavior-and-lifecycle" class="level2">
+</div>
+<section id="7-failure-behavior-and-lifecycle"
+class="source-block role-failures" data-source-block="51"
+data-source-sha256="caf163a2a6ae29594c9aceec85019732d86f557465622ee179014fdfedcee686">
 <h2>7. Failure behavior and lifecycle</h2>
+</section>
+<div class="source-block" data-source-block="52"
+data-source-sha256="5e7ffab2b344662d01f18c703e090281b62963dbf8b882847d824cdbb0caf1df">
 <ul>
 <li>A missing, unreadable, or non-Markdown source stops generation and
 names the failed path.</li>
-<li>An ambiguous document kind stops generation and asks for
-<code>prd</code> or <code>design</code>.</li>
+<li>A source whose basename is not exactly <code>prd.md</code> or
+<code>design.md</code> and has no explicit kind stops generation and
+asks for <code>prd</code> or <code>design</code>.</li>
 <li>Invalid Markdown is preserved as visible text where safe. The skill
 reports the affected source location instead of silently dropping
 it.</li>
-<li>A diagram that cannot be rendered remains as a clearly labeled code
-block. The skill reports that browser proof is incomplete.</li>
+<li>A missing Mermaid renderer, Mermaid parse error, or rejected SVG
+stops generation and names the failing diagram. No candidate becomes the
+final output.</li>
 <li>Unsafe raw HTML is escaped by default. If the user explicitly
 permits trusted raw HTML, it is sanitized before inclusion.</li>
 <li>An existing output file is overwritten only when its generator
 metadata points to the same source path, or when the user explicitly
 chose that output. Otherwise the skill stops to avoid replacing
 unrelated work.</li>
-<li>A failed generation or browser check does not replace a previously
-valid output. Generation writes a temporary sibling file, verifies it,
-then moves it into place.</li>
+<li>Generation takes an exclusive lock for the exact output and writes a
+uniquely named sibling candidate. If a live lock already exists, it
+stops instead of running concurrently.</li>
+<li>A failed generation, structural check, browser check, or final
+replacement does not replace a previously valid output. After all checks
+pass, generation calls one atomic replacement operation. It never
+deletes the old output first.</li>
+<li>Normal failures and cancellation remove the candidate and lock. A
+forced process kill may leave a stale candidate and lock. A later run
+reports their exact paths and requires an explicit discard action before
+trying again.</li>
 <li>Regeneration replaces the entire generated page. It never attempts
 to merge hand edits.</li>
 <li>The skill stops after the HTML passes parity and browser checks. It
 does not publish or host the file.</li>
 </ul>
-</section>
-<section id="8-security-privacy-and-operations" class="level2">
+</div>
+<section id="8-security-privacy-and-operations" class="source-block"
+data-source-block="53"
+data-source-sha256="d373a802adb9444e8d300217a0222856fa057b13255436c0f4709f894158a5f1">
 <h2>8. Security, privacy, and operations</h2>
+</section>
+<div class="source-block" data-source-block="54"
+data-source-sha256="a1ef90793e1aeb80f3f8dfa26f965974cb0bc1859bc748c36afe6103e078fc78">
 <p>Markdown is untrusted input. Text and attributes are HTML-escaped.
 Links allow <code>http</code>, <code>https</code>, <code>mailto</code>,
 relative paths, and fragment targets. Other URL schemes are rendered as
 text. External links use <code>rel="noopener noreferrer"</code>.</p>
-<p>Generated SVG allows only the elements and attributes needed for
-diagrams. It excludes scripts, event attributes, embedded HTML, and
-remote resources. The page uses no runtime JavaScript. A restrictive
-content security policy blocks scripts, objects, frames, and network
-connections.</p>
+</div>
+<div class="source-block" data-source-block="55"
+data-source-sha256="d4c4a2240bdc4add16cdb4c97c4e8853c8129626d39e94889ee7962cf0eea816">
+<p>Mermaid CLI runs locally at generation time with a locked version and
+a fixed strict configuration. Before rendering, the generator rejects
+resource-bearing source syntax, initialization directives, icon packs,
+CSS imports and URLs, HTML resource elements, and remote, local-file, or
+data URLs. Chromium keeps its sandbox enabled and starts with a deny-all
+proxy plus host-resolution rules that fail every host. The generator
+then parses the SVG and accepts only documented elements, attributes,
+and fragment references. Any disallowed construct rejects the whole
+diagram. The browser loads accepted SVG only through an <code>img</code>
+data URL, which isolates it from the document DOM. The page uses no
+runtime JavaScript. A restrictive content security policy blocks
+scripts, objects, frames, and network connections.</p>
+</div>
+<div class="source-block" data-source-block="56"
+data-source-sha256="4ee22b4b3589c8a29b3d67f2dc7b094858636547a4e9543fce04c33679c9e4d5">
+<p>Generation requires Node.js 22.12 or newer, Pandoc 3 or newer, and
+npm. The skill installs the exact checked-in dependency tree with
+<code>npm ci</code>. Puppeteer may download its locked Chromium build
+during installation, before document content is read. The skill checks
+these dependencies before creating a candidate and never sends source
+content to a service.</p>
+</div>
+<div class="source-block" data-source-block="57"
+data-source-sha256="76aa6e87f82e7e36ff4e9b708e03688de26eb67a7eacf7db22ac0cb757eeca33">
 <p>The skill reads one source file and writes one output file. A default
 maximum source size of 2 MiB prevents accidental rendering of generated
 data or logs. The skill stops with a clear error at that limit. It never
 sends document content to an external service.</p>
-</section>
-<section id="9-acceptance-criteria" class="level2">
+</div>
+<section id="9-acceptance-criteria"
+class="source-block role-acceptance-criteria" data-source-block="58"
+data-source-sha256="6d76b4820d002f28fcf60404f54b3b5893667240dd3e86def26e97bd7b6ad68d">
 <h2>9. Acceptance criteria</h2>
-<ul>
-<li>Given representative PRD and design Markdown fixtures, the skill
-creates sibling HTML pages and leaves both sources byte-for-byte
-unchanged.</li>
-<li>Every source heading, paragraph, list item, table cell, code block,
-and diagram label appears once and in source order in the rendered
-document.</li>
-<li>The page header contains the correct kind, source path, status, and
-SHA-256 hash.</li>
-<li>Repeated, Unicode-only, and punctuation-only headings receive unique
-working anchors according to the naming rules.</li>
-<li>The table of contents links to every second-level and third-level
-heading.</li>
-<li>A generated page opens from disk with network access disabled and
-has no failed runtime resource requests.</li>
-<li>At 390, 768, and 1440 CSS pixels, text does not overlap, navigation
-remains usable, code scrolls within its container, and tables remain
-readable without widening the page.</li>
-<li>Keyboard-only navigation can reach the skip link, table of contents,
-document links, and section targets in a clear order with a visible
-focus indicator.</li>
-<li>Screen-reader inspection finds one page title, one <code>main</code>
-landmark, ordered headings without skipped levels introduced by the
-template, useful link names, and text alternatives for diagrams.</li>
-<li>Print preview on A4 and US Letter hides navigation, preserves
-headings with their first content block where practical, repeats table
-headers, and does not clip code or diagrams.</li>
-<li>Script tags, event attributes, unsafe URL schemes, embedded HTML,
-and remote SVG resources in a hostile fixture do not execute or enter
-the generated DOM.</li>
-<li>A browser check failure or interrupted generation leaves the
-previous verified output unchanged.</li>
-<li>An unrelated existing HTML file is not overwritten without explicit
-user direction.</li>
-</ul>
 </section>
-<section id="10-test-approach" class="level2">
+<div class="source-block" data-source-block="59"
+data-source-sha256="729f29221212c1a3e9edc3609a78fad04723f498903fdecc1cf610420788ce70">
+<ul>
+<li><code>AC-1</code>: Given representative PRD and design Markdown
+fixtures, the skill creates sibling HTML pages and leaves both sources
+byte-for-byte unchanged.</li>
+<li><code>AC-2</code>: Every top-level Markdown abstract-syntax-tree
+block maps to one signed node in the canonical content subtree and
+remains in source order, with nested content kept in its parent.
+Navigation, metadata, and derived accessibility text are excluded from
+parity. Each Mermaid block maps to one figure whose exact source appears
+once in a disclosure.</li>
+<li><code>AC-3</code>: The page header contains the correct visible
+kind, source path, status, and SHA-256 hash, while
+<code>document-kind</code> metadata contains canonical <code>prd</code>
+or <code>design</code>.</li>
+<li><code>AC-4</code>: Repeated, Unicode-only, and punctuation-only
+headings receive unique working anchors according to the naming rules,
+and every emitted DOM ID is unique.</li>
+<li><code>AC-5</code>: The table of contents links to every second-level
+and third-level heading.</li>
+<li><code>AC-6</code>: A generated page opens from disk with network
+access disabled and has no failed runtime resource requests.</li>
+<li><code>AC-7</code>: At 390, 768, and 1440 CSS pixels, text does not
+overlap, navigation remains usable, code scrolls within its container,
+and tables remain readable without widening the page.</li>
+<li><code>AC-8</code>: Keyboard-only navigation can reach the skip link,
+table of contents, document links, and section targets in a clear order
+with a visible focus indicator.</li>
+<li><code>AC-9</code>: Screen-reader inspection finds one page title,
+one <code>main</code> landmark, ordered headings without skipped levels
+introduced by the template, useful link names, and text alternatives for
+diagrams.</li>
+<li><code>AC-10</code>: Print preview on A4 and US Letter hides
+navigation, preserves headings with their first content block where
+practical, repeats table headers, and does not clip code or
+diagrams.</li>
+<li><code>AC-11</code>: Script tags, event attributes, unsafe URL
+schemes, embedded HTML, external CSS imports, and remote SVG resources
+in a hostile fixture do not execute or enter the generated DOM.</li>
+<li><code>AC-12</code>: Resource-bearing Mermaid is rejected before
+renderer launch. A denied renderer request, Mermaid parse failure, SVG
+allowlist rejection, browser check failure, final replacement failure,
+or interrupted generation leaves the previous verified output
+byte-for-byte unchanged.</li>
+<li><code>AC-13</code>: An unrelated existing HTML file is not
+overwritten without explicit user direction.</li>
+<li><code>AC-14</code>: In a clean environment, <code>npm ci</code>
+installs the exact locked Mermaid CLI and Puppeteer versions and renders
+the representative Mermaid fixture.</li>
+<li><code>AC-15</code>: Concurrent renders for one output cannot both
+proceed. Normal failures remove their candidate and lock, while stale
+state from a forced kill is reported and can be discarded
+explicitly.</li>
+</ul>
+</div>
+<section id="10-test-approach" class="source-block"
+data-source-block="60"
+data-source-sha256="c12e936da26b05f551bb9244d0b3c7384b2d3d340c374095d6baea0e971a43de">
 <h2>10. Test approach</h2>
-<ul>
-<li>Keep one compact PRD fixture and one compact design fixture
-containing every supported Markdown block and semantic section.</li>
-<li>Compare extracted normalized text and block order between each
-source and generated page. Separately assert source files are
-unchanged.</li>
-<li>Use hostile Markdown fixtures for raw HTML, unsafe links, SVG
-content, duplicate headings, deeply nested lists, wide tables, and long
-unbroken code.</li>
-<li>Serve nothing and disable browser networking while opening each
-output through a local file URL.</li>
-<li>Run browser checks at 390, 768, and 1440 CSS pixels. Capture
-screenshots for review and inspect overflow, focus order, landmarks,
-headings, anchors, and console errors.</li>
-<li>Open print preview for A4 and US Letter and inspect each page for
-clipping and isolated headings.</li>
-<li>Force diagram conversion, verification, and final replacement
-failures. Confirm that each failure is reported and that an earlier
-valid output remains byte-for-byte unchanged.</li>
-<li>Run the repository's skill review against the new instruction and
-template. Check that <code>/html-doc</code> stays a presentation outcome
-and does not duplicate PRD or design decisions.</li>
-</ul>
 </section>
-<section id="11-risks-and-tradeoffs" class="level2">
+<div class="source-block" data-source-block="61"
+data-source-sha256="0d183f723c571ebca400ca44ae1f79faa011ede18821e5198d63d38896093b5c">
+<ul>
+<li>Prove <code>INV-1</code>, <code>INV-2</code>, <code>AC-1</code>, and
+<code>AC-2</code> with compact PRD and design fixtures containing every
+supported Markdown block and semantic section. Compare signed top-level
+abstract-syntax-tree blocks, rendered text, and canonical content-node
+order, apply the documented Mermaid figure mapping, and assert that the
+sources are unchanged.</li>
+<li>Prove <code>INV-6</code> and <code>AC-3</code> by checking visible
+metadata, canonical machine metadata, and the SHA-256 source hash.</li>
+<li>Prove <code>INV-5</code>, <code>AC-4</code>, <code>AC-5</code>,
+<code>AC-7</code>, <code>AC-8</code>, and <code>AC-9</code> with
+repeated, Unicode-only, and punctuation-only headings plus real-browser
+checks at 390, 768, and 1440 CSS pixels. Inspect overflow, keyboard
+focus, landmarks, headings, anchors, diagram alternatives, console
+errors, and unique DOM IDs.</li>
+<li>Prove <code>INV-4</code> and <code>AC-6</code> by serving nothing,
+disabling browser networking, and opening the output through a local
+file URL when browser policy permits. Otherwise use a local static
+server and separately assert that no runtime URL can leave the
+file.</li>
+<li>Prove <code>AC-10</code> by opening print preview for A4 and US
+Letter and inspecting each page for clipping and isolated headings.</li>
+<li>Prove <code>INV-7</code>, <code>INV-8</code>, <code>AC-11</code>,
+<code>AC-12</code>, <code>AC-13</code>, and <code>AC-15</code> with
+hostile Markdown and SVG fixtures, invalid Mermaid, a controlled
+endpoint that records attempted requests, a forced browser failure, a
+simulated final replacement failure, normal interruption, concurrent
+renders, stale-state recovery, and an unrelated existing output. Confirm
+that unsafe Mermaid is rejected before renderer launch, renderer network
+requests cannot reach the endpoint, each failure is reported, normal
+cleanup occurs, and an earlier valid output remains byte-for-byte
+unchanged.</li>
+<li>Prove <code>INV-3</code> by regenerating a fixture and confirming
+that the generator replaces the whole candidate instead of merging hand
+edits.</li>
+<li>Prove <code>AC-14</code> from an environment without
+<code>node_modules</code>: run <code>npm ci</code>, assert the installed
+package versions match the lockfile, and render the representative
+Mermaid fixture.</li>
+<li>Run the repository's skill review against the new instruction,
+renderer, script, and template. Check that <code>/html-doc</code> stays
+a presentation outcome and does not duplicate PRD or design
+decisions.</li>
+</ul>
+</div>
+<section id="11-risks-and-tradeoffs" class="source-block role-risks"
+data-source-block="62"
+data-source-sha256="1285aaa4ffd2e9469718aff3ada6282e941a59e9a8b79073a130a46b00ce69bd">
 <h2>11. Risks and tradeoffs</h2>
-<div class="table-wrap" role="region" aria-label="Scrollable table" tabindex="0">
+</section>
+<div class="source-block table-wrap" data-source-block="63"
+data-source-sha256="c5296b65263dd3d679ec2b189a2816838c07d2a9ea376ddcca8ee7b37ee439a6">
 <table>
 <thead>
 <tr>
@@ -956,32 +924,38 @@ edits</td>
 fixtures</td>
 </tr>
 <tr>
-<td>Offline diagram generation varies by environment</td>
-<td>A document can lose its clearest visual</td>
-<td>Bundle or pin the generation path during implementation and retain
-labeled source fallback</td>
+<td>Mermaid CLI and Chromium add a large generation dependency</td>
+<td>First use is slower and may fail on constrained machines</td>
+<td>Pin both packages, check dependencies before writing, and fail
+without replacing the previous output</td>
 </tr>
 </tbody>
 </table>
 </div>
-</section>
-<section id="12-open-questions" class="level2">
+<section id="12-open-questions" class="source-block role-open-questions"
+data-source-block="64"
+data-source-sha256="9a814093a20806bc5a44c69acb6ee4c27c516199b03238efaf23de1e8b4e534d">
 <h2>12. Open questions</h2>
+</section>
+<div class="source-block" data-source-block="65"
+data-source-sha256="e49d6eb7ae5d55dcd35d6597372b7f953d9c82e5b89044f1faa24f56c82f56e1">
 <ul>
 <li>Should generated HTML be committed beside Markdown by default, or
-treated as a local review artifact? This changes repository policy and
-does not block implementing the skill.</li>
-<li>Which pinned diagram renderer can meet the offline, sanitization,
-and portability requirements without adding a large bundle? This blocks
-implementation of rendered Mermaid diagrams.</li>
-<li>Does the first version need exact text parity for inline formatting
-such as footnotes and definition lists, or may unsupported syntax remain
-in a source block? This blocks final fixture selection, not the basic
-workflow.</li>
+treated as a local review artifact? The recommended default is a local
+review artifact unless repository policy says generated files are
+committed. This does not block implementation.</li>
+<li>V1 supports GitHub-Flavored Markdown as parsed by Pandoc. Other
+Markdown extensions are out of scope and must be enabled by a later
+design. This does not block implementation.</li>
 </ul>
-</section>
-<section id="13-out-of-scope" class="level2">
+</div>
+<section id="13-out-of-scope" class="source-block"
+data-source-block="66"
+data-source-sha256="c22168596a4b1b1829bac627abf17561e31167099a31c6893f97bddab585a496">
 <h2>13. Out of scope</h2>
+</section>
+<div class="source-block" data-source-block="67"
+data-source-sha256="cc9fa8154818d81cfb4e70ed772d4849b0ec81e9f19e5c2686453bb8b76be87d">
 <ul>
 <li>Deciding PRD content, product priorities, or technical
 architecture</li>
@@ -992,10 +966,10 @@ architecture</li>
 <li>Slide decks or marketing pages</li>
 <li>Live synchronization between Markdown and an open browser</li>
 </ul>
-</section>
-</section>
+</div>
+
     </main>
   </div>
-  <footer>Generated from <strong>docs/html-doc/design.md</strong> by blueprint/html-doc@1</footer>
+  <footer class="document-footer">Generated from docs/html-doc/design.md by blueprint/html-doc@1. Edit the Markdown source, then regenerate.</footer>
 </body>
 </html>

--- a/docs/html-doc/design.md
+++ b/docs/html-doc/design.md
@@ -34,11 +34,11 @@ The authoring step owns meaning. `/html-doc` owns presentation. Review comments 
 
 ### How it works
 
-A user invokes `/html-doc` with a Markdown path and may state whether it is a PRD or design document. The skill reads the complete source and detects the kind only when the user did not provide it. It refuses to guess when the structure is ambiguous.
+A user invokes `/html-doc` with a Markdown path and states whether it is a PRD or design document. The kind may be omitted only when the source basename is exactly `prd.md` or `design.md`. The skill does not infer the kind from headings or prose.
 
 The skill copies the bundled HTML template to a sibling output such as `docs/payments/prd.html`. It maps the source into semantic HTML in the same order. It adds a document header, status and source metadata, a linked table of contents, and presentation treatments based on section meaning. Unknown sections remain normal sections and are never dropped.
 
-The page uses semantic HTML, inline CSS, and no runtime JavaScript. Mermaid diagrams become sanitized inline SVG during generation and retain an accessible text description. The result works as a local file without a server or network connection.
+The page uses semantic HTML, inline CSS, and no runtime JavaScript. During generation, the exact dependency tree recorded in the skill lockfile renders Mermaid blocks with `@mermaid-js/mermaid-cli@11.16.0` and Puppeteer `25.5.0`. The generator rejects resource-bearing Mermaid source before rendering, runs Chromium with network resolution and proxy access denied, validates each SVG against an allowlist, embeds it as a base64 data image, and keeps the exact Mermaid source in a disclosure below the image. The result works as a local file without a server or network connection.
 
 The skill opens the result in a real browser. It checks desktop and mobile widths, keyboard navigation, diagrams, long tables, code blocks, links, and print preview. It compares the rendered content with the source. It fixes presentation defects in the generated file or template, but sends content defects back to the source.
 
@@ -69,6 +69,7 @@ On narrow screens, the contents move above the document and the page becomes one
 | --- | --- | --- | --- |
 | `SKILL.md` | Input rules, generation workflow, parity checks, browser proof, and stop condition | Repository policy and supplied source | Product or technical decisions |
 | HTML template | Page structure, design tokens, responsive layout, print rules, and accessibility defaults | Browser standards | Document content |
+| Render script | Markdown conversion, diagram rendering, sanitization, metadata, and structural checks | Pandoc, Node.js, and pinned Mermaid CLI and Puppeteer packages | Content decisions or browser proof |
 | Generated HTML | One reviewable view of one source revision | Markdown source and template | Canonical content or later edits |
 | Markdown source | All claims, requirements, decisions, and document order | Its authoring workflow | Browser presentation |
 
@@ -78,32 +79,45 @@ On narrow screens, the contents move above the document and the page becomes one
 
 **Make the skill presentation-only.** `/design` already owns technical design in this repository. Letting `/html-doc` also settle requirements or architecture would create two conflicting workflows. A user with only a rough idea must first supply or create the source document.
 
-**Generate a static, offline page.** The output uses inline CSS and generated inline SVG with no fonts, scripts, images, or style sheets fetched at runtime. This makes a file easy to share and avoids broken pages behind network or content-security restrictions. It costs more generation work than loading a web framework.
+**Generate a static, offline page.** The output uses inline CSS and sanitized, base64-embedded SVG images with no fonts, scripts, images, or style sheets fetched at runtime. This makes a file easy to share and avoids broken pages behind network or content-security restrictions. It costs more generation work than loading a web framework.
+
+**Lock the Mermaid renderer.** Generation uses `@mermaid-js/mermaid-cli@11.16.0` with Puppeteer `25.5.0`, Node.js 22.12 or newer, and Pandoc 3 or newer. The complete Node dependency tree is checked into the skill as `package-lock.json` and installed with `npm ci`. Mermaid CLI provides broad Mermaid compatibility and renders locally. Its Chromium dependency makes the first render slower and larger than a hand-written SVG path, but it does not become part of the output file.
+
+**Deny renderer network access.** Before invoking Mermaid CLI, the generator rejects Mermaid source containing remote or local resource syntax, Mermaid initialization directives, icon-pack syntax, CSS `url()` or `@import`, HTML image or link elements, protocol-relative URLs, and `http:`, `https:`, `file:`, or `data:` URLs. Chromium keeps its sandbox enabled and starts with a deny-all proxy plus host resolution rules that map every host to failure. Remote configuration and icon packs are not loaded. After rendering, a parser-based SVG allowlist either accepts the whole diagram or rejects it. It never edits an unsafe diagram into a different one.
+
+**Fail the whole candidate when a diagram fails.** A missing renderer, Mermaid parse error, sanitizer rejection, or browser failure is a generation failure. The skill reports the failing diagram and keeps the previous valid HTML byte-for-byte unchanged. Publishing a code-block fallback was rejected because readers could mistake a degraded page for a verified result.
 
 **Use one restrained visual system for both document kinds.** Both layouts share typography, spacing, navigation, metadata, tables, code, and print behavior. PRDs emphasize users, goals, requirements, and measures. Designs emphasize system context, decisions, invariants, interfaces, failures, and risks. Separate templates would drift and add little value.
 
 **Preserve source order and wording.** Presentation treatments may group a heading with its own content, but may not summarize, rewrite, rank, or omit source claims. This keeps the HTML trustworthy. A separate executive overview may appear only when that overview exists in the source.
 
+**Define parity over canonical content.** Parity compares the Markdown abstract syntax tree with the canonical document-content subtree inside `main`. It excludes navigation, machine metadata, visible source metadata, and derived accessibility text because those repeat or describe source content. Each top-level Markdown block maps to one signed content node in source order, with its nested content kept inside that node. A Mermaid block maps to one `figure`; its exact source appears once in a disclosure and its rendered image has a useful alternative derived from diagram labels.
+
+**Finalize atomically.** Generation creates a uniquely named candidate beside the output and takes an exclusive lock for that output. Only one render may target an output at a time. After structural and browser checks pass, one atomic replace operation installs the candidate without deleting the old output first. Normal failures and cancellation clean up the candidate and lock. A forced process kill may leave stale state, which the next run reports and requires the user to discard explicitly.
+
 ## 5. Invariants and requirements
 
 ### Invariants
 
-1. Every source heading and content block appears once in the HTML and in the same order.
-2. The HTML introduces no new requirement, decision, claim, priority, or status.
-3. Content changes happen in Markdown, followed by regeneration. Generated HTML is not hand-edited.
-4. The generated page needs no network connection at read time.
-5. Navigation, reading order, and meaning remain usable without color, a mouse, or a wide screen.
-6. The page identifies the exact source content revision from which it was generated.
+- `INV-1`: Every top-level Markdown abstract-syntax-tree block maps to one signed canonical content node in the HTML and remains in source order, with nested content kept inside its parent and the documented Mermaid figure mapping as the only compound presentation.
+- `INV-2`: The HTML introduces no new requirement, decision, claim, priority, or status.
+- `INV-3`: Content changes happen in Markdown, followed by regeneration. Generated HTML is not hand-edited.
+- `INV-4`: The generated page needs no network connection at read time.
+- `INV-5`: Navigation, reading order, and meaning remain usable without color, a mouse, or a wide screen.
+- `INV-6`: The page identifies the exact source content revision from which it was generated.
+- `INV-7`: A failed diagram, structural check, browser check, or final replacement never changes the previous valid output.
+- `INV-8`: Only one active render may target an output, and every normal failure or cancellation removes its candidate and lock.
 
 ### Requirements
 
 - Accept a repository-relative or absolute Markdown path. Also accept exact inline Markdown when the user explicitly provides the full document.
-- Support `prd` and `design` document kinds. Prefer an explicit kind and use heading-based detection only when unambiguous.
+- Support `prd` and `design` document kinds. Require an explicit kind except when the source basename is exactly `prd.md` or `design.md`.
 - Write `<source-basename>.html` beside the source by default. Accept an explicit output path.
 - Leave the Markdown source unchanged.
 - Show title, document kind, status when supplied, source path, and a SHA-256 source hash in the page header.
 - Add a linked table of contents for second-level and third-level headings.
 - Give stable, readable anchor IDs to headings and deduplicate repeated headings with numeric suffixes.
+- Ensure every emitted DOM ID is unique. Repeated desktop and mobile navigation must not duplicate IDs.
 - Render Markdown paragraphs, emphasis, links, lists, tasks, tables, blockquotes, code, and fenced diagrams without data loss.
 - Use specific treatments for summary, goals, non-goals, requirements, acceptance criteria, decisions, invariants, failures, risks, and open questions when those sections exist.
 - Include responsive styles for a 390-pixel viewport and a print stylesheet for A4 and US Letter.
@@ -131,9 +145,11 @@ The generated page includes machine-readable metadata:
 <meta name="generator" content="blueprint/html-doc@1">
 ```
 
-The visible header repeats the document kind, source path, and source status. It does not show a generation time because timestamps create noisy diffs without proving content identity.
+The visible header repeats the document kind, source path, and source status. V1 recognizes status only from an exact leading blockquote in the form `> **Status:** <value>`. When that field is absent, the visible status is omitted. It does not show a generation time because timestamps create noisy diffs without proving content identity.
 
-Heading IDs use a lowercase ASCII slug made from visible heading text. Runs of other characters become one hyphen. Leading and trailing hyphens are removed. An empty result becomes `section`. Repeated IDs receive `-2`, `-3`, and so on in source order. Existing explicit IDs are preserved when they are valid and unique.
+The `document-kind` metadata value is always the canonical lowercase value `prd` or `design`. The visible header may show the human labels `PRD` or `Technical design`.
+
+Heading IDs use a lowercase ASCII slug made from visible heading text. Runs of other characters become one hyphen. Leading and trailing hyphens are removed. An empty result becomes `section`. Repeated IDs receive `-2`, `-3`, and so on in source order. Explicit source IDs are not supported in V1 because they are not part of the selected GitHub-Flavored Markdown input contract.
 
 ### Naming and identity
 
@@ -142,12 +158,14 @@ The source file path identifies the document. Its SHA-256 hash identifies the re
 ## 7. Failure behavior and lifecycle
 
 - A missing, unreadable, or non-Markdown source stops generation and names the failed path.
-- An ambiguous document kind stops generation and asks for `prd` or `design`.
+- A source whose basename is not exactly `prd.md` or `design.md` and has no explicit kind stops generation and asks for `prd` or `design`.
 - Invalid Markdown is preserved as visible text where safe. The skill reports the affected source location instead of silently dropping it.
-- A diagram that cannot be rendered remains as a clearly labeled code block. The skill reports that browser proof is incomplete.
+- A missing Mermaid renderer, Mermaid parse error, or rejected SVG stops generation and names the failing diagram. No candidate becomes the final output.
 - Unsafe raw HTML is escaped by default. If the user explicitly permits trusted raw HTML, it is sanitized before inclusion.
 - An existing output file is overwritten only when its generator metadata points to the same source path, or when the user explicitly chose that output. Otherwise the skill stops to avoid replacing unrelated work.
-- A failed generation or browser check does not replace a previously valid output. Generation writes a temporary sibling file, verifies it, then moves it into place.
+- Generation takes an exclusive lock for the exact output and writes a uniquely named sibling candidate. If a live lock already exists, it stops instead of running concurrently.
+- A failed generation, structural check, browser check, or final replacement does not replace a previously valid output. After all checks pass, generation calls one atomic replacement operation. It never deletes the old output first.
+- Normal failures and cancellation remove the candidate and lock. A forced process kill may leave a stale candidate and lock. A later run reports their exact paths and requires an explicit discard action before trying again.
 - Regeneration replaces the entire generated page. It never attempts to merge hand edits.
 - The skill stops after the HTML passes parity and browser checks. It does not publish or host the file.
 
@@ -155,36 +173,41 @@ The source file path identifies the document. Its SHA-256 hash identifies the re
 
 Markdown is untrusted input. Text and attributes are HTML-escaped. Links allow `http`, `https`, `mailto`, relative paths, and fragment targets. Other URL schemes are rendered as text. External links use `rel="noopener noreferrer"`.
 
-Generated SVG allows only the elements and attributes needed for diagrams. It excludes scripts, event attributes, embedded HTML, and remote resources. The page uses no runtime JavaScript. A restrictive content security policy blocks scripts, objects, frames, and network connections.
+Mermaid CLI runs locally at generation time with a locked version and a fixed strict configuration. Before rendering, the generator rejects resource-bearing source syntax, initialization directives, icon packs, CSS imports and URLs, HTML resource elements, and remote, local-file, or data URLs. Chromium keeps its sandbox enabled and starts with a deny-all proxy plus host-resolution rules that fail every host. The generator then parses the SVG and accepts only documented elements, attributes, and fragment references. Any disallowed construct rejects the whole diagram. The browser loads accepted SVG only through an `img` data URL, which isolates it from the document DOM. The page uses no runtime JavaScript. A restrictive content security policy blocks scripts, objects, frames, and network connections.
+
+Generation requires Node.js 22.12 or newer, Pandoc 3 or newer, and npm. The skill installs the exact checked-in dependency tree with `npm ci`. Puppeteer may download its locked Chromium build during installation, before document content is read. The skill checks these dependencies before creating a candidate and never sends source content to a service.
 
 The skill reads one source file and writes one output file. A default maximum source size of 2 MiB prevents accidental rendering of generated data or logs. The skill stops with a clear error at that limit. It never sends document content to an external service.
 
 ## 9. Acceptance criteria
 
-- Given representative PRD and design Markdown fixtures, the skill creates sibling HTML pages and leaves both sources byte-for-byte unchanged.
-- Every source heading, paragraph, list item, table cell, code block, and diagram label appears once and in source order in the rendered document.
-- The page header contains the correct kind, source path, status, and SHA-256 hash.
-- Repeated, Unicode-only, and punctuation-only headings receive unique working anchors according to the naming rules.
-- The table of contents links to every second-level and third-level heading.
-- A generated page opens from disk with network access disabled and has no failed runtime resource requests.
-- At 390, 768, and 1440 CSS pixels, text does not overlap, navigation remains usable, code scrolls within its container, and tables remain readable without widening the page.
-- Keyboard-only navigation can reach the skip link, table of contents, document links, and section targets in a clear order with a visible focus indicator.
-- Screen-reader inspection finds one page title, one `main` landmark, ordered headings without skipped levels introduced by the template, useful link names, and text alternatives for diagrams.
-- Print preview on A4 and US Letter hides navigation, preserves headings with their first content block where practical, repeats table headers, and does not clip code or diagrams.
-- Script tags, event attributes, unsafe URL schemes, embedded HTML, and remote SVG resources in a hostile fixture do not execute or enter the generated DOM.
-- A browser check failure or interrupted generation leaves the previous verified output unchanged.
-- An unrelated existing HTML file is not overwritten without explicit user direction.
+- `AC-1`: Given representative PRD and design Markdown fixtures, the skill creates sibling HTML pages and leaves both sources byte-for-byte unchanged.
+- `AC-2`: Every top-level Markdown abstract-syntax-tree block maps to one signed node in the canonical content subtree and remains in source order, with nested content kept in its parent. Navigation, metadata, and derived accessibility text are excluded from parity. Each Mermaid block maps to one figure whose exact source appears once in a disclosure.
+- `AC-3`: The page header contains the correct visible kind, source path, status, and SHA-256 hash, while `document-kind` metadata contains canonical `prd` or `design`.
+- `AC-4`: Repeated, Unicode-only, and punctuation-only headings receive unique working anchors according to the naming rules, and every emitted DOM ID is unique.
+- `AC-5`: The table of contents links to every second-level and third-level heading.
+- `AC-6`: A generated page opens from disk with network access disabled and has no failed runtime resource requests.
+- `AC-7`: At 390, 768, and 1440 CSS pixels, text does not overlap, navigation remains usable, code scrolls within its container, and tables remain readable without widening the page.
+- `AC-8`: Keyboard-only navigation can reach the skip link, table of contents, document links, and section targets in a clear order with a visible focus indicator.
+- `AC-9`: Screen-reader inspection finds one page title, one `main` landmark, ordered headings without skipped levels introduced by the template, useful link names, and text alternatives for diagrams.
+- `AC-10`: Print preview on A4 and US Letter hides navigation, preserves headings with their first content block where practical, repeats table headers, and does not clip code or diagrams.
+- `AC-11`: Script tags, event attributes, unsafe URL schemes, embedded HTML, external CSS imports, and remote SVG resources in a hostile fixture do not execute or enter the generated DOM.
+- `AC-12`: Resource-bearing Mermaid is rejected before renderer launch. A denied renderer request, Mermaid parse failure, SVG allowlist rejection, browser check failure, final replacement failure, or interrupted generation leaves the previous verified output byte-for-byte unchanged.
+- `AC-13`: An unrelated existing HTML file is not overwritten without explicit user direction.
+- `AC-14`: In a clean environment, `npm ci` installs the exact locked Mermaid CLI and Puppeteer versions and renders the representative Mermaid fixture.
+- `AC-15`: Concurrent renders for one output cannot both proceed. Normal failures remove their candidate and lock, while stale state from a forced kill is reported and can be discarded explicitly.
 
 ## 10. Test approach
 
-- Keep one compact PRD fixture and one compact design fixture containing every supported Markdown block and semantic section.
-- Compare extracted normalized text and block order between each source and generated page. Separately assert source files are unchanged.
-- Use hostile Markdown fixtures for raw HTML, unsafe links, SVG content, duplicate headings, deeply nested lists, wide tables, and long unbroken code.
-- Serve nothing and disable browser networking while opening each output through a local file URL.
-- Run browser checks at 390, 768, and 1440 CSS pixels. Capture screenshots for review and inspect overflow, focus order, landmarks, headings, anchors, and console errors.
-- Open print preview for A4 and US Letter and inspect each page for clipping and isolated headings.
-- Force diagram conversion, verification, and final replacement failures. Confirm that each failure is reported and that an earlier valid output remains byte-for-byte unchanged.
-- Run the repository's skill review against the new instruction and template. Check that `/html-doc` stays a presentation outcome and does not duplicate PRD or design decisions.
+- Prove `INV-1`, `INV-2`, `AC-1`, and `AC-2` with compact PRD and design fixtures containing every supported Markdown block and semantic section. Compare signed top-level abstract-syntax-tree blocks, rendered text, and canonical content-node order, apply the documented Mermaid figure mapping, and assert that the sources are unchanged.
+- Prove `INV-6` and `AC-3` by checking visible metadata, canonical machine metadata, and the SHA-256 source hash.
+- Prove `INV-5`, `AC-4`, `AC-5`, `AC-7`, `AC-8`, and `AC-9` with repeated, Unicode-only, and punctuation-only headings plus real-browser checks at 390, 768, and 1440 CSS pixels. Inspect overflow, keyboard focus, landmarks, headings, anchors, diagram alternatives, console errors, and unique DOM IDs.
+- Prove `INV-4` and `AC-6` by serving nothing, disabling browser networking, and opening the output through a local file URL when browser policy permits. Otherwise use a local static server and separately assert that no runtime URL can leave the file.
+- Prove `AC-10` by opening print preview for A4 and US Letter and inspecting each page for clipping and isolated headings.
+- Prove `INV-7`, `INV-8`, `AC-11`, `AC-12`, `AC-13`, and `AC-15` with hostile Markdown and SVG fixtures, invalid Mermaid, a controlled endpoint that records attempted requests, a forced browser failure, a simulated final replacement failure, normal interruption, concurrent renders, stale-state recovery, and an unrelated existing output. Confirm that unsafe Mermaid is rejected before renderer launch, renderer network requests cannot reach the endpoint, each failure is reported, normal cleanup occurs, and an earlier valid output remains byte-for-byte unchanged.
+- Prove `INV-3` by regenerating a fixture and confirming that the generator replaces the whole candidate instead of merging hand edits.
+- Prove `AC-14` from an environment without `node_modules`: run `npm ci`, assert the installed package versions match the lockfile, and render the representative Mermaid fixture.
+- Run the repository's skill review against the new instruction, renderer, script, and template. Check that `/html-doc` stays a presentation outcome and does not duplicate PRD or design decisions.
 
 ## 11. Risks and tradeoffs
 
@@ -194,13 +217,12 @@ The skill reads one source file and writes one output file. A default maximum so
 | Visual treatment changes meaning | A callout can imply priority or status not present in source | Map only known section roles and preserve wording and order |
 | Generated HTML creates noisy diffs | Pull requests become harder to review | Keep output deterministic and omit timestamps or random IDs |
 | Complex Markdown exceeds the template | Content is clipped or dropped | Preserve unknown blocks plainly and prove parity with adversarial fixtures |
-| Offline diagram generation varies by environment | A document can lose its clearest visual | Bundle or pin the generation path during implementation and retain labeled source fallback |
+| Mermaid CLI and Chromium add a large generation dependency | First use is slower and may fail on constrained machines | Pin both packages, check dependencies before writing, and fail without replacing the previous output |
 
 ## 12. Open questions
 
-- Should generated HTML be committed beside Markdown by default, or treated as a local review artifact? This changes repository policy and does not block implementing the skill.
-- Which pinned diagram renderer can meet the offline, sanitization, and portability requirements without adding a large bundle? This blocks implementation of rendered Mermaid diagrams.
-- Does the first version need exact text parity for inline formatting such as footnotes and definition lists, or may unsupported syntax remain in a source block? This blocks final fixture selection, not the basic workflow.
+- Should generated HTML be committed beside Markdown by default, or treated as a local review artifact? The recommended default is a local review artifact unless repository policy says generated files are committed. This does not block implementation.
+- V1 supports GitHub-Flavored Markdown as parsed by Pandoc. Other Markdown extensions are out of scope and must be enabled by a later design. This does not block implementation.
 
 ## 13. Out of scope
 

--- a/skills/html-doc/SKILL.md
+++ b/skills/html-doc/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: html-doc
+description: Generates a polished, static HTML reading view from an existing Markdown PRD or technical design. Use when a user asks to render, present, visualize, or make a PRD or design document easier for humans to read in a browser.
+---
+
+# HTML document
+
+Turn one complete Markdown PRD or technical design into one verified static HTML page. Keep Markdown canonical. Change presentation, not meaning.
+
+## Boundaries
+
+- Accept an existing Markdown file or exact inline Markdown.
+- Support only `prd` and `design` document kinds.
+- Infer the kind only from the exact basename `prd.md` or `design.md`. Otherwise require the user or request to name it.
+- Do not write requirements, settle design choices, summarize missing content, or edit the source.
+- If the source is only a rough brief, use the appropriate authoring skill first.
+- Do not hand-edit generated HTML. Change the template or renderer, then regenerate.
+- Do not publish or host the result unless the user separately asks.
+
+## Requirements
+
+Generation requires Python 3.11 or newer, Pandoc 3 or newer, Node.js 22.12 or newer, and npm. The skill directory contains a locked Mermaid dependency tree.
+
+Before the first Mermaid render, run:
+
+```bash
+npm ci --prefix <skill-directory>
+```
+
+Use `scripts/html_doc.py` from this skill directory for all generation and lifecycle operations.
+
+## Workflow
+
+### 1. Read and classify the source
+
+Read the complete source. Confirm it is no larger than 2 MiB. Determine the document kind from the request or the exact basename rule.
+
+Treat content problems separately from presentation problems. If the Markdown contradicts itself, omits a required decision, or contains an invalid diagram, report that source problem. Do not silently repair its meaning.
+
+### 2. Create a candidate
+
+For a file source:
+
+```bash
+python3 <skill-directory>/scripts/html_doc.py render <source.md> --kind <prd-or-design> --out <output.html>
+```
+
+`--kind` may be omitted only for exact `prd.md` and `design.md` basenames. `--out` may be omitted to create a sibling HTML file.
+
+For exact inline Markdown, pipe it through standard input and provide both kind and output:
+
+```bash
+python3 <skill-directory>/scripts/html_doc.py render --inline --kind <prd-or-design> --out <output.html>
+```
+
+The command returns JSON containing `candidate`, `output`, and `token`. It does not replace the final output. Keep those exact values for verification and finalization.
+
+If an output lock already exists, do not delete it automatically. It may represent another pending render. Report its path. Use `discard --force-stale` only when the state is known to be abandoned.
+
+### 3. Verify the candidate in a real browser
+
+Open the candidate as a local file. Do not treat source inspection as browser proof.
+
+Check all of these:
+
+- desktop at 1440 CSS pixels;
+- tablet at 768 CSS pixels;
+- mobile at 390 CSS pixels;
+- A4 and US Letter print preview;
+- table-of-contents links and section targets;
+- keyboard order from skip link through navigation and document links;
+- visible focus indicators;
+- one `main` landmark and a sensible heading outline;
+- unique DOM IDs;
+- horizontal overflow, clipped text, code, tables, and diagrams;
+- useful diagram alternatives and accessible disclosure controls;
+- console errors and failed resource requests;
+- operation with browser network access disabled.
+
+Compare the canonical content inside `main` with the Markdown abstract syntax tree. Navigation, source metadata, and derived accessibility text are not canonical content. Each top-level source block must map to one ordered `data-source-block` node with its SHA-256 identity and nested content intact. A Mermaid block maps to one figure whose exact source appears once in its disclosure.
+
+If a presentation defect comes from the shared renderer or styles, fix that source and regenerate. If it is a content defect, leave the source and candidate unchanged and report it.
+
+### 4. Finalize or discard
+
+Only after every check passes, atomically install the candidate:
+
+```bash
+python3 <skill-directory>/scripts/html_doc.py finalize --out <output.html> --token <token>
+```
+
+If any check fails, remove only this pending candidate:
+
+```bash
+python3 <skill-directory>/scripts/html_doc.py discard --out <output.html> --token <token>
+```
+
+Finalization performs one same-directory atomic replacement. It never deletes the previous output first. A failed render, check, or replacement must leave the previous verified output byte-for-byte unchanged.
+
+## Output standard
+
+The final page must:
+
+- preserve source wording and order;
+- use canonical `prd` or `design` machine metadata;
+- record the source path and SHA-256 hash;
+- use semantic HTML, inline CSS, and no runtime JavaScript;
+- contain no external runtime assets;
+- use a restrained blue-grey visual system;
+- remain readable without color, a mouse, a wide screen, or network access;
+- include responsive and print styles;
+- embed validated Mermaid SVG as a base64 image and retain the exact source in a disclosure.
+
+Stop when the verified candidate is finalized. Report the output path, source hash, and browser checks performed.

--- a/skills/html-doc/assets/mermaid.json
+++ b/skills/html-doc/assets/mermaid.json
@@ -1,0 +1,19 @@
+{
+  "securityLevel": "strict",
+  "htmlLabels": false,
+  "flowchart": {
+    "htmlLabels": false,
+    "useMaxWidth": true
+  },
+  "theme": "base",
+  "themeVariables": {
+    "background": "#f7f9fb",
+    "primaryColor": "#dbe5ec",
+    "primaryTextColor": "#172630",
+    "primaryBorderColor": "#60798a",
+    "lineColor": "#526a79",
+    "secondaryColor": "#edf2f5",
+    "tertiaryColor": "#f7f9fb",
+    "fontFamily": "Inter, ui-sans-serif, system-ui, sans-serif"
+  }
+}

--- a/skills/html-doc/assets/puppeteer.json
+++ b/skills/html-doc/assets/puppeteer.json
@@ -1,0 +1,11 @@
+{
+  "args": [
+    "--proxy-server=http://127.0.0.1:9",
+    "--proxy-bypass-list=<-loopback>",
+    "--host-resolver-rules=MAP * ~NOTFOUND",
+    "--disable-background-networking",
+    "--disable-component-update",
+    "--disable-domain-reliability",
+    "--disable-sync"
+  ]
+}

--- a/skills/html-doc/assets/styles.css
+++ b/skills/html-doc/assets/styles.css
@@ -1,0 +1,203 @@
+:root {
+  color-scheme: light;
+  --paper: #f7f9fb;
+  --surface: #ffffff;
+  --surface-soft: #edf2f5;
+  --ink: #172630;
+  --muted: #526773;
+  --line: #ccd8df;
+  --line-strong: #8fa5b3;
+  --accent: #385e75;
+  --accent-soft: #dbe5ec;
+  --focus: #176b93;
+  --risk: #6b4f28;
+  --risk-soft: #f3ecdf;
+  --radius: 12px;
+  --shadow: 0 16px 42px rgb(31 54 68 / 10%);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; background: var(--paper); }
+a { color: var(--accent); text-underline-offset: 0.16em; }
+a:hover { text-decoration-thickness: 2px; }
+a:focus-visible, summary:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 10;
+  left: 1rem;
+  top: 1rem;
+  padding: .65rem .9rem;
+  background: var(--ink);
+  color: white;
+  transform: translateY(-180%);
+}
+.skip-link:focus { transform: translateY(0); }
+
+.document-header {
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(145deg, #e5edf2 0%, #f7f9fb 70%);
+}
+.document-header__inner,
+.page-shell,
+.document-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin-inline: auto;
+}
+.document-header__inner { padding: 3.8rem 0 3rem; }
+.eyebrow {
+  margin: 0 0 .8rem;
+  color: var(--accent);
+  font-size: .78rem;
+  font-weight: 750;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+.document-title {
+  max-width: 900px;
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2.25rem, 5vw, 4.6rem);
+  font-weight: 500;
+  line-height: 1.05;
+  letter-spacing: -.035em;
+}
+.metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .55rem 1.25rem;
+  margin: 1.6rem 0 0;
+  color: var(--muted);
+  font-size: .88rem;
+}
+.metadata dt { font-weight: 700; color: var(--ink); }
+.metadata dd { margin: 0; overflow-wrap: anywhere; }
+.metadata__item { display: grid; grid-template-columns: auto 1fr; gap: .35rem; }
+
+.page-shell {
+  display: grid;
+  grid-template-columns: minmax(190px, 250px) minmax(0, 1fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: start;
+  padding-block: 3rem 5rem;
+}
+.toc {
+  position: sticky;
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+  padding: 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgb(255 255 255 / 78%);
+}
+.toc-title { margin: 0 0 .75rem; font: 750 .78rem/1.2 Inter, sans-serif; letter-spacing: .09em; text-transform: uppercase; }
+.toc ol { list-style: none; padding: 0; margin: 0; }
+.toc li + li { margin-top: .34rem; }
+.toc li[data-level="3"] { padding-left: .8rem; font-size: .88rem; }
+.toc a { display: block; color: var(--muted); text-decoration: none; line-height: 1.35; }
+.toc a:hover { color: var(--ink); }
+
+.document-content {
+  min-width: 0;
+  padding: clamp(1.4rem, 4vw, 3.8rem);
+  border: 1px solid var(--line);
+  border-radius: calc(var(--radius) + 4px);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+.source-block { min-width: 0; }
+.source-block > :first-child { margin-top: 0; }
+.source-block > :last-child { margin-bottom: 0; }
+.source-block + .source-block { margin-top: 1rem; }
+.source-block:has(> h1), .source-block:has(> h2) { margin-top: 3.7rem; }
+.source-block:first-child { margin-top: 0; }
+h1, h2, h3, h4 { color: var(--ink); line-height: 1.2; scroll-margin-top: 1.5rem; }
+.document-content h1 { font: 500 clamp(2rem, 5vw, 3.2rem)/1.08 Georgia, serif; letter-spacing: -.025em; }
+.document-content h2 { padding-top: .4rem; font: 500 clamp(1.7rem, 3vw, 2.3rem)/1.15 Georgia, serif; letter-spacing: -.018em; }
+.document-content h3 { font-size: 1.12rem; }
+.document-content h4 { font-size: 1rem; }
+p, ul, ol, blockquote, pre, table, figure { margin-block: 1rem; }
+blockquote {
+  margin-inline: 0;
+  padding: .8rem 1rem;
+  border-left: 4px solid var(--line-strong);
+  background: var(--surface-soft);
+  color: #314854;
+}
+blockquote > :first-child { margin-top: 0; }
+blockquote > :last-child { margin-bottom: 0; }
+.role-requirements, .role-acceptance-criteria, .role-invariants,
+.role-decisions, .role-risks, .role-open-questions {
+  margin-top: 1.25rem;
+  padding: 1rem 1.2rem;
+  border-left: 4px solid var(--line-strong);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  background: var(--surface-soft);
+}
+.role-risks, .role-open-questions { border-left-color: var(--risk); background: var(--risk-soft); }
+code, pre { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
+code { padding: .12em .32em; border-radius: 4px; background: var(--surface-soft); font-size: .9em; }
+pre {
+  max-width: 100%;
+  overflow: auto;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #132630;
+  color: #edf4f7;
+  line-height: 1.48;
+}
+pre code { padding: 0; background: transparent; color: inherit; }
+.table-wrap { max-width: 100%; overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; font-size: .93rem; }
+th, td { padding: .68rem .75rem; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+th { background: var(--surface-soft); font-weight: 720; }
+tbody tr:nth-child(even) { background: #f9fbfc; }
+.diagram {
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: #fbfcfd;
+}
+.diagram img { display: block; width: 100%; height: auto; max-height: 650px; object-fit: contain; }
+.diagram figcaption { margin-top: .75rem; color: var(--muted); font-size: .86rem; }
+.diagram details { margin-top: .8rem; }
+.diagram summary { cursor: pointer; color: var(--accent); font-weight: 650; }
+.diagram details pre { max-height: 18rem; }
+.document-footer { padding: 0 0 3rem; color: var(--muted); font-size: .82rem; }
+
+@media (max-width: 760px) {
+  .document-header__inner { padding: 2.7rem 0 2.2rem; }
+  .page-shell { grid-template-columns: 1fr; gap: 1.2rem; padding-top: 1.25rem; }
+  .toc { position: static; max-height: none; }
+  .document-content { padding: 1.25rem; border-radius: var(--radius); }
+  .source-block:has(> h1), .source-block:has(> h2) { margin-top: 2.7rem; }
+}
+
+@media print {
+  :root { background: white; font-size: 10.5pt; }
+  @page { size: auto; margin: 16mm; }
+  .skip-link, .toc { display: none; }
+  .document-header { background: white; }
+  .document-header__inner, .page-shell, .document-footer { width: 100%; }
+  .document-header__inner { padding: 0 0 12mm; }
+  .document-title { font-size: 28pt; }
+  .page-shell { display: block; padding: 0; }
+  .document-content { padding: 0; border: 0; box-shadow: none; }
+  h1, h2, h3, h4 { break-after: avoid-page; }
+  table, figure, pre, blockquote { break-inside: avoid; }
+  thead { display: table-header-group; }
+  pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+  .document-footer { padding: 10mm 0 0; }
+}

--- a/skills/html-doc/package-lock.json
+++ b/skills/html-doc/package-lock.json
@@ -1,0 +1,2304 @@
+{
+  "name": "blueprint-html-doc",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "blueprint-html-doc",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mermaid-js/mermaid-cli": "11.16.0",
+        "puppeteer": "25.5.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.1.tgz",
+      "integrity": "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@headlessui/react/node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@headlessui/tailwindcss": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.2.2.tgz",
+      "integrity": "sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0 || ^4.0"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
+      "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.10.tgz",
+      "integrity": "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@mermaid-js/layout-elk": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.2.2.tgz",
+      "integrity": "sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/layout-tidy-tree": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-tidy-tree/-/layout-tidy-tree-0.2.2.tgz",
+      "integrity": "sha512-8RmjDXjKJBxqTS1mICStm8zWRM45fSzs0SOrkp28+KsOGS2YEMFMVTwwRU8CsC6M1L+pDYZVjf1m9AC1c9Wndg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "d3": "^7.9.0"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-cli": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-11.16.0.tgz",
+      "integrity": "sha512-0InK2nbVIMtzVzCugmdvPkAuvS6wRUqU6Utntff1n8c7lgfRZAdhKY6PSKvcIK9nFmuOUzAgB5+x/XWcroZ7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.0.0 || ^7.0.1",
+        "@mermaid-js/layout-elk": "^0.1.5 || ^0.2.0",
+        "@mermaid-js/mermaid-zenuml": "^0.2.0",
+        "chalk": "^5.0.1",
+        "commander": "^13.1.0",
+        "import-meta-resolve": "^4.1.0",
+        "katex": "^0.16.25",
+        "mermaid": "^11.14.0",
+        "p-limit": "^6.2.0"
+      },
+      "bin": {
+        "mmdc": "src/cli.js"
+      },
+      "engines": {
+        "node": "^18.19 || >=20.0"
+      },
+      "optionalDependencies": {
+        "@mermaid-js/layout-tidy-tree": "^0.2.1"
+      },
+      "peerDependencies": {
+        "puppeteer": "^23 || ^24 || ^25"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-zenuml": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-zenuml/-/mermaid-zenuml-0.2.3.tgz",
+      "integrity": "sha512-RGBtgL6fc+5Y2Jm9odOH9HRJ80BP4l6atBYnAK5bBzEowF0PU3UtvZRRcbFxImPGPuLIzqZq31ur8lVO0AoF3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zenuml/core": "^3.47.0"
+      },
+      "peerDependencies": {
+        "mermaid": "^10 || ^11"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.1.0.tgz",
+      "integrity": "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.1.tgz",
+      "integrity": "sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.1.tgz",
+      "integrity": "sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.1.tgz",
+      "integrity": "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@zenuml/core": {
+      "version": "3.50.1",
+      "resolved": "https://registry.npmjs.org/@zenuml/core/-/core-3.50.1.tgz",
+      "integrity": "sha512-Q18BXvIfhRuGw0JfO4e+pltG04Phhv2E7n35EWTNSZKKH/HEkyE4Sh7KERb9dqaOfjOdRdKvLG0YekjK3fcDXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "@headlessui/react": "^2.2.9",
+        "@headlessui/tailwindcss": "^0.2.2",
+        "antlr4": "~4.11.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "color-string": "^2.1.4",
+        "dompurify": "^3.3.1",
+        "highlight.js": "^11.10.0",
+        "html-to-image": "^1.11.13",
+        "jotai": "^2.16.1",
+        "marked": "^4.3.0",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
+        "tailwind-merge": "^3.4.0"
+      },
+      "bin": {
+        "zenuml": "dist/cli/zenuml.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.97"
+      },
+      "peerDependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "peerDependenciesMeta": {
+        "playwright-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/antlr4": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.11.0.tgz",
+      "integrity": "sha512-GUGlpE2JUjAN+G8G5vY+nOoeyNhHsXoIJwP1XF1oRw89vifA1K46T6SEkwLwr7drihN7I/lf0DIjKc4OZvBX8w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1653615",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
+      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/elkjs": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+      "license": "EPL-2.0"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.2.tgz",
+      "integrity": "sha512-oaXMACAU0kzOMXBjWpNcX+vlwSBCIAiZ9BHa7gA15NOTtT2L/l8OSZDuqS2XppOhZBPJ7hm4o8ep2kyuip2uEQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.20.2.tgz",
+      "integrity": "sha512-aHB4CNb9qRcyf0mwSB6EO5bCGAjx8cTwFgOFCE2leOnTzqACbnSWG8XoWB3LxCT1Qoj03I1OWAHszDmN4uHb/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0",
+        "@babel/template": ">=7.0.0",
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.5.0.tgz",
+      "integrity": "sha512-qpp73xblxNr+bF0nSXTodM3v+zcK5IPo/GkjLsdUqRf/qpLJp/1KxBUbstoMMnwnPw9xD6OMei8kmYf6CLWfGw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.1.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.5.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.5.0.tgz",
+      "integrity": "sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.1.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.51.0.tgz",
+      "integrity": "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.3",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.49.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.49.0.tgz",
+      "integrity": "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.3",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/skills/html-doc/package.json
+++ b/skills/html-doc/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "blueprint-html-doc",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Locked generation dependencies for the Blueprint html-doc skill",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "dependencies": {
+    "@mermaid-js/mermaid-cli": "11.16.0",
+    "puppeteer": "25.5.0"
+  }
+}

--- a/skills/html-doc/scripts/html_doc.py
+++ b/skills/html-doc/scripts/html_doc.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python3
+"""Generate and atomically install static HTML views of Markdown documents."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import html
+from html.parser import HTMLParser
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unicodedata
+import uuid
+import xml.etree.ElementTree as ET
+
+
+GENERATOR = "blueprint/html-doc@1"
+MAX_SOURCE_BYTES = 2 * 1024 * 1024
+SKILL_DIR = Path(__file__).resolve().parents[1]
+ASSETS_DIR = SKILL_DIR / "assets"
+
+RESOURCE_SOURCE_PATTERNS = (
+    re.compile(r"%%\{"),
+    re.compile(r"(?:https?|file|data):", re.IGNORECASE),
+    re.compile(r"(?<!:)//"),
+    re.compile(r"@import\b", re.IGNORECASE),
+    re.compile(r"\burl\s*\(", re.IGNORECASE),
+    re.compile(r"<\s*(?:img|link)\b", re.IGNORECASE),
+    re.compile(r"\b(?:icon|image):", re.IGNORECASE),
+)
+
+ALLOWED_SVG_ELEMENTS = {
+    "svg", "g", "path", "rect", "circle", "ellipse", "line", "polyline",
+    "polygon", "text", "tspan", "defs", "marker", "style", "title", "desc",
+    "clipPath", "linearGradient", "radialGradient", "stop", "filter", "feDropShadow",
+}
+ALLOWED_SVG_ATTRIBUTES = {
+    "id", "class", "style", "viewBox", "version", "baseProfile", "xmlns",
+    "role", "tabindex", "aria-label", "aria-labelledby", "aria-describedby",
+    "aria-roledescription", "width", "height", "x", "y", "x1", "y1", "x2",
+    "y2", "cx", "cy", "r", "rx", "ry", "d", "points", "transform", "fill",
+    "stroke", "stroke-width", "stroke-dasharray", "stroke-dashoffset",
+    "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "fill-opacity",
+    "stroke-opacity", "opacity", "marker-start", "marker-mid", "marker-end",
+    "orient", "refX", "refY", "markerWidth", "markerHeight", "markerUnits",
+    "preserveAspectRatio", "dominant-baseline", "alignment-baseline", "text-anchor",
+    "font-family", "font-size", "font-weight", "font-style", "letter-spacing", "dy",
+    "dx", "offset", "stop-color", "stop-opacity", "clip-path", "overflow", "color",
+    "shape-rendering", "vector-effect", "paint-order", "href", "filter", "flood-color",
+    "flood-opacity", "stdDeviation", "gradientUnits", "data-edge", "data-et", "data-id",
+    "data-look", "data-points",
+}
+UNSAFE_SVG_TEXT = re.compile(
+    r"(?:https?|file|data|javascript|vbscript):|@import\b|(?<!:)//", re.IGNORECASE
+)
+URL_FUNCTION = re.compile(r"url\s*\(([^)]*)\)", re.IGNORECASE)
+
+
+class GenerationError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, stdin: str | None = None) -> str:
+    result = subprocess.run(
+        command,
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode:
+        detail = (result.stderr or result.stdout).strip()
+        raise GenerationError(f"Command failed ({command[0]}): {detail}")
+    return result.stdout
+
+
+def version_tuple(value: str) -> tuple[int, ...]:
+    match = re.search(r"(\d+(?:\.\d+)+)", value)
+    if not match:
+        raise GenerationError(f"Could not parse version from {value!r}")
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def check_dependencies(require_mermaid: bool) -> None:
+    if version_tuple(run(["pandoc", "--version"]).splitlines()[0]) < (3, 0):
+        raise GenerationError("Pandoc 3 or newer is required")
+    if version_tuple(run(["node", "--version"])) < (22, 12):
+        raise GenerationError("Node.js 22.12 or newer is required")
+    if not require_mermaid:
+        return
+    mmdc = SKILL_DIR / "node_modules" / ".bin" / "mmdc"
+    if not mmdc.exists():
+        raise GenerationError(f"Mermaid dependencies are missing. Run `npm ci` in {SKILL_DIR}")
+    for package, expected in (("@mermaid-js/mermaid-cli", "11.16.0"), ("puppeteer", "25.5.0")):
+        package_file = SKILL_DIR / "node_modules" / package / "package.json"
+        try:
+            actual = json.loads(package_file.read_text())["version"]
+        except (FileNotFoundError, KeyError, json.JSONDecodeError) as error:
+            raise GenerationError(f"Cannot verify installed {package}: {error}") from error
+        if actual != expected:
+            raise GenerationError(f"Installed {package} is {actual}; expected {expected}. Run `npm ci`")
+
+
+def reject_resource_bearing_mermaid(source: str) -> None:
+    for pattern in RESOURCE_SOURCE_PATTERNS:
+        match = pattern.search(source)
+        if match:
+            raise GenerationError(
+                f"Mermaid source contains forbidden resource syntax near {match.group(0)!r}"
+            )
+
+
+def local_name(value: str) -> str:
+    return value.rsplit("}", 1)[-1]
+
+
+def validate_svg(svg: bytes) -> bytes:
+    decoded = svg.decode("utf-8")
+    if "<!DOCTYPE" in decoded.upper() or "<!ENTITY" in decoded.upper():
+        raise GenerationError("Rendered SVG contains a document type or entity")
+    try:
+        root = ET.fromstring(decoded)
+    except ET.ParseError as error:
+        raise GenerationError(f"Rendered SVG is invalid XML: {error}") from error
+    if local_name(root.tag) != "svg":
+        raise GenerationError("Rendered diagram root is not SVG")
+    for element in root.iter():
+        tag = local_name(element.tag)
+        if tag not in ALLOWED_SVG_ELEMENTS:
+            raise GenerationError(f"Rendered SVG contains forbidden element <{tag}>")
+        if element.text:
+            if tag == "style" and "\\" in element.text:
+                raise GenerationError("Rendered SVG style contains a CSS escape")
+            if UNSAFE_SVG_TEXT.search(element.text):
+                raise GenerationError(f"Rendered SVG <{tag}> contains a forbidden resource reference")
+            for url_value in URL_FUNCTION.findall(element.text):
+                if not url_value.strip(" \t\"'").startswith("#"):
+                    raise GenerationError("Rendered SVG style contains a non-fragment CSS URL")
+        for raw_name, value in element.attrib.items():
+            name = local_name(raw_name)
+            if name.lower().startswith("on") or name not in ALLOWED_SVG_ATTRIBUTES:
+                raise GenerationError(f"Rendered SVG contains forbidden attribute {name!r}")
+            if UNSAFE_SVG_TEXT.search(value):
+                raise GenerationError(f"Rendered SVG attribute {name!r} contains a resource URL")
+            if name in {
+                "style", "fill", "stroke", "filter", "clip-path", "marker-start",
+                "marker-mid", "marker-end", "href",
+            } and "\\" in value:
+                raise GenerationError(f"Rendered SVG attribute {name!r} contains a CSS escape")
+            if name == "href" and value and not value.startswith("#"):
+                raise GenerationError("Rendered SVG contains a non-fragment href")
+            for url_value in URL_FUNCTION.findall(value):
+                if not url_value.strip(" \t\"'").startswith("#"):
+                    raise GenerationError("Rendered SVG contains a non-fragment CSS URL")
+    return svg
+
+
+def render_mermaid(source: str, diagram_number: int) -> str:
+    reject_resource_bearing_mermaid(source)
+    mmdc = SKILL_DIR / "node_modules" / ".bin" / "mmdc"
+    with tempfile.TemporaryDirectory(prefix="blueprint-html-doc-") as temp_dir:
+        temp = Path(temp_dir)
+        source_path = temp / "diagram.mmd"
+        svg_path = temp / "diagram.svg"
+        source_path.write_text(source, encoding="utf-8")
+        run([
+            str(mmdc), "--quiet", "--input", str(source_path), "--output", str(svg_path),
+            "--configFile", str(ASSETS_DIR / "mermaid.json"),
+            "--puppeteerConfigFile", str(ASSETS_DIR / "puppeteer.json"),
+            "--backgroundColor", "transparent",
+        ])
+        svg = validate_svg(svg_path.read_bytes())
+    encoded = base64.b64encode(svg).decode("ascii")
+    escaped_source = html.escape(source)
+    alt = html.escape(diagram_description(source, diagram_number))
+    return (
+        f'<figure class="diagram source-block" data-source-block="diagram-{diagram_number}">'
+        f'<img alt="{alt}" src="data:image/svg+xml;base64,{encoded}">'
+        f'<figcaption>Diagram {diagram_number}</figcaption>'
+        '<details><summary>View Mermaid source</summary>'
+        f'<pre><code class="language-mermaid">{escaped_source}</code></pre>'
+        '</details></figure>'
+    )
+
+
+def diagram_description(source: str, diagram_number: int) -> str:
+    labels: list[str] = []
+    patterns = (r'\[\[?"?([^\]\["]+)"?\]\]?', r'\(\[?"?([^()\[]"]+)"?\]?\)', r'\|([^|]+)\|')
+    for pattern in patterns:
+        for value in re.findall(pattern, source):
+            clean = re.sub(r"\s+", " ", value).strip(" \t\"'")
+            if clean and clean not in labels:
+                labels.append(clean)
+    if not labels:
+        prose = re.sub(r"[-=<>()[\]{}|;]+", " ", " ".join(source.splitlines()[1:]))
+        prose = re.sub(r"\b(?:subgraph|end|click|classDef|style)\b", " ", prose, flags=re.IGNORECASE)
+        clean = re.sub(r"\s+", " ", prose).strip()
+        if clean:
+            labels.append(clean)
+    detail = ", ".join(labels)[:320] or "the relationships defined in the Mermaid source below"
+    return f"Diagram {diagram_number} showing {detail}"
+
+
+def inline_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(inline_text(item) for item in value)
+    if not isinstance(value, dict):
+        return ""
+    kind = value.get("t")
+    content = value.get("c")
+    if kind in {"Str", "Code", "Math"}:
+        if kind == "Str":
+            return str(content)
+        return str(content[-1])
+    if kind in {"Space", "SoftBreak", "LineBreak"}:
+        return " "
+    return inline_text(content)
+
+
+def slugify(value: str, used: set[str]) -> str:
+    normalized = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    base = re.sub(r"[^a-z0-9]+", "-", normalized.lower()).strip("-") or "section"
+    candidate = base
+    suffix = 2
+    while candidate in used:
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+    used.add(candidate)
+    return candidate
+
+
+def sanitize_links(node: object) -> None:
+    if isinstance(node, list):
+        for child in node:
+            sanitize_links(child)
+        return
+    if not isinstance(node, dict):
+        return
+    if node.get("t") in {"Link", "Image"}:
+        target = node["c"][2][0]
+        scheme = re.match(r"^([A-Za-z][A-Za-z0-9+.-]*):", target)
+        if scheme and scheme.group(1).lower() not in {"http", "https", "mailto"}:
+            node["t"] = "Span"
+            node["c"] = [node["c"][0], node["c"][1]]
+    sanitize_links(node.get("c"))
+
+
+def escape_raw_html(node: object) -> None:
+    if isinstance(node, list):
+        for child in node:
+            escape_raw_html(child)
+        return
+    if not isinstance(node, dict):
+        return
+    if node.get("t") == "RawBlock" and node.get("c", [None])[0] == "html":
+        node["t"] = "CodeBlock"
+        node["c"] = [["", ["raw-html"], []], node["c"][1]]
+        return
+    if node.get("t") == "RawInline" and node.get("c", [None])[0] == "html":
+        node["t"] = "Code"
+        node["c"] = [["", ["raw-html"], []], node["c"][1]]
+        return
+    escape_raw_html(node.get("c"))
+
+
+def role_for_heading(text: str) -> str | None:
+    key = re.sub(r"[^a-z]+", "-", text.lower()).strip("-")
+    roles = {
+        "executive-summary": "summary", "summary": "summary", "goals": "goals",
+        "non-goals": "non-goals", "requirements": "requirements",
+        "acceptance-criteria": "acceptance-criteria", "decisions": "decisions",
+        "invariants": "invariants", "failure-behavior": "failures",
+        "failure-behavior-and-lifecycle": "failures", "risks": "risks",
+        "risks-and-tradeoffs": "risks", "open-questions": "open-questions",
+    }
+    return roles.get(key)
+
+
+def pandoc_document(markdown: str) -> dict:
+    raw = run(["pandoc", "--from", "gfm-raw_html", "--to", "json"], stdin=markdown)
+    return json.loads(raw)
+
+
+def block_signature(block: dict) -> str:
+    encoded = json.dumps(block, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def transform_document(document: dict) -> tuple[str, list[tuple[int, str, str]], list[str]]:
+    used_ids: set[str] = {"document-content"}
+    toc: list[tuple[int, str, str]] = []
+    transformed: list[dict] = []
+    diagram_number = 0
+    source_blocks = document.get("blocks", [])
+    signatures = [block_signature(block) for block in source_blocks]
+    escape_raw_html(source_blocks)
+    sanitize_links(source_blocks)
+    for index, block in enumerate(source_blocks, start=1):
+        kind = block.get("t")
+        classes = block.get("c", [["", [], []]])[0][1] if kind == "CodeBlock" else []
+        if kind == "CodeBlock" and "mermaid" in classes:
+            diagram_number += 1
+            rendered = render_mermaid(block["c"][1], diagram_number)
+            rendered = rendered.replace(
+                f'data-source-block="diagram-{diagram_number}"',
+                f'data-source-block="{index}"',
+            )
+            rendered = rendered.replace(
+                '<figure class="diagram source-block"',
+                f'<figure class="diagram source-block" data-source-sha256="{signatures[index - 1]}"',
+            )
+            transformed.append({"t": "RawBlock", "c": ["html", rendered]})
+            continue
+        role = None
+        if kind == "Header":
+            level, attributes, inlines = block["c"]
+            text = inline_text(inlines).strip()
+            heading_id = slugify(text, used_ids)
+            attributes[0] = heading_id
+            role = role_for_heading(text)
+            if level in {2, 3}:
+                toc.append((level, heading_id, text))
+        wrapper_classes = ["source-block"]
+        if kind == "Table":
+            wrapper_classes.append("table-wrap")
+        if role:
+            wrapper_classes.append(f"role-{role}")
+        transformed.append({
+            "t": "Div",
+            "c": [["", wrapper_classes, [
+                ["data-source-block", str(index)],
+                ["data-source-sha256", signatures[index - 1]],
+            ]], [block]],
+        })
+    document["blocks"] = transformed
+    body = run(["pandoc", "--from", "json", "--to", "html5", "--no-highlight"], stdin=json.dumps(document))
+    body = re.sub(r'<a href="(https?://)', r'<a rel="noopener noreferrer" href="\1', body)
+    return body, toc, signatures
+
+
+def title_from_document(document: dict, fallback: str) -> str:
+    for block in document.get("blocks", []):
+        if block.get("t") == "Header" and block["c"][0] == 1:
+            title = inline_text(block["c"][2]).strip()
+            if title:
+                return title
+    return fallback
+
+
+def source_status(markdown: str) -> str | None:
+    match = re.match(r"\A# [^\n]+\n\n> \*\*Status:\*\* ([^\n]+)(?:\n|\Z)", markdown)
+    return match.group(1).strip() if match else None
+
+
+def toc_html(items: list[tuple[int, str, str]]) -> str:
+    links = "".join(
+        f'<li data-level="{level}"><a href="#{html.escape(anchor)}">{html.escape(text)}</a></li>'
+        for level, anchor, text in items
+    )
+    return f'<nav class="toc" aria-label="Document contents"><p class="toc-title">Contents</p><ol>{links}</ol></nav>'
+
+
+def render_page(
+    markdown: str,
+    kind: str,
+    source_label: str,
+    fallback_title: str,
+) -> tuple[str, int]:
+    document = pandoc_document(markdown)
+    title = title_from_document(document, fallback_title)
+    has_mermaid = any(
+        block.get("t") == "CodeBlock" and "mermaid" in block["c"][0][1]
+        for block in document.get("blocks", [])
+    )
+    check_dependencies(has_mermaid)
+    body, toc, source_signatures = transform_document(document)
+    source_block_count = len(source_signatures)
+    source_hash = hashlib.sha256(markdown.encode("utf-8")).hexdigest()
+    styles = (ASSETS_DIR / "styles.css").read_text(encoding="utf-8")
+    visible_kind = "PRD" if kind == "prd" else "Technical design"
+    status = source_status(markdown)
+    status_item = ""
+    if status:
+        status_item = (
+            '<div class="metadata__item"><dt>Status</dt>'
+            f'<dd>{html.escape(status)}</dd></div>'
+        )
+    page = f'''<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
+  <meta name="document-kind" content="{kind}">
+  <meta name="source-path" content="{html.escape(source_label, quote=True)}">
+  <meta name="source-sha256" content="{source_hash}">
+  <meta name="generator" content="{GENERATOR}">
+  <title>{html.escape(title)}</title>
+  <style>{styles}</style>
+</head>
+<body>
+  <a class="skip-link" href="#document-content">Skip to document</a>
+  <header class="document-header">
+    <div class="document-header__inner">
+      <p class="eyebrow">{visible_kind}</p>
+      <p class="document-title">{html.escape(title)}</p>
+      <dl class="metadata">
+        {status_item}
+        <div class="metadata__item"><dt>Source</dt><dd>{html.escape(source_label)}</dd></div>
+        <div class="metadata__item"><dt>SHA-256</dt><dd><code>{source_hash}</code></dd></div>
+      </dl>
+    </div>
+  </header>
+  <div class="page-shell">
+    {toc_html(toc)}
+    <main id="document-content" class="document-content" data-source-block-count="{source_block_count}">
+{body}
+    </main>
+  </div>
+  <footer class="document-footer">Generated from {html.escape(source_label)} by {GENERATOR}. Edit the Markdown source, then regenerate.</footer>
+</body>
+</html>
+'''
+    validate_html(page, source_signatures, kind, source_hash)
+    return page, source_block_count
+
+
+class StructureParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: list[str] = []
+        self.hrefs: list[str] = []
+        self.source_blocks: list[tuple[str, str]] = []
+        self.scripts = 0
+        self.external_resources: list[str] = []
+        self.metadata: dict[str, str] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if values.get("id"):
+            self.ids.append(values["id"] or "")
+        if values.get("data-source-block"):
+            self.source_blocks.append((
+                values["data-source-block"] or "",
+                values.get("data-source-sha256") or "",
+            ))
+        if tag == "a" and (values.get("href") or "").startswith("#"):
+            self.hrefs.append((values.get("href") or "")[1:])
+        if tag == "script":
+            self.scripts += 1
+        if tag in {"img", "link", "iframe", "object", "embed", "source"}:
+            resource = values.get("src") or values.get("href") or values.get("data") or ""
+            if resource and not resource.startswith("data:"):
+                self.external_resources.append(resource)
+        if tag == "meta" and values.get("name"):
+            self.metadata[values["name"] or ""] = values.get("content") or ""
+
+
+def validate_html(page: str, expected_signatures: list[str], kind: str, source_hash: str) -> None:
+    parser = StructureParser()
+    parser.feed(page)
+    expected_blocks = [(str(index), signature) for index, signature in enumerate(expected_signatures, start=1)]
+    if parser.source_blocks != expected_blocks:
+        raise GenerationError(
+            "Parity check failed: source block identities or order changed"
+        )
+    if len(parser.ids) != len(set(parser.ids)):
+        duplicates = sorted({value for value in parser.ids if parser.ids.count(value) > 1})
+        raise GenerationError(f"Generated HTML contains duplicate IDs: {', '.join(duplicates)}")
+    missing_targets = sorted({target for target in parser.hrefs if target not in parser.ids})
+    if missing_targets:
+        raise GenerationError(f"Generated navigation has missing targets: {', '.join(missing_targets)}")
+    if parser.scripts or parser.external_resources:
+        raise GenerationError("Generated HTML contains scripts or external runtime resources")
+    if parser.metadata.get("document-kind") != kind:
+        raise GenerationError("Generated document-kind metadata is not canonical")
+    if parser.metadata.get("source-sha256") != source_hash:
+        raise GenerationError("Generated source hash is incorrect")
+
+
+def lock_path(output: Path) -> Path:
+    return output.with_name(f".{output.name}.html-doc.lock")
+
+
+def read_lock(output: Path) -> dict:
+    path = lock_path(output)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise GenerationError(f"No pending html-doc render exists for {output}") from error
+    except (json.JSONDecodeError, UnicodeError) as error:
+        raise GenerationError(f"Invalid stale lock at {path}; discard it explicitly") from error
+    if not isinstance(data, dict):
+        raise GenerationError(f"Invalid stale lock at {path}; discard it explicitly")
+    return data
+
+
+def acquire_lock(output: Path, candidate: Path, token: str) -> None:
+    path = lock_path(output)
+    payload = json.dumps({"token": token, "candidate": str(candidate), "output": str(output), "pid": os.getpid()})
+    try:
+        descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as error:
+        raise GenerationError(f"Output is locked by pending or stale state at {path}; finalize or discard it") from error
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def safe_candidate_from_lock(output: Path, data: dict) -> Path:
+    candidate = Path(str(data.get("candidate", ""))).resolve()
+    prefix = f"{output.name}."
+    if candidate.parent != output.parent or not candidate.name.startswith(prefix) or not candidate.name.endswith(".candidate.html"):
+        raise GenerationError("Lock contains an unsafe candidate path")
+    return candidate
+
+
+def cleanup(output: Path, candidate: Path | None) -> None:
+    if candidate:
+        candidate.unlink(missing_ok=True)
+    lock_path(output).unlink(missing_ok=True)
+
+
+def force_cleanup_stale(output: Path) -> None:
+    prefix = f"{output.name}."
+    for candidate in output.parent.iterdir():
+        if candidate.is_file() and candidate.name.startswith(prefix) and candidate.name.endswith(".candidate.html"):
+            candidate.unlink()
+    lock_path(output).unlink(missing_ok=True)
+
+
+def source_label(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return str(resolved)
+
+
+def infer_kind(path: Path | None, explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    if path and path.name == "prd.md":
+        return "prd"
+    if path and path.name == "design.md":
+        return "design"
+    raise GenerationError("Document kind is required: use --kind prd or --kind design")
+
+
+def existing_output_matches(output: Path, expected_source: str) -> bool:
+    if not output.exists():
+        return True
+    match = re.search(r'<meta name="source-path" content="([^"]*)">', output.read_text(encoding="utf-8"))
+    return bool(match and html.unescape(match.group(1)) == expected_source)
+
+
+def command_render(args: argparse.Namespace) -> None:
+    source_path: Path | None = None
+    if args.inline:
+        if not args.out:
+            raise GenerationError("Inline Markdown requires --out")
+        markdown = sys.stdin.read()
+        label = "inline-input"
+        fallback_title = "Untitled document"
+    else:
+        if not args.source:
+            raise GenerationError("A Markdown source path is required")
+        source_path = Path(args.source)
+        if source_path.suffix.lower() not in {".md", ".markdown"}:
+            raise GenerationError(f"Source is not Markdown: {source_path}")
+        try:
+            size = source_path.stat().st_size
+        except OSError as error:
+            raise GenerationError(f"Cannot read source {source_path}: {error}") from error
+        if size > MAX_SOURCE_BYTES:
+            raise GenerationError(f"Source exceeds the {MAX_SOURCE_BYTES}-byte limit: {source_path}")
+        markdown = source_path.read_text(encoding="utf-8")
+        label = source_label(source_path)
+        fallback_title = source_path.stem.replace("-", " ").title()
+    if len(markdown.encode("utf-8")) > MAX_SOURCE_BYTES:
+        raise GenerationError(f"Source exceeds the {MAX_SOURCE_BYTES}-byte limit")
+    kind = infer_kind(source_path, args.kind)
+    explicit_output = bool(args.out)
+    output = Path(args.out) if args.out else source_path.with_suffix(".html")  # type: ignore[union-attr]
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists() and not explicit_output and not existing_output_matches(output, label):
+        raise GenerationError(f"Refusing to replace unrelated output {output}; choose it explicitly with --out")
+    token = uuid.uuid4().hex
+    candidate = output.with_name(f"{output.name}.{token}.candidate.html")
+    acquire_lock(output, candidate, token)
+    try:
+        page, source_blocks = render_page(markdown, kind, label, fallback_title)
+        descriptor = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(page)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        cleanup(output, candidate)
+        raise
+    print(json.dumps({
+        "candidate": str(candidate), "output": str(output), "token": token,
+        "source_blocks": source_blocks, "source_sha256": hashlib.sha256(markdown.encode()).hexdigest(),
+    }))
+
+
+def command_finalize(args: argparse.Namespace) -> None:
+    output = Path(args.out).resolve()
+    data = read_lock(output)
+    candidate = safe_candidate_from_lock(output, data)
+    if data.get("token") != args.token:
+        raise GenerationError("Token does not match the pending render")
+    try:
+        if not candidate.is_file():
+            raise GenerationError(f"Candidate is missing: {candidate}")
+        os.replace(candidate, output)
+    except BaseException:
+        cleanup(output, candidate)
+        raise
+    lock_path(output).unlink(missing_ok=True)
+    print(json.dumps({"output": str(output), "installed": True}))
+
+
+def command_discard(args: argparse.Namespace) -> None:
+    output = Path(args.out).resolve()
+    try:
+        data = read_lock(output)
+    except GenerationError:
+        if not args.force_stale:
+            raise
+        force_cleanup_stale(output)
+        print(json.dumps({"output": str(output), "discarded": True, "stale": True}))
+        return
+    if not args.force_stale and data.get("token") != args.token:
+        raise GenerationError("Token does not match the pending render; use --force-stale only for abandoned state")
+    try:
+        candidate = safe_candidate_from_lock(output, data)
+    except GenerationError:
+        if not args.force_stale:
+            raise
+        force_cleanup_stale(output)
+    else:
+        cleanup(output, candidate)
+    print(json.dumps({"output": str(output), "discarded": True}))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    render_parser = commands.add_parser("render", help="Create a locked candidate for browser verification")
+    render_parser.add_argument("source", nargs="?")
+    render_parser.add_argument("--inline", action="store_true", help="Read exact Markdown from stdin")
+    render_parser.add_argument("--kind", choices=("prd", "design"))
+    render_parser.add_argument("--out")
+    render_parser.set_defaults(function=command_render)
+    finalize_parser = commands.add_parser("finalize", help="Atomically install a verified candidate")
+    finalize_parser.add_argument("--out", required=True)
+    finalize_parser.add_argument("--token", required=True)
+    finalize_parser.set_defaults(function=command_finalize)
+    discard_parser = commands.add_parser("discard", help="Remove a failed or stale candidate")
+    discard_parser.add_argument("--out", required=True)
+    discard_parser.add_argument("--token")
+    discard_parser.add_argument("--force-stale", action="store_true")
+    discard_parser.set_defaults(function=command_discard)
+    return parser
+
+
+def main() -> int:
+    try:
+        args = build_parser().parse_args()
+        args.function(args)
+        return 0
+    except (GenerationError, OSError, UnicodeError) as error:
+        print(f"html-doc: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/html-doc/tests/fixtures/design.md
+++ b/skills/html-doc/tests/fixtures/design.md
@@ -1,0 +1,43 @@
+# Queue design
+
+> **Status:** Proposed
+
+## Summary
+
+Keep jobs durable and ordered.
+
+## Requirements
+
+- `INV-1`: Jobs survive a restart.
+- `AC-1`: A restored job runs once.
+
+### Repeated
+
+First repeated heading.
+
+### Repeated
+
+Second repeated heading.
+
+## 設計
+
+Unicode heading.
+
+## !!!
+
+Punctuation heading.
+
+## Diagram
+
+```mermaid
+flowchart LR
+    Queue --> Worker
+```
+
+| Input | Result |
+| --- | --- |
+| job | accepted |
+
+```python
+print("kept")
+```

--- a/skills/html-doc/tests/fixtures/diagram.mmd
+++ b/skills/html-doc/tests/fixtures/diagram.mmd
@@ -1,0 +1,4 @@
+flowchart LR
+    Brief([Idea or problem]) --> Author[Author]
+    Author --> Source[Canonical Markdown]
+    Source --> Page[Static HTML]

--- a/skills/html-doc/tests/fixtures/prd.md
+++ b/skills/html-doc/tests/fixtures/prd.md
@@ -1,0 +1,42 @@
+# Account recovery PRD
+
+> **Status:** Approved
+
+## Summary
+
+Let a locked-out user recover an account without support.
+
+## Goals
+
+- Restore access within five minutes.
+- Keep the existing account identity.
+
+## Non-goals
+
+- Replacing multi-factor authentication.
+
+## Requirements
+
+1. Send a single-use recovery link.
+2. Expire the link after 15 minutes.
+
+- [x] Record successful recovery.
+- [ ] Add translated email copy later.
+
+> Support staff cannot read recovery tokens.
+
+The flow keeps **private data** protected and shows *plain guidance*. Read the [support policy](https://example.com/policy).
+
+| Input | Result |
+| --- | --- |
+| known email | generic response |
+| unknown email | generic response |
+
+```json
+{"result":"accepted"}
+```
+
+## Acceptance criteria
+
+- `AC-1`: Both known and unknown emails receive the same visible response.
+- `AC-2`: A used link cannot be reused.

--- a/skills/html-doc/tests/test_html_doc.py
+++ b/skills/html-doc/tests/test_html_doc.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from html.parser import HTMLParser
+import importlib.util
+import json
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import threading
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "html_doc.py"
+SPEC = importlib.util.spec_from_file_location("html_doc", SCRIPT)
+assert SPEC and SPEC.loader
+html_doc = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(html_doc)
+
+
+def ast_visible_text(node: object) -> str:
+    if isinstance(node, list):
+        return " ".join(ast_visible_text(child) for child in node if isinstance(child, (dict, list)))
+    if not isinstance(node, dict):
+        return ""
+    kind = node.get("t")
+    content = node.get("c")
+    if kind == "Str":
+        return str(content)
+    if kind in {"Space", "SoftBreak", "LineBreak"}:
+        return " "
+    if kind in {"Code", "Math"}:
+        return str(content[-1])
+    if kind in {"CodeBlock", "RawBlock"}:
+        return str(content[1])
+    if kind in {"Link", "Image"}:
+        return ast_visible_text(content[1])
+    if kind == "Header":
+        return ast_visible_text(content[2])
+    return ast_visible_text(content)
+
+
+def normalized(value: str) -> str:
+    value = value.replace("☒", "").replace("☐", "")
+    return re.sub(r"\s+([:,.])", r"\1", " ".join(value.split()))
+
+
+class SourceTextParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_main = False
+        self.current: str | None = None
+        self.text: dict[str, list[str]] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag == "main":
+            self.in_main = True
+        if self.in_main and values.get("data-source-block"):
+            self.current = values["data-source-block"]
+            self.text[self.current] = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "main":
+            self.in_main = False
+            self.current = None
+
+    def handle_data(self, data: str) -> None:
+        if self.in_main and self.current:
+            self.text[self.current].append(data)
+
+
+class HtmlDocTests(unittest.TestCase):
+    def run_cli(self, *arguments: str, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["python3", str(SCRIPT), *arguments],
+            input=stdin,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_render_candidate_then_finalize(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "design.md"
+            output = root / "design.html"
+            markdown = (SKILL_DIR / "tests" / "fixtures" / "design.md").read_text()
+            source.write_text(markdown)
+
+            rendered = self.run_cli("render", str(source), "--out", str(output))
+            self.assertEqual(rendered.returncode, 0, rendered.stderr)
+            result = json.loads(rendered.stdout)
+            candidate = Path(result["candidate"])
+            self.assertTrue(candidate.is_file())
+            self.assertFalse(output.exists())
+            self.assertEqual(source.read_text(), markdown)
+
+            page = candidate.read_text()
+            self.assertIn('<meta name="document-kind" content="design">', page)
+            self.assertIn('<dd>Proposed</dd>', page)
+            self.assertIn('id="repeated"', page)
+            self.assertIn('id="repeated-2"', page)
+            self.assertIn('id="section"', page)
+            self.assertIn('id="section-2"', page)
+            self.assertIn("data:image/svg+xml;base64,", page)
+            self.assertIn("Diagram 1 showing Queue Worker", page)
+            self.assertEqual(page.count("data-source-block="), result["source_blocks"])
+
+            finalized = self.run_cli(
+                "finalize", "--out", str(output), "--token", result["token"]
+            )
+            self.assertEqual(finalized.returncode, 0, finalized.stderr)
+            self.assertEqual(output.read_text(), page)
+            self.assertFalse(candidate.exists())
+
+    def test_prd_and_design_ast_content_stays_in_source_order(self) -> None:
+        for name, kind in (("prd.md", "prd"), ("design.md", "design")):
+            with self.subTest(name=name):
+                markdown = (SKILL_DIR / "tests" / "fixtures" / name).read_text()
+                document = html_doc.pandoc_document(markdown)
+                original_blocks = document["blocks"]
+                expected_signatures = [html_doc.block_signature(block) for block in original_blocks]
+                page, count = html_doc.render_page(markdown, kind, f"fixtures/{name}", name)
+                structure = html_doc.StructureParser()
+                structure.feed(page)
+                self.assertEqual(count, len(original_blocks))
+                self.assertEqual(
+                    structure.source_blocks,
+                    [(str(index), signature) for index, signature in enumerate(expected_signatures, 1)],
+                )
+                rendered_text = SourceTextParser()
+                rendered_text.feed(page)
+                for index, block in enumerate(original_blocks, 1):
+                    classes = block.get("c", [["", [], []]])[0][1] if block.get("t") == "CodeBlock" else []
+                    if "mermaid" in classes:
+                        continue
+                    self.assertEqual(
+                        normalized("".join(rendered_text.text[str(index)])),
+                        normalized(ast_visible_text(block)),
+                        f"content changed in source block {index} of {name}",
+                    )
+
+    def test_pending_render_excludes_concurrent_render_and_can_be_discarded(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "design.md"
+            output = root / "view.html"
+            source.write_text("# Design\n\n## Decision\n\nKeep one writer.\n")
+            first = self.run_cli("render", str(source), "--out", str(output))
+            self.assertEqual(first.returncode, 0, first.stderr)
+            first_result = json.loads(first.stdout)
+
+            second = self.run_cli("render", str(source), "--out", str(output))
+            self.assertNotEqual(second.returncode, 0)
+            self.assertIn("locked", second.stderr)
+
+            discarded = self.run_cli(
+                "discard", "--out", str(output), "--token", first_result["token"]
+            )
+            self.assertEqual(discarded.returncode, 0, discarded.stderr)
+            self.assertFalse(Path(first_result["candidate"]).exists())
+            self.assertFalse(html_doc.lock_path(output.resolve()).exists())
+
+    def test_interrupted_render_cleans_candidate_and_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "design.md"
+            output = root / "view.html"
+            source.write_text("# Design\n")
+            arguments = SimpleNamespace(
+                inline=False, source=str(source), out=str(output), kind=None
+            )
+            with mock.patch.object(html_doc, "render_page", side_effect=KeyboardInterrupt):
+                with self.assertRaises(KeyboardInterrupt):
+                    html_doc.command_render(arguments)
+            self.assertFalse(html_doc.lock_path(output.resolve()).exists())
+            self.assertEqual(list(root.glob("*.candidate.html")), [])
+
+    def test_default_output_does_not_replace_unrelated_html(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "design.md"
+            output = root / "design.html"
+            source.write_text("# Design\n")
+            output.write_text("unrelated")
+            rendered = self.run_cli("render", str(source))
+            self.assertNotEqual(rendered.returncode, 0)
+            self.assertIn("unrelated output", rendered.stderr)
+            self.assertEqual(output.read_text(), "unrelated")
+
+    def test_failed_final_replace_preserves_previous_output_and_cleans_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "design.md"
+            output = root / "view.html"
+            old = b"previous verified output"
+            source.write_text("# Design\n\n## Decision\n\nKeep one writer.\n")
+            output.write_bytes(old)
+            rendered = self.run_cli("render", str(source), "--out", str(output))
+            self.assertEqual(rendered.returncode, 0, rendered.stderr)
+            result = json.loads(rendered.stdout)
+
+            with mock.patch.object(html_doc.os, "replace", side_effect=OSError("simulated")):
+                with self.assertRaises(OSError):
+                    html_doc.command_finalize(SimpleNamespace(out=str(output), token=result["token"]))
+            self.assertEqual(output.read_bytes(), old)
+            self.assertFalse(Path(result["candidate"]).exists())
+            self.assertFalse(html_doc.lock_path(output.resolve()).exists())
+
+    def test_resource_bearing_mermaid_is_rejected_before_render(self) -> None:
+        hostile = "flowchart LR\nA-->B\nclick A https://127.0.0.1:8765/steal"
+        with mock.patch.object(html_doc, "run") as renderer:
+            with self.assertRaisesRegex(html_doc.GenerationError, "forbidden resource syntax"):
+                html_doc.render_mermaid(hostile, 1)
+        renderer.assert_not_called()
+
+    def test_svg_allowlist_rejects_active_content_and_external_urls(self) -> None:
+        fixtures = (
+            b'<svg xmlns="http://www.w3.org/2000/svg"><script>bad()</script></svg>',
+            b'<svg xmlns="http://www.w3.org/2000/svg"><image href="https://bad.test/x"/></svg>',
+            b'<svg xmlns="http://www.w3.org/2000/svg" onload="bad()"/>',
+            b'<svg xmlns="http://www.w3.org/2000/svg"><style>.x{fill:u\\72l(\\68ttps://bad.test/x)}</style></svg>',
+        )
+        for fixture in fixtures:
+            with self.subTest(fixture=fixture):
+                with self.assertRaises(html_doc.GenerationError):
+                    html_doc.validate_svg(fixture)
+
+    def test_unsafe_html_and_url_schemes_do_not_enter_generated_dom(self) -> None:
+        markdown = "# Design\n\n<script>alert(1)</script>\n\n[bad](javascript:alert(1))\n"
+        page, _ = html_doc.render_page(markdown, "design", "inline-input", "Design")
+        self.assertNotIn("<script>", page)
+        self.assertNotIn('href="javascript:', page)
+        self.assertIn("&lt;script&gt;", page)
+
+    def test_locked_package_versions_and_real_mermaid_render(self) -> None:
+        html_doc.check_dependencies(True)
+        markdown = (SKILL_DIR / "tests" / "fixtures" / "design.md").read_text()
+        page, blocks = html_doc.render_page(markdown, "design", "tests/fixtures/design.md", "Design")
+        self.assertGreater(blocks, 1)
+        self.assertIn("data:image/svg+xml;base64,", page)
+
+    def test_generated_ids_cannot_collide_with_source_headings(self) -> None:
+        markdown = "# Design\n\n## Document content\n\nOne.\n\n## Source block 1\n\nTwo.\n\n## cb1\n\n```python\nprint(1)\n```\n"
+        page, _ = html_doc.render_page(markdown, "design", "inline-input", "Design")
+        parser = html_doc.StructureParser()
+        parser.feed(page)
+        self.assertEqual(len(parser.ids), len(set(parser.ids)))
+        self.assertIn("document-content-2", parser.ids)
+        self.assertIn("source-block-1", parser.ids)
+        self.assertIn("cb1", parser.ids)
+
+    def test_force_stale_removes_malformed_lock_and_known_candidates(self) -> None:
+        for output_name, other_name in (
+            ("view.html", "other.html.deadbeef.candidate.html"),
+            ("view[1].html", "view1.html.deadbeef.candidate.html"),
+            ("*.html", "unrelated.html.deadbeef.candidate.html"),
+        ):
+            with self.subTest(output=output_name), tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / output_name
+                candidate = output.with_name(f"{output.name}.deadbeef.candidate.html")
+                other = output.with_name(other_name)
+                candidate.write_text("partial")
+                other.write_text("keep")
+                html_doc.lock_path(output).write_text("{partial")
+                discarded = self.run_cli("discard", "--out", str(output), "--force-stale")
+                self.assertEqual(discarded.returncode, 0, discarded.stderr)
+                self.assertFalse(candidate.exists())
+                self.assertEqual(other.read_text(), "keep")
+                self.assertFalse(html_doc.lock_path(output).exists())
+
+    def test_chromium_cannot_reach_controlled_endpoint(self) -> None:
+        class Handler(BaseHTTPRequestHandler):
+            requests = 0
+
+            def do_GET(self) -> None:  # noqa: N802
+                Handler.requests += 1
+                self.send_response(204)
+                self.end_headers()
+
+            def log_message(self, format: str, *args: object) -> None:
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        url = f"http://127.0.0.1:{server.server_port}/probe"
+        config = json.loads((SKILL_DIR / "assets" / "puppeteer.json").read_text())
+        script = f'''
+import puppeteer from "puppeteer";
+const browser = await puppeteer.launch({{headless: true, args: {json.dumps(config["args"])}}});
+const page = await browser.newPage();
+let blocked = false;
+try {{ await page.goto({json.dumps(url)}, {{timeout: 3000}}); }} catch {{ blocked = true; }}
+await browser.close();
+if (!blocked) process.exit(2);
+'''
+        try:
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script],
+                cwd=SKILL_DIR,
+                text=True,
+                capture_output=True,
+                timeout=15,
+                check=False,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(Handler.requests, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add the `/html-doc` skill for rendering existing Markdown PRDs and technical designs as static HTML.
- Add a locked Pandoc and Mermaid generation path with fail-closed SVG validation, denied renderer networking, signed source-block parity, and atomic candidate finalization.
- Update the reviewed design, generated blue-grey HTML view, install docs, migration guide, and changelog.

## Developer impact

Agents can create a responsive, printable, offline HTML reading view without changing the canonical Markdown. Failed generation or verification keeps the previous output unchanged.

## Checks

- [x] 13 Python tests covering PRD and design parity, Mermaid rendering, network denial, hostile input, ID collisions, lock recovery, concurrency, and atomic replacement
- [x] `npm ls --depth=0` confirms Mermaid CLI 11.16.0 and Puppeteer 25.5.0
- [x] `git diff --check`
- [x] Generated HTML source hash matches `design.md`
- [x] Independent architecture review: Approve
- [x] Independent implementation review: Approve
- [ ] Current candidate could not be opened through Codex's in-app browser because that browser blocks local `file://` navigation. PR #59 previously verified the design view at 1440px and 390px; the new renderer's structural, accessibility-contract, offline, and resource checks are automated. Print preview remains unverified.