### PR TITLE
Pin Codex issue coordinator threads

### DIFF
--- a/skills/codex-issue-coordinator/SKILL.md
+++ b/skills/codex-issue-coordinator/SKILL.md
@@ -41,7 +41,9 @@ operations, branch-protection bypasses, or changes outside the supplied batch.
 ## Coordinator workflow
 
 1. Keep the calling thread as coordinator. Name it `#<parent> Coordinator` when
-   the batch has a parent issue.
+   the batch has a parent issue. Use `set_thread_pinned` to pin it at the start
+   of every new or resumed coordinator run, before inspecting or dispatching
+   workers.
 2. Reuse an existing active worker for the same issue. Inspect an unclear or
    interrupted worker before creating another. If the issue already has an
    open pull request, create or resume its worker on that pull request's exact


### PR DESCRIPTION
## Plain English summary

Long-running issue coordinators can disappear among their worker threads. This change tells the coordinator to pin its own thread at the start of every new or resumed run, before it inspects or dispatches workers. Worker behavior and queue scope remain unchanged.

## Reviewer notes

The behavior is instruction-only. Blueprint has no runtime harness for exercising Codex thread pinning.

## Checklist

- **Is this one focused, self-contained change?** Yes
  - One workflow rule in the coordinator skill.
- **Did you write or update tests?** Not applicable
  - No runtime test harness exists for skill-driven Codex thread actions.
- **Did you run the relevant tests and checks?** Yes
  - `git diff --check` passed.
  - YAML frontmatter parsed successfully and retained the expected skill name.
  - Focused assertions proved new-or-resumed pinning before worker handling.
  - Only the coordinator skill changed and no intake or queue behavior was added.
  - Live thread-tool execution remains unverified because there is no runtime harness.
- **Did you independently review the final diff and address valid findings?** Yes
  - Fresh read-only review returned Approve with no findings.
- **Did you update documentation when behavior changed?** Yes
  - The skill instruction is the behavior contract.
- **Did required CI checks pass?** Not configured
  - GitHub reports no checks for this branch.

Closes #66