### PR TITLE
Apply a plain writing standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,6 @@ Blueprint is a small set of instructions for AI coding. It separates deciding wh
 - Keep current architecture separate from proposed design.
 - Review technical proposals before implementation when a wrong choice could materially affect behavior, data, security, scale, performance, compatibility, operations, cost, or proof.
 - Update an existing architecture document when code changes ownership, dependency direction, protocols, stored data, trust boundaries, deployment topology, or hard limits.
-- Start with the simplest useful explanation. Use short sentences and everyday words. Define technical terms before using them.
-- Write for a new teammate. Put detail after the main idea. Remove anything that does not help someone decide, build, test, or review the work.
 - Skip phases that add no value. Small, decided work can go straight to implementation.
 - A task is ready when a new agent can finish it without asking product or technical questions.
 - Each pull request delivers one focused outcome and its proof. A reviewer should not have to separate unrelated work to understand it.
@@ -25,6 +23,23 @@ Blueprint is a small set of instructions for AI coding. It separates deciding wh
 - Prefer the smallest complete change. Do not mix product work with unrelated cleanup.
 - Humans review decisions and normally merge. Agents may merge only when the user explicitly delegates it. Explicitly naming `/codex-issue-coordinator` delegates merge authority for the supplied batch after its quality gates pass; an implicit skill match does not.
 
+## Writing
+
+Write for a new teammate who needs to understand the point on the first read.
+
+- Lead with the outcome, decision, or rule. Put supporting detail after it.
+- Use short sentences and everyday words. Give each sentence one main idea.
+- Write instructions as direct commands. Put a condition before the step it controls.
+- Name the actor. Prefer `the parser rejects the file` to `the file is rejected`.
+- Use the same word for the same thing. Define a necessary technical term once.
+- Use real names, paths, commands, limits, and effects. Replace vague claims with facts.
+- Cut filler, repetition, sales language, fake warmth, and generic conclusions.
+- Use sentence case for headings. Use numbered lists for sequences and bullets for real lists.
+- Keep a human voice. State a judgment when the document calls for one. Keep instructions and reference text neutral.
+- Vary sentence length when it helps the prose sound natural. Do not force every point into the same shape.
+
+Before finishing, reread the text. Cut words that do no work. Fix sentences that can be read two ways. Rewrite anything that sounds generated instead of written for this project.
+
 ## Phases
 
 - `/architecture`: create or update root `ARCHITECTURE.md` from verified implementation. Stop with the document ready for human review.
@@ -36,7 +51,7 @@ Blueprint is a small set of instructions for AI coding. It separates deciding wh
 - `/improve`: inspect existing code and improve its clarity, simplicity, and structure without changing intended behavior.
 - `/codex-issue-coordinator`: coordinate a large GitHub issue batch through separate Codex worker threads, reviewed pull requests, and gated merges.
 
-## Workflow: Code changes
+## Workflow for code changes
 
 For one or more code changes, follow the [`/task-to-pr` skill](skills/task-to-pr/SKILL.md). It stacks dependent work after prerequisite pull requests are open and independently approved, runs independent work at the same time when useful, and takes each task through a tested and reviewed pull request. A milestone is one possible source of tasks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Small documentation corrections can go straight to a pull request.
 
 - Keep one pull request to one outcome.
 - Put repository policy in `AGENTS.md` and phase-specific behavior in the relevant skill.
-- Use short sentences and familiar words. Define project terms before using them.
+- Follow the writing standard in `AGENTS.md`. Lead with the point, use plain words, and cut filler.
 - Do not add placeholders, fake examples presented as proof, or unfinished sections.
 - Update examples and public guides when a skill change would make them inaccurate.
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,20 @@
 
 </div>
 
-Blueprint gives capable coding agents a clear engineering process without turning every change into ceremony. It separates understanding existing code, deciding what to build, and delivering reviewed pull requests.
+Blueprint gives coding agents ten focused workflows. They cover understanding
+existing code, deciding what to build, and delivering reviewed pull requests.
 
 ## Why Blueprint
 
-Agents keep getting better. They need clear standards and useful workflows, not a script for every move.
+Capable agents do not need a script for every move. They need a clear outcome,
+the constraints that matter, and proof that the work is done.
 
 Blueprint turns long-standing software engineering practice into a small set of skills: understand the system, make decisions before expensive changes, keep each task focused, test the result, and review the work. The skills say what good work looks like and what evidence is needed. They leave the mechanics to the agent.
 
