### PR TITLE
feat(skills): add issue coordinator workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Blueprint is a small set of instructions for AI coding. It separates deciding wh
 - Browser behavior is proven in a real browser, not by reading source.
 - If the task, design, or plan is wrong, update it before changing more code.
 - Prefer the smallest complete change. Do not mix product work with unrelated cleanup.
-- Humans review decisions and merge. Agents handle the path between them.
+- Humans review decisions and normally merge. Agents may merge only when the user explicitly delegates it. Explicitly naming `/issue-coordinator` delegates merge authority for the supplied batch after its quality gates pass; an implicit skill match does not.
 
 ## Phases
 
@@ -34,12 +34,15 @@ Blueprint is a small set of instructions for AI coding. It separates deciding wh
 - `/test`: prove acceptance criteria and failure paths affected by the change, including real-browser checks when browser-rendered behavior changes.
 - `/review`: use a fresh subagent for an independent, read-only implementation review.
 - `/improve`: inspect existing code and improve its clarity, simplicity, and structure without changing intended behavior.
+- `/issue-coordinator`: coordinate a large GitHub issue batch through separate Codex worker threads, reviewed pull requests, and gated merges.
 
 ## Workflow: Code changes
 
 For one or more code changes, follow the [`/task-to-pr` skill](skills/task-to-pr/SKILL.md). It stacks dependent work after prerequisite pull requests are open and independently approved, runs independent work at the same time when useful, and takes each task through a tested and reviewed pull request. A milestone is one possible source of tasks.
 
 Merge pull requests only when the user asks. Otherwise, leave them open.
+
+For a large GitHub issue batch that needs visible, isolated Codex sessions, use [`/issue-coordinator`](skills/issue-coordinator/SKILL.md). Explicitly naming it asks in-scope workers to merge after every required test, review, CI, approval, and mergeability gate passes. An implicit match leaves passing pull requests open. Neither mode grants deployment or release authority.
 
 Writing code is a basic agent ability, not a separate skill. Debugging and test-driven development are ways to implement a change, not separate product skills.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file records notable changes to Blueprint.
 ### Added
 
 - Added `/html-doc` to turn an existing Markdown PRD or technical design into a verified static HTML reading view with offline Mermaid diagrams, responsive layout, and print styles.
+- Added `/issue-coordinator`, presented as the Ultra-scale workflow, to coordinate large GitHub issue batches through visible Codex worker threads, isolated worktrees, ready-for-review pull requests, review and CI loops, and gated agent merges.
 
 ### Changed
 
@@ -15,6 +16,8 @@ This file records notable changes to Blueprint.
 - Delivery now has two clear phases: build and review the code, then pass CI and automated code review.
 - Automated review findings require a reply that says what changed or why no change was needed.
 - Pull requests stay open unless the user asks the agent to merge them.
+- Pull requests are marked ready before independent and GitHub review begin.
+- Explicitly naming `/issue-coordinator` grants merge authority for only its supplied batch after every quality gate passes. An implicit skill match leaves passing pull requests open.
 - Dependent work now stacks on open, independently approved prerequisite pull requests instead of waiting for merge.
 - Design invariants and acceptance criteria now use stable IDs that planning, testing, and review preserve.
 - Architecture invariants now name their enforcing mechanism, and architecture documents carry their own update triggers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@
 
 Blueprint keeps shared repository policy in `AGENTS.md` and only Claude-specific setup here.
 
-Install Blueprint with `npx skills add owainlewis/blueprint`. Use `/architecture`, `/design`, `/architecture-review`, `/plan`, `/test`, `/review`, and `/improve` for one kind of engineering work. Use `/task-to-pr` to deliver one or more code changes.
+Install Blueprint with `npx skills add owainlewis/blueprint`. Use `/architecture`, `/design`, `/architecture-review`, `/plan`, `/test`, `/review`, and `/improve` for one kind of engineering work. Use `/task-to-pr` to deliver one or more code changes. Use `/issue-coordinator` only in Codex to coordinate a large GitHub issue batch through separate worker threads and gated merges.
 