-The set is deliberately small. It contains the core skills its maintainer uses every day to build professional software. There is no agent framework or elaborate setup to maintain. Install the skills and use only the ones the work needs.
+The set is deliberately small. It contains the core skills its maintainer uses
+to make changes that another person can understand, test, and review. There is
+no agent framework to maintain. Install the skills and use only the ones the
+work needs.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 </div>
 
-Blueprint gives coding agents ten focused workflows. They cover understanding
+Blueprint gives coding agents ten focused skills. They cover understanding
 existing code, deciding what to build, and delivering reviewed pull requests.
 
 ## Why Blueprint

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -2,8 +2,13 @@
 
 Review Blueprint as a small set of engineering instructions. Read the issue, complete diff, rendered public docs, and relevant surrounding files.
 
-- Can a new teammate understand the summary without already knowing Blueprint terms?
-- Does the writing use short sentences, everyday words, and only useful detail?
+- Does the writing lead with the outcome, decision, or rule?
+- Can a new teammate understand it without already knowing Blueprint terms?
+- Does each sentence carry one main idea in short, everyday words?
+- Does each thing keep the same name throughout the text?
+- Are claims tied to real names, paths, commands, limits, or effects?
+- Did the writer cut filler, repetition, sales language, fake warmth, and generic conclusions?
+- Do headings use sentence case and tell the reader what follows?
 - Does each skill represent one meaningful engineering phase or delivery outcome?
 - Is policy in `AGENTS.md`, with each phase and delivery workflow in its skill?
 - Does `/architecture` create or update root `ARCHITECTURE.md` from verified implementation while `/design` describes a proposed system or feature change?
@@ -32,5 +37,7 @@ Review Blueprint as a small set of engineering instructions. Read the issue, com
 - Are removed concepts handled by an explicit migration instead of compatibility clutter?
 - Can each judgment be decided from evidence? Replace vague terms such as "code health", "adequate", "robust", and "production-ready" with concrete criteria.
 - Is every sentence useful enough to compete for agent attention?
+- Can any sentence be read two ways? If so, rewrite it.
+- Does any passage sound generated instead of written for this project? If so, make it specific or cut it.
 
 Prefer the shortest wording that preserves the rule. Treat extra skills, duplicate workflows, fake reviewer roles, and steps without proof as regressions.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -5,7 +5,7 @@ Review Blueprint as a small set of engineering instructions. Read the issue, com
 - Does the writing lead with the outcome, decision, or rule?
 - Can a new teammate understand it without already knowing Blueprint terms?
 - Does each sentence carry one main idea in short, everyday words?
-- Does each thing keep the same name throughout the text?
+- Does each concept keep the same name throughout the text?
 - Are claims tied to real names, paths, commands, limits, or effects?
 - Did the writer cut filler, repetition, sales language, fake warmth, and generic conclusions?
 - Do headings use sentence case and tell the reader what follows?

--- a/skills/architecture-review/SKILL.md
+++ b/skills/architecture-review/SKILL.md
@@ -5,19 +5,20 @@ user-invocable: true
 argument-hint: "[technical proposal, design, RFC, ADR, or issue]"
 ---
 
-# Architecture Review
+# Architecture review
 
-Review a technical proposal before implementation. It may describe a large
-system change or a small implementation-level design. Review the proposed
-choices, not the document type or size.
+Find choices that could make a technical proposal wrong, unsafe, or impossible
+to prove. Review the proposed behavior and tradeoffs, not the document's size
+or format.
 
-Use one fresh subagent that did not write the proposal. Give it the complete
-review context and tell it to review directly without delegating. If you are
-that reviewer, review directly. Stay read-only.
+Use one fresh subagent that did not write the proposal. Give the reviewer the
+complete context. Tell the reviewer to work directly without delegating. If
+you are that reviewer, review directly. Stay read-only.
 
-If fresh subagents are unavailable, stop and report that independent review is blocked unless the user explicitly accepts a documented self-review.
+If fresh subagents are unavailable, stop and report that independent review is
+blocked. Continue only if the user explicitly accepts a documented self-review.
 
-## Workflow
+## Process
 
 1. Read the goal, proposal, repository instructions, relevant current code,
    tests, schemas, configuration, and linked material. Treat claims about the
@@ -33,9 +34,9 @@ If fresh subagents are unavailable, stop and report that independent review is b
    duplication, or operational work.
 5. Surface material open questions. Recommend an answer when evidence supports
    one. Do not invent questions that cannot change the design.