-Everything you call in Blueprint is a skill. `/task-to-pr` accepts tasks, tickets, pull requests, or a milestone and creates one pull request for each task. `AGENTS.md` contains the repository rules.
+Everything you call in Blueprint is a skill. `/task-to-pr` accepts tasks, tickets, pull requests, or a milestone and creates one pull request for each task. `/issue-coordinator` is Codex-specific because it requires Codex thread and managed-worktree tools. `AGENTS.md` contains the repository rules.
 
 The `/architecture-review` and `/review` phases use a fresh generic subagent. Blueprint does not require a separate reviewer agent definition.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migrate from older Blueprint skills
 
-> **Breaking change:** Blueprint now ships nine skills. You must remove old Blueprint skill folders and copied commands by hand.
+> **Breaking change:** Blueprint now ships ten skills. You must remove old Blueprint skill folders and copied commands by hand.
 
 ## What changed
 
@@ -8,6 +8,7 @@
 | --- | --- |
 | No previous equivalent | `/architecture` |
 | No previous equivalent | `/html-doc` |
+| `multitask` | `/issue-coordinator` for Codex issue batches |
 | Design review through `/review` | `/architecture-review` |
 | `design-doc`, `spec` | `/design` |
 | `browser-verify` | Browser proof inside `/test` |
@@ -15,27 +16,27 @@
 | `branch`, `commit`, `implement`, `pr`, `pr-to-ready` | Steps inside `/task-to-pr` |
 | `task-to-pr` | `/task-to-pr`, now for one or more tasks |
 | `debug`, `tdd` | Techniques used while implementing |
-| `goal-design`, `multitask` | Ordinary instructions or project-specific workflows |
+| `goal-design` | Ordinary instructions or a project-specific workflow |
 | `milestone` | `/task-to-pr` with the milestone as input |
 | `code-reviewer` agent definition | A fresh generic subagent launched by `/review` |
 
-These are the nine skills you can call:
+These are the ten skills you can call:
 
 ```text
-/architecture · /design · /architecture-review · /plan · /test · /review · /improve · /task-to-pr · /html-doc
+/architecture · /design · /architecture-review · /plan · /test · /review · /improve · /task-to-pr · /html-doc · /issue-coordinator
 ```
 
 ## Clean upgrade
 
 1. **Remove old Blueprint skills and commands.** In the skill directory used by your coding tool, remove the old `milestone` skill and the other old Blueprint skill folders listed above. Also remove copied Blueprint `implement.md` and `task-to-pr.md` command files. Do not delete whole skill or command directories because they may contain unrelated files.
-2. **Install all nine skills.**
+2. **Install all ten skills.**
 
    ```bash
    npx skills add owainlewis/blueprint
    ```
 
 3. **Remove copied reviewer agents.** Delete any old Blueprint `code-reviewer` definition. The `/review` skill now launches a fresh generic subagent.
-4. **Check the result.** The `/architecture`, `/design`, `/architecture-review`, `/plan`, `/test`, `/review`, `/improve`, `/task-to-pr`, and `/html-doc` skills should be available.
+4. **Check the result.** The `/architecture`, `/design`, `/architecture-review`, `/plan`, `/test`, `/review`, `/improve`, `/task-to-pr`, `/html-doc`, and `/issue-coordinator` skills should be available.
 
 ## Why cleanup is manual
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 </div>
 
-Blueprint helps agents decide what to build, make focused changes, test them, get an independent review, and open pull requests.
+Blueprint helps agents decide what to build, make focused changes, test them, get an independent review, and deliver pull requests. Its Codex-only coordinator can run a large issue batch through isolated worker threads and gated merges.
 
 ## Start with the work, not the process
 