-6. Return findings, open questions, a short assessment, and one verdict. Do not
-   rewrite the proposal, plan the work, review implementation code, or implement
-   changes.
+6. Return findings, open questions, a short assessment, and one verdict.
+   Do not rewrite the proposal, plan the work, review implementation code, or
+   implement changes.
 
 ## Review focus
 
@@ -78,6 +79,9 @@ For each finding or open question include its location, concrete failure or
 ambiguity, impact, evidence, and the smallest correction or recommended answer.
 Report unclear wording when it prevents a new teammate from explaining,
 evaluating, or implementing the design. Omit other writing preferences.
+
+Use plain words. State the exact condition, failure, and effect. Do not hide an
+unknown behind vague language such as `may have issues` or `could be risky`.
 
 ## Verdict
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -7,13 +7,11 @@ argument-hint: "[repository or existing ARCHITECTURE.md]"
 
 # Architecture
 
-## Outcome
-
 Create or update root `ARCHITECTURE.md` so a new teammate can understand the system that exists in code today.
 
 The document should reveal the few rules that give the system its shape: where truth lives, which way dependencies point, how important work moves through the system, and which boundaries a change must preserve.
 
-## Workflow
+## Process
 
 1. Read the request, repository instructions, and any existing `ARCHITECTURE.md`.
 2. Inspect the implementation. Start with manifests, entry points, configuration, schemas, migrations, infrastructure, tests, and the code behind a few critical flows. Follow evidence rather than trying to read every file.
@@ -27,7 +25,7 @@ The document should reveal the few rules that give the system its shape: where t
 Start every document with this small common frame:
 
 ```markdown
-# <System> Architecture
+# <System> architecture
 
 ## Executive summary
 
@@ -91,3 +89,8 @@ Reread the document and check:
 6. **Separation.** Are all proposed changes kept in design documents rather than presented as implemented architecture?
 
 Correct every issue supported by repository evidence. Put anything that cannot be verified under `Verification` with the evidence needed to resolve it.
+
+## Return
+
+Report the document path, the main sources used to verify it, and any evidence
+gap that remains.

--- a/skills/codex-issue-coordinator/SKILL.md
+++ b/skills/codex-issue-coordinator/SKILL.md
@@ -5,11 +5,11 @@ user-invocable: true
 argument-hint: "<parent issue, milestone, or issue list>"
 ---
 
-# Codex Issue Coordinator
+# Codex issue coordinator
 
-Use one Codex thread as the coordinator. Give each active GitHub issue its own
-Codex worker thread, worktree, branch, and pull request. Keep implementation
-context in workers and dependency state in GitHub.
+Use one Codex thread to coordinate a GitHub issue batch. Give each active issue
+its own worker thread, worktree, branch, and pull request. Workers hold
+implementation context. GitHub holds dependency state.
 
 Explicitly naming `/codex-issue-coordinator`, or explicitly telling the
 coordinator that agents may merge, authorizes in-scope workers to merge their
@@ -165,6 +165,12 @@ return its URL and proof.>
 Do not deploy, publish a release, bypass repository rules, or change unrelated
 work.
 ```
+
+## Return
+
+For each issue, report its worker, pull request, gate state, and blocker. State
+which issues are complete and which need human action. Do not repeat worker
+logs that do not change the result.
 
 ## Boundaries
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -7,7 +7,9 @@ argument-hint: "<feature, problem, or brief>"
 
 # Design
 
-## Workflow
+Settle choices that implementation must not invent. A useful design states the behavior, the main tradeoff, and the proof before code is written.
+
+## Process
 
 1. Read the request, repository instructions, relevant code, and linked material.
 2. Identify choices that would change behavior, interfaces, data, errors, security, operations, or tests.
@@ -112,3 +114,7 @@ Reread the draft once and check each category. Fix any gap you can resolve from 
 10. **Either/or acceptance criteria.** Do not allow both sides of "recovers or retains" to pass. Choose one observable behavior.
 
 Put anything you cannot resolve under Open questions and state whether it blocks task breakdown.
+
+## Return
+
+Report the design path, the main decision and its downside, each blocking question, and the result of the review pass.

--- a/skills/html-doc/SKILL.md
+++ b/skills/html-doc/SKILL.md
@@ -111,4 +111,7 @@ The final page must:
 - include responsive and print styles;
 - embed validated Mermaid SVG as a base64 image and retain the exact source in a disclosure.
 