@@ -19,6 +19,7 @@ Choose the first skill based on what you need.
 | Challenge a technical proposal before implementation | `/architecture-review` | Material flaws, open questions, and a verdict |
 | Split a decided feature into work for several agent runs | `/plan` | Ordered tasks in chat or tracker tickets |
 | Deliver one or more tasks | `/task-to-pr` | One tested and reviewed pull request per task |
+| Coordinate a large GitHub issue batch in Codex | `/issue-coordinator` | Issue-named worker threads, isolated pull requests, and gated merges |
 | Prove a change works | `/test` | Acceptance criteria mapped to evidence |
 | Review an implementation change | `/review` | Findings and a pre-merge verdict from a fresh subagent |
 | Simplify existing code without changing behavior | `/improve` | Clearer, smaller, better-structured code |
@@ -44,12 +45,14 @@ flowchart TB
     end
 
     subgraph Deliver["Deliver with /task-to-pr"]
-        Tasks --> Order["order and plan"] --> Task["each task"] --> Code["write code"] --> Test["test"] --> Review["subagent review"]
+        Tasks --> Order["order and plan"] --> Task["each task"] --> Code["write code"] --> Test["test"] --> PR["ready pull request"] --> Review["subagent review"]
         Review -->|finding| Code
-        Review -->|approved| PR["open or update PR"] --> Automated["CI + automated review"]
+        Review -->|approved| Automated["CI + automated review"]
         Automated -->|finding| Code
         Automated -->|clean| Done([Task done])
     end
+
+    Batch([Parent issue or batch]) --> Coordinator["/issue-coordinator"] --> Tasks
 ```
 
 Use `/architecture` when you need to understand or document existing code. Use `/improve` to simplify code without changing what it does. Not every change needs either skill.
@@ -71,6 +74,7 @@ The model has two layers:
 | `/review` | Independent review of an implementation's correctness, security, regressions, complexity, and proof | Findings and a verdict are reported |
 | `/improve` | Behavior-preserving simplification of existing code | Relevant checks prove behavior was preserved |
 | `/html-doc` | A static HTML reading view of a complete Markdown PRD or technical design | The browser-verified candidate atomically replaces the prior generated view |
+| `/issue-coordinator` | A large GitHub issue batch executed through visible Codex worker threads | Every issue is merged and Done, has a passing ready pull request in no-merge mode, or has a recorded human blocker |
 
 Writing code is a basic agent ability, not a separate skill. Branching, committing, debugging, browser checks, and feedback are steps inside a workflow.
 
@@ -82,15 +86,21 @@ For each task, it:
 
 1. creates or reuses a branch and worktree from the latest default branch or the reviewed prerequisite base;
 2. writes and tests the code;
-3. asks a fresh subagent that did not write the code to review it;
-4. opens or updates a pull request with a short summary and proof;
+3. opens or updates a pull request with a short summary and proof, then marks it ready;
+4. asks a fresh subagent that did not write the code to review it;
 5. waits for configured CI and automated code review, then fixes, reviews, and replies to every finding.
 
 It leaves pull requests open unless the user asks to merge them.
 
+## Ultra-scale issue coordination
+
+[`skills/issue-coordinator/SKILL.md`](skills/issue-coordinator/SKILL.md) is the Codex-only workflow for a large parent issue, milestone, or issue batch. The calling thread stays clean as the coordinator. Each active issue runs in a visible Codex thread named `#<issue-number> <short title>` with its own managed worktree, branch, and pull request.
+
+The coordinator starts independent work up to a bounded limit and waits for prerequisite merges before starting dependent work. Workers use `/task-to-pr`, mark pull requests ready before review, address CI and review findings, and repeat proof after code changes. Explicitly naming `/issue-coordinator`, or explicitly granting merge authority, authorizes workers to merge only their in-scope pull requests after every test, review, approval, and repository gate passes. An implicit skill match leaves passing pull requests open and records dependent issues as waiting for human merge. Neither mode authorizes deployment or release publication.
+
 ## Install
 