-Stop when the verified candidate is finalized. Report the output path, source hash, and browser checks performed.
+## Return
+
+Stop when the verified candidate is finalized. Report the output path, source
+hash, and browser checks performed.

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -7,7 +7,9 @@ argument-hint: "[code, files, diff, branch, or improvement focus]"
 
 # Improve
 
-## Workflow
+Make code easier to understand without changing what it does. Reduce the layers a reader must trace and the hidden state they must remember.
+
+## Process
 
 1. Identify the target from the request, current diff, or recently changed code.
 2. Read the target, its tests, and relevant surrounding code. State the behavior that must not change.
@@ -16,6 +18,10 @@ argument-hint: "[code, files, diff, branch, or improvement focus]"
 5. Make focused improvements by deleting, deduplicating, renaming, simplifying, extracting, or inlining.
 6. Preserve public interfaces, data shapes, errors, and user-visible behavior unless the user explicitly asks to change them.
 7. Run tests and checks that cover behavior the refactor can affect. Report what improved, what behavior was preserved, and the evidence.
+
+## Return
+
+State what became simpler, what behavior stayed the same, and which checks prove it. Name any behavior that remains unverified.
 
 ## Boundaries
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -7,7 +7,9 @@ argument-hint: "<design, brief, issue, or request>"
 
 # Plan
 
-## Workflow
+Create tasks that a new agent can finish without making product or technical decisions. Split work by working result, not by file, layer, or team boundary.
+
+## Process
 
 1. Read the source, repository instructions, and relevant code.
 2. Stop and return to design if an unresolved choice would change behavior, interfaces, data, security, scale, performance, compatibility, operations, cost, or proof.
@@ -87,3 +89,8 @@ Before returning the plan, read each task twice:
 2. Agent pass: can a fresh agent find the source, identify dependencies and fixed decisions, implement the task, and prove it without asking a product or architecture question?
 
 Delete repeated background after both passes succeed.
+
+## Return
+
+Return the ordered tasks, their dependencies, and any decision that still
+blocks implementation. Do not add a separate summary that repeats the tasks.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -7,13 +7,17 @@ argument-hint: "[diff, branch, commit, PR, or file path]"
 
 # Review
 
-The reviewer must be a fresh subagent that did not implement the change. Do not edit files or post comments.
+Find defects that can change the result or make the change unsafe. Do not turn personal taste into a finding.
+
+Use a fresh subagent that did not implement the change. Stay read-only. Do not edit files or post comments.
 
 ## Scope
 
 Review the implementation target named by the user. It may be a file, diff, branch, commit, pull request, or other code change on GitHub. Use `/architecture-review` for a technical proposal that has not been implemented.
 
-If the user does not name a target, review the current repository's complete local change set: commits on the current branch relative to the repository's default branch, staged changes, unstaged changes, and untracked files. Use the repository and immediate surrounding code as context. If there are no local changes, say so instead of substituting a whole-repository audit.
+If the user does not name a target, review the repository's complete local change set. Include commits on the current branch relative to the default branch, staged changes, unstaged changes, and untracked files.
+
+Use the repository and the immediate surrounding code as context. If there are no local changes, say so. Do not substitute a whole-repository audit.
 
 ## Standard
 
@@ -44,16 +48,18 @@ The verdict is independent agent evidence. It is not GitHub approval or a replac
 
 ## Code review findings
 
-For code, commit, branch, and pull request reviews, report only real bugs, customer-impacting issues, and proven simplifications introduced or exposed by the change. Check security, logic, behavior, reliability, compatibility, regressions, and affected failure paths. Inspect the immediate surrounding code needed to prove each finding. A simplification must deliver the same outcome and proof with less state, indirection, duplication, or operational work. Report it only as `Could fix`.
+Report only real bugs, customer-impacting problems, and proven simplifications introduced or exposed by the change. Check security, logic, behavior, reliability, compatibility, regressions, and affected failure paths.
+
+Inspect enough surrounding code to prove each finding. A simplification must deliver the same result and proof with less state, indirection, duplication, or operational work. Report it only as `Could fix`.
 
 Use this format for every finding:
 
 ```text
 Priority: Must fix / Should fix / Could fix
-Confidence: 0–5
+Confidence: 0 to 5
 What I found: Describe the technical problem.
 Why it matters: Explain the impact on customers, callers, or the service.
-ELI5: In one or two short sentences, state the exact condition that triggers the problem and what the customer or service experiences. Use no analogies, jargon, or acronyms.
+Trigger and effect: State the exact condition and what the customer or service experiences.
 Where: File and line.
 Suggested fix: Give a short, practical direction.
 ```
@@ -69,9 +75,9 @@ Confidence means:
 - **5:** Confirmed by reproduction, test, or direct code evidence.
 - **4:** Strong evidence with no credible alternative explanation.
 - **3:** Probable, but some runtime evidence is unavailable.
-- **0–2:** Do not report. Investigate further or mark the area unverified.
+- **0 to 2:** Do not report. Investigate further or mark the area unverified.
 
-Write so the developer can quickly understand what is broken, who it affects, and why they should care. Be concise. Do not report style preferences, theoretical concerns, or problems outside the changed code and its immediate context.
+Use plain words. State what breaks, when it breaks, and who it affects. Omit style preferences, theoretical concerns, and problems outside the change.
 
 ## Verdict
 

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -60,7 +60,8 @@ After a prerequisite merges, retarget its dependents to the default branch and u
 Continue with every task that can make progress. For each task, report the pull request, tests, review verdict, CI state, and any blocker.
 
 Without merge authority, stop when every task has a pull request with all
-available checks passing and no unresolved automated review finding. Record
-required human approval or merge as the task blocker. With merge authority,
-stop when every in-scope pull request is merged and its ticket is complete when
-possible. If no task can move forward, state what is needed.
+available checks passing, a final `/review` verdict of `Approve`, and no
+unresolved automated review finding. Record required human approval or merge as
+the task blocker. With merge authority, stop when every in-scope pull request is
+merged and its ticket is complete when possible. If no task can move forward,
+state what is needed.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -60,6 +60,7 @@ After a prerequisite merges, retarget its dependents to the default branch and u
 Continue with every task that can make progress. For each task, report the pull request, tests, review verdict, CI state, and any blocker.
 
 Without merge authority, stop when every task has a pull request with all
-available checks passing and no unresolved automated review finding. With
-merge authority, stop when every in-scope pull request is merged and its ticket
-is complete when possible. If no task can move forward, state what is needed.
+available checks passing and no unresolved automated review finding. Record
+required human approval or merge as the task blocker. With merge authority,
+stop when every in-scope pull request is merged and its ticket is complete when
+possible. If no task can move forward, state what is needed.

--- a/skills/task-to-pr/SKILL.md
+++ b/skills/task-to-pr/SKILL.md
@@ -7,13 +7,19 @@ argument-hint: "<tasks, tickets, pull requests, or milestone>"
 
 # Task to PR
 
-Review the tasks you were given. Decide the order and which tasks can run at the same time. Make a short plan.
+Take each task from a decided outcome to a tested and reviewed pull request. Keep one task, branch, and pull request focused on one result.
 
-Complete each task in two phases. Keep working without waiting for the user while any task can make progress.
+Review the tasks first. Decide their order, note dependencies, and identify work that can run at the same time. Then make a short plan.
 
-Independent tasks may start together. Start a dependent task after every prerequisite has an open pull request, an independent `/review` verdict of `Approve`, and no known blocking finding. Stack dependent work on the prerequisite branch. If several unmerged prerequisites feed one task, stack those prerequisite branches in dependency order before branching the dependent task. When a prerequisite branch or pull request base changes, update every dependent branch to that reviewed state and repeat `/test` and `/review`. Retarget each stacked pull request to the default branch after its prerequisite merges, then repeat the proof against that base.
+## Order dependent work
 
-## Phase 1: Build the code
+- Start independent tasks together when useful.
+- Start a dependent task only after each prerequisite has an open pull request, an independent `/review` verdict of `Approve`, and no known blocking finding.
+- Stack dependent work on the prerequisite branch. If a task has several unmerged prerequisites, stack those branches in dependency order before creating the dependent branch.
+- When a prerequisite branch or pull request base changes, update every dependent branch to that reviewed state. Repeat `/test` and `/review`.
+- After a prerequisite merges, retarget its stacked pull requests to the default branch. Repeat the proof against that base.
+
+## Phase 1: build the code
 
 1. Create or reuse a branch and worktree for the task. Start independent work from the latest default branch and dependent work from its reviewed prerequisite or stacked base.
 2. Write the code.
@@ -24,7 +30,7 @@ Independent tasks may start together. Start a dependent task after every prerequ
 7. Use `/review` with a fresh subagent that did not write the code.
 8. Fix valid problems, then repeat `/test` and `/review`. Commit and push every reviewed fix before continuing.
 
-## Phase 2: Pass the automated checks
+## Phase 2: pass the automated checks
 
 1. Use the GitHub CLI to wait for CI and automated code review when the repository uses them.
 2. Fix failures caused by your changes and valid review findings.