-Install all nine skills:
+Install all ten skills:
 
 ```bash
 npx skills add owainlewis/blueprint
@@ -103,7 +113,7 @@ Read the [changelog](CHANGELOG.md) for notable changes.
 ## Repository map
 
 ```text
-skills/                 seven phase skills, one delivery workflow, and one presentation skill
+skills/                 seven phase skills, one delivery workflow, one Codex coordination workflow, and one presentation skill
 AGENTS.md                portable repository policy
 CLAUDE.md                Claude Code adapter
 REVIEW.md                review standard for Blueprint itself
@@ -134,6 +144,6 @@ For a larger system-part design, read the [Dispatch local control-plane design](
 - **Use the real surface.** Browser behavior is checked in a browser. Live PR feedback is read from the PR.
 - **Fix the original instruction.** If implementation exposes a bad requirement, update the task or design before continuing.
 - **Prefer less.** Keep the smallest complete change, shortest useful instruction, and no duplicate ways to start the same work.
-- **Keep irreversible judgment human.** Agents prepare the decision. Humans review designs and merge pull requests unless they explicitly delegate it.
+- **Keep irreversible judgment explicit.** Humans review decisions and normally merge. Agents merge only when the user explicitly delegates it, including by explicitly naming `/issue-coordinator` for a batch.
 
-Blueprint is not an issue tracker, agent framework, release system, or reviewer-persona library. It is a compact engineering process for capable coding agents.
+Blueprint is not an issue tracker, general agent runtime, release system, or reviewer-persona library. It is a compact engineering process for capable coding agents.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -15,10 +15,18 @@ Review Blueprint as a small set of engineering instructions. Read the issue, com
 - Are triggers, outputs, boundaries, proof, and stop conditions clear?
 - Is the change one focused, self-contained, reviewable outcome with its related proof?
 - Does `/task-to-pr` order one or more tasks and create one tested and independently reviewed pull request for each task?
+- Does `/task-to-pr` mark each pull request ready before independent and GitHub review begin?
 - Does each task use its own branch and worktree, with independent tasks allowed to run at the same time and dependent tasks stacked after prerequisite pull requests are open and independently approved?
 - Does it stop after configured CI and automated review instead of waiting for human feedback?
 - Does it reply to every automated review finding and resolve threads only after they are fully addressed?
-- Does it merge only when the user asks?
+- Does it merge only when the user asks, including the explicit batch authority granted by `/issue-coordinator`?
+- Does `/issue-coordinator` use one visible Codex worker thread, worktree, branch, and pull request per GitHub issue?
+- Does it name workers after issue numbers, bound concurrency, wait for prerequisite merges, and keep implementation context out of the coordinator?
+- Does every worker test first, mark its pull request ready, obtain fresh approval, pass CI, resolve review feedback, and satisfy repository rules before merging?
+- Does coordinator merge authority require explicit user wording, remain limited to the supplied batch, and exclude deployment, releases, destructive actions, and unrelated pull requests?
+- Does the coordinator resume an open pull request from its exact head branch and reconcile already-merged pull requests with closed issue state only after the change and proof satisfy the issue?
+- In no-merge mode, does it record dependent issues as waiting for human merge instead of dispatching from an unmerged branch or waiting indefinitely?
+- In no-merge mode, does it stop after agent-completable gates and record required human approval or merge as a blocker instead of waiting indefinitely?
 - Is browser-rendered behavior checked in a real browser?
 - Can a capable agent choose local mechanics without redundant instructions?
 - Are removed concepts handled by an explicit migration instead of compatibility clutter?

--- a/skills/issue-coordinator/SKILL.md
+++ b/skills/issue-coordinator/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: issue-coordinator
+description: "Coordinates a large batch of GitHub issues through separate Codex worker threads, tested pull requests, review loops, and gated merges. Use when the user asks one Codex thread to manage several coding sessions or complete a parent issue, milestone, or issue batch."
+user-invocable: true
+argument-hint: "<parent issue, milestone, or issue list>"
+---
+
+# Ultra-scale issue coordination
+
+Use one Codex thread as the coordinator. Give each active GitHub issue its own
+Codex worker thread, worktree, branch, and pull request. Keep implementation
+context in workers and dependency state in GitHub.
+
+Explicitly naming `/issue-coordinator`, or explicitly telling the coordinator
+that agents may merge, authorizes in-scope workers to merge their own pull
+requests after every merge gate below passes. An implicit skill match does not
+grant merge authority: run in no-merge mode unless the user's words grant it.
+Neither mode authorizes deployment, release publication, destructive
+operations, branch-protection bypasses, or changes outside the supplied batch.
+
+## Preconditions
+
+1. Read the repository instructions, parent issue, native sub-issues, declared
+   dependencies, project board, issue state, and linked open or merged pull
+   requests. A merged pull request is only evidence of completion when it
+   closes or explicitly references the issue and its final change and proof
+   satisfy the issue scope. Reconcile that issue and project state instead of
+   dispatching it again. Do not infer completion from a link alone.
+2. Use Codex thread tools. If visible Codex threads and Codex-managed worktrees
+   are unavailable, stop. Do not replace workers with hidden subagents.
+3. Make every issue a complete task before dispatch. If a missing product or
+   technical decision could change behavior, data, security, compatibility,
+   operations, cost, or proof, mark that issue as needing human input.
+4. Build a dependency graph. Treat GitHub as the durable source of issue, pull
+   request, review, and merge state. Stop for human correction if the graph
+   contains a dependency cycle. Do not create a second local tracker.
+5. Default to two active workers. Use another limit only when the user asks or
+   the repository gives a stricter limit.
+
+## Coordinator workflow
+
+1. Keep the calling thread as coordinator. Name it `#<parent> Coordinator` when
+   the batch has a parent issue.
+2. Reuse an existing active worker for the same issue. Inspect an unclear or
+   interrupted worker before creating another. If the issue already has an
+   open pull request, create or resume its worker on that pull request's exact
+   head branch and include the branch and pull request URL in its prompt.
+   Otherwise create a Codex project thread in a managed worktree from the
+   latest remote default branch and include the required new branch name.
+3. Name every worker `#<issue-number> <short title>`.
+4. Start only issues whose prerequisites are merged. Independent issues may
+   run together up to the worker limit. Do not stack dependent branches in
+   this workflow.
+5. Give the worker the full issue URL, dependency state, repository location,
+   resolved branch and pull request state, and the worker contract below. Tell
+   it to use `/task-to-pr` and pass the coordinator's explicit merge or
+   no-merge mode. Merge mode grants authority only for that worker's issue.
+6. Monitor workers with compact `wait_threads` snapshots. Use `read_thread`
+   only when a worker needs help. Send decisions or corrected scope back with
+   `send_message_to_thread`; do not edit the worker's files from the
+   coordinator.
+7. Continue independent work when one issue is blocked. After three failed
+   attempts at the same check or review finding, pause that issue, record the
+   evidence on GitHub, and request human input.
+8. In merge mode, when a worker reports completion, verify GitHub says the pull
+   request is merged, the issue contains final proof, and the issue is closed.
+   Close it explicitly if the merged pull request did not close it. Then mark
+   the issue Done when the project supports it and archive the worker thread.
+   In no-merge mode, stop that worker after its pull request passes all
+   agent-completable gates, leave the issue in Review, record any pending human
+   approval or merge as its blocker, and leave the thread available.
+9. Refresh the dependency graph after every merge and dispatch newly ready
+   issues from the updated remote default branch. In no-merge mode, when a
+   dependent issue is waiting only for a passing prerequisite pull request to
+   be merged, record that human-merge dependency as its blocker. Do not wait
+   indefinitely or dispatch the dependent from an unmerged branch.
+10. In merge mode, finish only when every in-scope issue is merged, closed, and
+    Done when the project supports that state, or every unfinished issue has a
+    recorded blocker that needs human action. In no-merge mode, finish when
+    every in-scope issue has a ready pull request with all agent-completable
+    gates passing or a recorded human blocker.
+
+## Worker contract
+
+Each worker owns one issue and follows this order:
+
+1. Read the issue, repository instructions, relevant design, code, tests, and
+   dependency pull requests. Move the issue to In Progress when possible.
+2. Use the Codex-managed worktree. If the issue has an open pull request, reuse
+   its exact head branch and pull request. Otherwise create the repository's
+   required issue-linked branch from the updated default branch.
+3. Implement only the issue. Add or update tests for every acceptance
+   criterion, affected failure path, regression risk, and named edge case.
+4. Use `/test`. Browser-facing work requires a real browser check of the
+   affected success and failure flows, responsive widths, keyboard behavior,
+   console errors, and failed requests when relevant.
+5. Commit and push the tested change. Open a draft pull request if one is not
+   already open. Include a short summary and current proof.
+6. Mark the pull request ready for review and move the issue to Review. Do this
+   before requesting independent review or waiting for GitHub review.
+7. Use `/review` with a fresh subagent that did not implement the change. Wait
+   for required CI and automated review. In merge mode, also wait for every
+   repository-required approval. In no-merge mode, do not wait indefinitely
+   for human feedback; record a pending required approval as a human blocker.
+8. Address every valid in-scope finding. Reply to review threads with the fix
+   or evidence for making no change. Resolve a thread only when it is fully
+   addressed.
+9. After any code change, repeat affected `/test` proof and fresh `/review`,
+   commit and push, update the pull request evidence, and wait for CI and
+   automated review again. Iterate until the mode's gates pass; do not
+   manufacture extra rounds or wait indefinitely for optional human feedback.
+10. In merge mode, merge the pull request using the repository's preferred
+    method after every merge gate passes. Never use an admin bypass. Wait until
+    GitHub reports the pull request as merged, record final proof, and verify
+    the issue is closed. Close it explicitly if the pull request did not. In
+    no-merge mode, leave the passing pull request open for a human to merge.
+    Report the final state to the coordinator.
+
+## Merge gates
+
+A worker may merge only when all of these are true:
+
+- The pull request is ready for review, not draft.
+- The complete issue scope and acceptance criteria have recorded proof.
+- Focused and required wider tests pass on the final commit.
+- A fresh `/review` verdict is `Approve` on the final code.
+- Every required GitHub check passes.
+- Every actionable automated or human review thread is resolved.
+- Every repository-required approval is present.
+- The pull request is mergeable and current with its required base.
+- No security, data-loss, compatibility, operational, or product decision is
+  unresolved.
+- The pull request changes only the worker's issue.
+
+If a gate cannot pass, do not merge. Record the blocker and continue other
+independent work.
+
+## Worker prompt
+
+Use this shape and replace every placeholder:
+
+```text
+Use /task-to-pr to complete <issue URL> in this Codex-managed worktree.
+
+Your thread owns only this issue, branch, worktree, and pull request.
+Branch state: <reuse PR head branch and PR URL, or create new branch name>.
+Delivery mode: <merge after all gates pass, or leave the passing PR open>.
+Read the issue and repository instructions as the source of truth.
+Implement the smallest complete change and prove acceptance criteria, edge
+cases, failure paths, and regressions.
+
+After local proof passes, commit, push, open or update the pull request, and
+mark it ready for review. Only then run fresh independent /review and wait for
+CI and GitHub review. Address valid findings and repeat test and review after
+every code change.
+
+<If merge mode: The user explicitly authorized this /issue-coordinator run to
+merge this issue's pull request after every merge gate passes. Wait until
+GitHub reports the merge, update and close the issue, and return the result.>
+<If no-merge mode: Leave the passing pull request open for human merge and
+return its URL and proof.>
+Do not deploy, publish a release, bypass repository rules, or change unrelated
+work.
+```
+
+## Boundaries
+
+- Use visible Codex threads for workers. Fresh subagents are only for the
+  independent `/review` inside a worker.
+- Never dispatch two workers for one issue or let two workers share a worktree.
+- Never replace or duplicate an existing pull request for the issue. Resume it.
+- Reconcile already-merged pull requests and closed issues before dispatch,
+  but only after their change and proof satisfy the issue scope.
+- Never start dependent work from an unmerged pull request in this workflow.
+- Never merge an unrelated pull request merely because it blocks the batch.
+- Never infer deployment or release authority from merge authority.
+- Do not archive a worker until its merge and final issue state are verified.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -18,11 +18,11 @@ Independent tasks may start together. Start a dependent task after every prerequ
 1. Create or reuse a branch and worktree for the task. Start independent work from the latest default branch and dependent work from its reviewed prerequisite or stacked base.
 2. Write the code.
 3. Use `/test` to prove the task works, affected failures are handled, and refactors preserve behavior.
-4. Use `/review` with a fresh subagent that did not write the code.
-5. Fix valid problems, then repeat `/test` and `/review`.
-6. Commit and push the changes.
-7. Create or update one pull request on GitHub. Include a short summary and the current proof.
-8. Move the ticket to the repository's review state, such as `In Review` or `Review`, when possible.
+4. Commit and push the changes.
+5. Create or update one pull request on GitHub. Include a short summary and the current proof, then mark it ready for review.
+6. Move the ticket to the repository's review state, such as `In Review` or `Review`, when possible.
+7. Use `/review` with a fresh subagent that did not write the code.
+8. Fix valid problems, then repeat `/test` and `/review`. Commit and push every reviewed fix before continuing.
 
 ## Phase 2: Pass the automated checks
 
@@ -36,6 +36,6 @@ Independent tasks may start together. Start a dependent task after every prerequ
 8. Repeat until all available checks pass and the automated review has no unresolved findings.
 9. Update the ticket with final proof and the pull request link when possible. Keep it in the repository's review state while the pull request is open.
 
-If the user asked you to merge the pull requests, merge them in dependency order after their automated checks pass. After each prerequisite merges, retarget its dependents to the default branch, update them to that base, and repeat `/test`, `/review`, CI, and automated review before merging them. Wait until GitHub reports each pull request as merged before marking its ticket complete when possible. Otherwise, leave it open.
+If the user asked you to merge the pull requests, merge them in dependency order after their automated checks pass, the final `/review` verdict is `Approve`, required approvals are present, and no review thread is unresolved. Explicitly naming `/issue-coordinator`, or explicitly telling its coordinator that agents may merge, is a merge request for only the issues in its supplied batch. Automatic skill selection is not merge authority. After each prerequisite merges, retarget its dependents to the default branch, update them to that base, and repeat `/test`, `/review`, CI, and automated review before merging them. Never bypass repository rules. Wait until GitHub reports each pull request as merged before marking its ticket complete when possible. Otherwise, leave it open.
 
-Continue with every task that can make progress. Stop when every task has a pull request with all available checks passing and no unresolved automated review findings. If no remaining task can move forward, explain what is needed.
+Continue with every task that can make progress. Stop when every task has a pull request with all available checks passing and no unresolved automated review findings. When merge was requested, stop only after every in-scope pull request is merged and its ticket is complete when possible. If no remaining task can move forward, explain what is needed.


### PR DESCRIPTION
## Summary

- add the Codex-only `/issue-coordinator` skill, presented as Ultra-scale issue coordination
- coordinate issue-named worker threads with isolated worktrees, branches, pull requests, dependency scheduling, resume handling, review loops, and gated merges
- distinguish explicit merge authority from implicit skill selection and document no-merge behavior
- align `/task-to-pr` and Blueprint documentation with ready-before-review ordering

## Proof

- all 10 skill frontmatter blocks and names validated
- README local links validated
- coordinator merge modes, exact-branch resume, merged-work reconciliation, dependency stops, and worker order validated
- `git diff --check`
- all 13 existing repository tests pass
- fresh independent review: Approve, no findings

Closes #61