@@ -36,6 +42,24 @@ Independent tasks may start together. Start a dependent task after every prerequ
 8. Repeat until all available checks pass and the automated review has no unresolved findings.
 9. Update the ticket with final proof and the pull request link when possible. Keep it in the repository's review state while the pull request is open.
 
-If the user asked you to merge the pull requests, merge them in dependency order after their automated checks pass, the final `/review` verdict is `Approve`, required approvals are present, and no review thread is unresolved. Explicitly naming `/codex-issue-coordinator`, or explicitly telling its coordinator that agents may merge, is a merge request for only the issues in its supplied batch. Automatic skill selection is not merge authority. After each prerequisite merges, retarget its dependents to the default branch, update them to that base, and repeat `/test`, `/review`, CI, and automated review before merging them. Never bypass repository rules. Wait until GitHub reports each pull request as merged before marking its ticket complete when possible. Otherwise, leave it open.
+## Merge only when asked
 
-Continue with every task that can make progress. Stop when every task has a pull request with all available checks passing and no unresolved automated review findings. When merge was requested, stop only after every in-scope pull request is merged and its ticket is complete when possible. If no remaining task can move forward, explain what is needed.
+If the user asks for merges, merge pull requests in dependency order. Before each merge, confirm that:
+
+- automated checks pass;
+- the final `/review` verdict is `Approve`;
+- required approvals are present; and
+- no review thread remains unresolved.
+
+Explicitly naming `/codex-issue-coordinator` grants merge authority only for that coordinator's issue batch. Automatic skill selection does not grant merge authority.
+
+After a prerequisite merges, retarget its dependents to the default branch and update them to that base. Repeat `/test`, `/review`, CI, and automated review before merging. Never bypass repository rules. Wait until GitHub reports the pull request as merged before marking its ticket complete when possible. If the user did not ask for merges, leave the pull request open.
+
+## Return
+
+Continue with every task that can make progress. For each task, report the pull request, tests, review verdict, CI state, and any blocker.
+
+Without merge authority, stop when every task has a pull request with all
+available checks passing and no unresolved automated review finding. With
+merge authority, stop when every in-scope pull request is merged and its ticket
+is complete when possible. If no task can move forward, state what is needed.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -7,7 +7,9 @@ argument-hint: "<task, acceptance criteria, diff, branch, PR, URL, or flow>"
 
 # Test
 
-## Workflow
+Prove the behavior that matters. A passing build or a source-code reading can support the proof, but neither proves a user-visible flow.
+
+## Process
 
 1. Read the task, its source design when present, changed code, existing tests, and repository instructions. Acceptance criteria come from the task or approved design. Preserve their wording and `AC-n` or `INV-n` IDs. Never rewrite criteria to match the code.
 2. Map every acceptance criterion, cited invariant, and affected failure path to proof by ID. Test changed behavior and behavior a refactor must preserve.
@@ -21,6 +23,19 @@ argument-hint: "<task, acceptance criteria, diff, branch, PR, URL, or flow>"
    - Check console errors and failed requests during every flow.
    - Capture evidence. Reading source is not browser proof.
 8. Report each `AC-n`, `INV-n`, or task criterion as pass, fail, or unverified. Include the command, browser flow, or other evidence.
+
+## Return
+
+Report each criterion in this shape:
+
+```text
+Criterion: <ID or exact wording>
+Result: Pass / Fail / Unverified
+Evidence: <command, browser flow, or artifact>
+Gap: <what remains unknown, or None>
+```
+
+Lead with failures and unverified criteria. Do not hide them below passing checks.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

- add one repository-wide standard for plain, specific writing
- give every skill a clean opening, a clear process, and an explicit return contract
- simplify public and review guidance without changing workflow or safety rules

## Proof

- ./scripts/check: passed (14 repository tests and 13 HTML document tests)
- independent review: Approve
- README checked on GitHub at 1440×900 and 390×844 with no horizontal overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a consistent writing standard covering clarity, terminology, formatting, tone, and editing.
  * Updated contributor guidance and README content for clearer project orientation.
  * Refined architecture, design, planning, improvement, testing, review, and delivery instructions.
  * Added standardized return requirements and clearer reporting expectations across workflows.
  * Strengthened review guidance with defect-focused findings, evidence-based claims, and explicit confidence criteria.
  * Clarified issue coordination, merge authority, verification, blockers, and evidence requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->