### PR TITLE
docs: define the AI engineering lifecycle and Blueprint roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Each skill owns one engineering phase or useful outcome. Repository policy stays
 
 ## Guides
 
+- [The AI engineering lifecycle](guides/lifecycle.md) explains the process from design through release and scaling it into automated systems.
+- [Blueprint improvement plan](guides/blueprint-plan.md) describes the proposed path for skills, evaluations, teaching material, and a website.
 - [Choosing the right skill](guides/choosing-a-skill.md) explains where each skill starts and stops.
 - [Common Blueprint workflows](guides/workflows.md) shows how the skills fit together for small changes, larger features, existing systems, and issue batches.
 - [Examples](examples/) contains reviewed designs and plans you can inspect or reuse.

--- a/guides/README.md
+++ b/guides/README.md
@@ -2,6 +2,8 @@
 
 These guides explain how to use Blueprint without repeating the full skill instructions.
 
+- [The AI engineering lifecycle](lifecycle.md) explains Design, Plan, Build, Test, Review, Ship, and Scale.
+- [Blueprint improvement plan](blueprint-plan.md) proposes stronger skills, evaluations, teaching material, and a website.
 - [Choosing the right skill](choosing-a-skill.md) explains where each skill starts and stops.
 - [Common Blueprint workflows](workflows.md) shows useful paths through the skills for different kinds of work.
 

--- a/guides/blueprint-plan.md
+++ b/guides/blueprint-plan.md
@@ -1,0 +1,150 @@
+# Improve Blueprint as an AI engineering foundation
+
+> Status: Proposed roadmap, 6 September 2026. The lifecycle guide and this plan are documentation delivered now. Skill changes, evaluations, website work, and courses below are planned, not implemented.
+
+## 1. Outcome
+
+Make Blueprint a practical foundation for learning and applying AI software engineering. A developer should be able to understand the lifecycle, choose an appropriate skill, complete a worked example, and judge the result using evidence.
+
+"10x quality" is an ambition, not a measured result. Improve successful task outcomes and reduce unnecessary human supervision before making numerical or competitive claims. A larger skill catalog or a more polished website alone cannot establish that improvement.
+
+The shared model is [Design → Plan → Build → Test → Review → Ship → Scale](lifecycle.md). Blueprint owns the explanation, engineering practices, skills, and teaching examples. Machinist executes selected workflows in code. Blueprint remains useful without Machinist.
+
+## 2. Starting point
+
+Blueprint currently has ten skills, a README, selection and workflow guides, examples, repository validation, and a tested Markdown-to-HTML renderer. Its skills separate existing architecture from proposed design, support small tasks that skip unnecessary phases, and require execution evidence and independent review.
+
+The current checks validate metadata, links, Markdown, and supporting tools. This is useful repository hygiene, but it does not measure whether the engineering skills improve agent behavior. The standalone delivery skill and Codex coordinator also have different dependency and execution rules that need clear routing.
+
+The main gaps are behavioral evidence, coverage of acceptance and release, a consistent learner journey, and a public reading experience that brings the method and examples together.
+
+## 3. Product boundaries
+
+Maintain a small set of skills organized around meaningful engineering outcomes. Writing code, branching, debugging, and repairing remain normal agent activities inside delivery. Add a public skill only when it owns a distinct outcome and has evidence that separate packaging helps.
+
+Repository-specific commands and permissions stay in the consumer repository. Requirements essential to a portable skill must be present in that skill or its shipped references; installing skills does not install Blueprint's own maintainer `AGENTS.md` as policy everywhere.
+
+Keep the Codex coordinator explicitly identified as an optional, harness-specific adapter. Naming a skill must not be confused in teaching material with technical enforcement of permissions. Document the current merge behavior accurately until an intentional policy change is approved and tested.
+
+The website teaches and distributes Blueprint. It is not a hosted coding platform, a task tracker, or a prerequisite for using the skills.
+
+## 4. Milestones and acceptance checks
+
+### B1. Establish the lifecycle and learner entry points
+
+**Result.** A developer can understand the seven stages, the human handoff, and the maker/checker relationship before installing anything.
+
+Publish the lifecycle guide, link it from the README and guides, and make the distinction between specification, ticket, PR, and release consistent across public documentation. Mark current behavior separately from proposed improvements. Use the archive-project example across later lessons so readers do not repeatedly learn a new domain.
+
+**Done when:** a reader can choose a path for a small bug, a feature with open decisions, and an existing PR that needs review; each path names its next artifact and stopping point. The lifecycle document explains QA, missing decisions, and release authority.
+
+**Check:** independent editorial review, repository link checks, and a short walkthrough with community members. Record points where learners choose the wrong stage rather than treating a successful document build as teaching proof.
+
+**Dependencies:** none. The lifecycle guide and navigation changes in this documentation work cover the initial artifact; learner validation remains planned.
+
+### B2. Establish a behavioral baseline
+
+**Result.** Skill improvements can be compared against observed agent behavior.
+
+Start with `test`, `review`, and `task-to-pr`. Build at least ten scenario families: a correct change needing approval; a seeded logic defect; a passing suite that misses a requirement; a browser-only failure; an ambiguous product decision; a scope-expanding review comment; a stale review; an interrupted delivery; an infrastructure failure; and an unauthorized consequential action.
+
+Compare a plain task prompt, Blueprint, and the relevant Addy skills with the same starting repository, model, tools, permissions, and resource budget. Pin the skill versions, include each setup's required references, and record which scenarios are comparable. Run at least three repetitions per comparable scenario and configuration. Start with one supported harness; test a second before claiming portability of measured results.
+
+Use deterministic checks for observable behavior and repository mutations. Use blind human adjudication for scope, findings, and missing decisions; an agent grader may assist but cannot be the only judge. Keep held-out scenarios and add independent cases beyond our own workflow failures. Separate trigger selection tests from execution tests.
+
+**Done when:** another maintainer can reproduce the baseline from documented commands, retrieve traces and artifacts, and see failures as well as successes. No task claims completion solely because the agent wrote the expected phrase.
+
+**Check:** rerun a seeded failure and a correct-change case from clean fixtures. Confirm the evaluator catches the defect and does not reward invented findings. Run mutating GitHub scenarios only in an explicitly disposable repository with a cleanup procedure; local fixtures are the default.
+
+**Dependencies:** B1 terminology and evidence definitions.
+
+### B3. Improve skills using the baseline
+
+**Result.** Existing skills produce more useful decisions and evidence with fewer unnecessary steps.
+
+Review each skill's entry conditions, required context, result, evidence, and stopping behavior. Keep concise core instructions; move substantial examples and specialist guidance into linked references. Avoid introducing a public skill for every technique.
+
+| Area | Improvement to investigate | Evidence required |
+| --- | --- | --- |
+| Design and plan | Scale the document to the decision; make shared decisions and ticket readiness explicit | A new maker can implement without inventing consequential decisions |
+| Test | Connect requirements to meaningful execution, including failure cases and browser behavior | Detect a change that passes existing tests but violates the task |
+| Review | Require supported findings and permit approval of sound changes | Catch seeded defects without increasing false findings |
+| Task to PR | Clarify completion, handling of feedback, and handoff limits | Ready PR or explicit blocker, with no unauthorized merge or repeated work |
+| Coordinator | Make harness requirements and dependency strategy explicit | Missing capabilities fail clearly; dependencies and authority remain correct |
+| Architecture and improve | Preserve the distinction between facts, proposals, and behavior-preserving changes | Claims trace to code; refactors preserve observable behavior |
+
+**Done when:** proposed revisions improve a predeclared primary measure and do not regress correctness or authority checks on the selected evaluation set. Publish tradeoffs and uncertainty. A target for the first iteration is lower median human intervention time at equal or better accepted-outcome rate; establish the numerical goal after measuring B2 and before tuning prompts.
+
+**Check:** repeat B2 with versioned revisions and inspect held-out cases. Investigate regressions instead of changing expectations merely to make a new skill pass.
+
+**Dependencies:** B2. Work on unrelated skills need not wait for a complete catalog rewrite.
+
+### B4. Complete useful SDLC coverage and course examples
+
+**Result.** Learners can connect requirements to release, with enough practice to assess their own work.
+
+Map existing skills to the lifecycle. Extend existing material where it already owns the outcome. Design an acceptance-and-release guide covering human acceptance, target environments, smoke checks, rollback, and post-release verification. Decide through an example whether release needs a dedicated portable skill. Record that decision before adding one. Keep production monitoring and incident response outside the first course unless a lesson needs them to close its release example.
+
+Build seven lessons in lifecycle order. The Scale lesson turns the familiar delivery loop into a proposed executable workflow with explicit inputs, checks, limits, and recovery. It introduces Machinist as the implementation path; the earlier lessons remain useful without it. Each has a learner outcome, one worked example, an exercise, and a completion check. The capstone uses a small application and a ready ticket, includes an intentionally seeded defect for the checker, and ends with explicit release verification or a clearly stated simulated release, followed by an automation exercise using the same task. Label simulated evidence.
+
+**Done when:** each of the seven lifecycle stages has teaching material and a credible way to perform the work; skill coverage does not depend on pretending every stage needs a new skill. A learner can complete the capstone with the supplied starting code and instructions.
+
+**Check:** pilot with community members, record where help was needed, and revise the lessons. Do not publish student quotes or results without their permission.
+
+**Dependencies:** B1; B3-tested practices feed the examples. Course outlines can be prepared while evaluations run.
+
+### B5. Publish a focused Blueprint website
+
+**Result.** Visitors can understand the method, try it, and inspect evidence without reading the entire repository.
+
+Use a static documentation site generated from repository content. Select the static-site tool in the website implementation proposal based on Markdown reuse, accessibility, preview deployment, and maintainer familiarity. This roadmap does not choose a hosting provider or purchase a domain.
+
+| Page | Reader's next action |
+| --- | --- |
+| Home | Understand Blueprint's purpose and choose Learn or Use |
+| Lifecycle | Follow the seven stages and inspect their artifacts |
+| Get started | Install a pinned release and complete one small example |
+| Skills | Choose by outcome, with inputs, stopping points, and examples |
+| Workflows | Follow a small fix, a feature, or an independent review |
+| Examples | Inspect a specification, tickets, PR evidence, and release check |
+| Evaluations | Read reproducible methods, results, limitations, and versions |
+| Teaching | Start an exercise or course module |
+
+Use readable typography, restrained visual design, working mobile navigation, and a clear version indicator. Keep source Markdown authoritative; avoid manually maintaining different lifecycle text in the repository and website. Link to Machinist as the automation path after a learner understands delivery.
+
+**Done when:** a new visitor can choose the correct skill and complete the getting-started example; all published examples and install commands are verified; no superiority claim appears without supporting results. The site works on mobile and desktop, with keyboard navigation and readable code, tables, and diagrams.
+
+**Check:** content/link validation, a production build, desktop and mobile browser checks, keyboard checks, and a learner walkthrough. Treat deployment and domain setup as explicit implementation work with their own review, not as part of creating this plan.
+
+**Dependencies:** B1 for information structure; publish evaluation claims only after B2/B3. A content prototype can proceed alongside evaluations.
+
+### B6. Release and maintain the method
+
+**Result.** Users know what changed and maintainers can detect behavioral regressions.
+
+Version skill releases and website documentation together. Keep compatibility guidance, migration notes, and representative evaluations with each release. Turn confirmed community failure reports into regression scenarios after removing private code and data. Revisit evaluations when a harness or model changes; attribute results to the exact tested combination.
+
+**Done when:** a release can be installed and reproduced, its changes and known limits are documented, and maintainers have a repeatable process for accepting or rejecting skill changes.
+
+**Check:** release rehearsal in a clean environment and rerun of the held-out evaluation set.
+
+**Dependencies:** B3 and B5; incorporate B4 lessons as they are validated.
+
+## 5. Measures that matter
+
+Track accepted task outcomes, missed defects, false review findings, unnecessary human questions, active human intervention time, elapsed time, token usage, and cost when prices are available. Report counts and per-scenario results, not just a blended score. A small benchmark supports conclusions about those scenarios, not all software development.
+
+For the website, observe whether learners find the right starting point and finish an example. Traffic and skill count are secondary. Measure "10x" only against a defined baseline and quantity; do not turn the phrase into an unsupported launch claim.
+
+## 6. Decisions and sequencing
+
+Start with B1 and B2. Begin website content structure and course outlines in parallel, then incorporate evaluated practices before making quality claims. Improve `test`, `review`, and `task-to-pr` before expanding the catalog.
+
+The website implementation still needs a selected tool, hosting arrangement, and visual design. The initial proposed audience is developers who know Git and tests but are learning to delegate work to AI. Validate that audience in the pilot. These decisions do not block writing the lifecycle or measuring existing skills.
+
+This is a roadmap, not an implementation-ready ticket batch. Each milestone should become scoped tasks only after its remaining product and technical choices are settled. No tracker issues, website, or skill changes are created by this plan.
+
+## References
+
+- [Blueprint lifecycle](lifecycle.md), [current skill selection](choosing-a-skill.md), and [repository checks](../scripts/check_repo.py).
+- Addy Osmani's [skills](https://github.com/addyosmani/agent-skills/tree/main/skills) and [evaluation approach](https://github.com/addyosmani/agent-skills/blob/main/evals/README.md). They are comparison inputs, not evidence that Blueprint already performs better.

--- a/guides/lifecycle.md
+++ b/guides/lifecycle.md
@@ -1,0 +1,154 @@
+# Build software with AI: from design to a verified release
+
+Blueprint explains a repeatable engineering process for people building software with AI. Use this lifecycle to decide what work needs to happen, who owns it, and what evidence shows that it is complete.
+
+This guide is for developers who know how a repository, a pull request, and automated tests work. By the end, you should be able to turn a request into a ready ticket, supervise a maker and checker, and distinguish a verified change from a shipped product.
+
+## One lifecycle, seven stages
+
+```text
+Design → Plan → Build → Test → Review → Ship → Scale
+```
+
+These are responsibilities, not seven mandatory agent sessions. Testing happens during building. Review findings send work back to the maker. Production observations can start another design or task. Expand the process when uncertainty or risk requires it; a small, decided change can enter at Build.
+
+| Stage | Question to answer | Output | Ready to move on when |
+| --- | --- | --- | --- |
+| Design | What should change, why does it matter, and how should it work? | A Markdown specification | Consequential decisions and acceptance criteria are explicit |
+| Plan | What deliverable changes will implement the specification? | Ordered tickets, dependencies, and useful milestones | Each ready ticket can be implemented without inventing product decisions |
+| Build | How do we implement this ticket within its constraints? | Code, tests, and a pull request | The scoped change exists and the maker has checked it locally |
+| Test | Does the behavior work when executed? | Automated results and relevant runtime evidence | Acceptance criteria and affected failure paths have evidence |
+| Review | Does the implementation satisfy the contract, and is the proof sufficient? | Independent findings and a verdict | Material findings are addressed or explicitly escalated |
+| Ship | Has the accepted change reached its intended users? | A release and verification of its behavior | The release meets its checks and its owner knows how to recover |
+| Scale | How do we turn repeatable engineering work into an automated system? | Executable workflows, triggers, workers, and operating evidence | The system preserves quality and authority while reducing repeated supervision |
+
+Continuous integration, or CI, runs automated checks when code changes. Passing CI is one part of verification. It does not establish that the requirements were right or that a release has happened.
+
+## Design combines requirements and technical design
+
+Requirements establish **what and why**: the problem, intended outcome, users, scope, and constraints. Technical design establishes **how**: behavior, interfaces, data, important failure cases, and tradeoffs.
+
+Keep these together in a Markdown specification when that helps someone understand the change. Separate documents are useful only when their ownership or size warrants it. Blueprint's current `/design` output defaults to `docs/<feature-slug>/design.md`; "specification" describes the document's purpose, not a required new filename.
+
+A useful specification contains:
+
+- the problem and intended user outcome;
+- the decisions implementation must preserve;
+- interfaces, data changes, and failure behavior where relevant;
+- acceptance criteria and how they will be verified;
+- exclusions and unresolved decisions.
+
+The human owns the product direction and consequential tradeoffs. An agent can research, draft, compare alternatives, and challenge the proposal. It must surface a missing decision when choosing an answer would change the agreed outcome or risk.
+
+Document existing architecture separately from proposed changes. A future design is not evidence of how the current code works.
+
+## Planning makes work delegable
+
+The specification defines a feature or system change. A ticket defines **one deliverable change**. A pull request contains that change and its evidence.
+
+For a small task, the ticket can contain the entire specification. For a larger feature, tickets link to the shared specification and include the requirements specific to their own outcome. Do not duplicate shared decisions across tickets and then let them drift.
+
+A ready ticket identifies:
+
+1. The problem and observable result.
+2. Scope, exclusions, and behavior that must remain unchanged.
+3. Acceptance criteria and verification methods.
+4. Relevant source documents and dependencies.
+5. Any authority or operational limits specific to the work.
+
+A new agent should be able to execute the ticket without access to the author's conversation. Ordinary implementation choices remain with the maker. If a shared decision changes during delivery, revise the specification and affected tickets before continuing.
+
+Milestones group useful outcomes, such as a working private preview. Dependencies describe which outcomes must exist first. They are not an excuse to divide every feature into separate database, API, and UI tickets that cannot be evaluated individually.
+
+The handoff boundary is **a ready ticket**, not merely the existence of a ticket in GitHub, Linear, or Jira.
+
+## The maker builds; the checker independently evaluates
+
+The maker reads the ticket and repository context, implements the change, writes relevant tests, and runs local checks. The maker owns repairs to that implementation.
+
+The checker receives the task, relevant specification, current diff, and verification evidence. It independently checks correctness and the adequacy of that evidence. It can run additional tests and inspect the application, but returns findings rather than editing the maker's change.
+
+```mermaid
+flowchart LR
+    A[Ready ticket] --> B[Maker: build and test]
+    B --> C[Open or update PR]
+    C --> D[CI and independent checker]
+    D --> E{Outcome}
+    E -->|Valid findings| B
+    E -->|Evidence accepted| F[Ready to ship]
+    E -->|Decision missing or budget exhausted| G[Human intervention]
+```
+
+The maker and checker have separate agent contexts. They can use the same model. Separation reduces dependence on the maker's reasoning, but it does not guarantee correctness. The checker still needs enough context and must support findings with evidence.
+
+Review is part of quality assurance, or QA. QA also includes executing user flows, checking failure behavior, and deciding whether the result is fit for its intended use. Reading a diff is not a substitute for exercising a browser interaction.
+
+A test report says what ran and what passed, failed, or remains unverified. A review says whether the implementation and proof satisfy the task. An agent review is neither a human approval nor a substitute for required GitHub approvals.
+
+## Run the ticket-to-PR loop with an explicit boundary
+
+For one ticket, the repeatable loop is build, test, review, collect CI feedback, repair valid problems, and verify the changed result again. The PR may be opened early to obtain remote checks; its existence is not completion.
+
+Choose the repair budget before running the loop. Three repair passes is a reasonable starting policy for the initial Machinist workflow. It is a limit on autonomous work, not permission to accept a defect after three attempts. Exhaustion returns the evidence and the unresolved problem to a human.
+
+Distinguish code defects from missing requirements, unavailable credentials, infrastructure failures, and optional suggestions. They require different responses. A reviewer comment is evidence to assess, not an instruction that must be obeyed.
+
+Verification belongs to a particular code revision. After a repair, recheck affected behavior and obtain an independent review of the changed result. Retain earlier evidence only where it still applies. Missing checks, stale approvals, and an agent saying "done" cannot establish readiness.
+
+## Ship is a separate decision
+
+The human accepts the change against the intended outcome and authorizes the next consequential action. Merge, deployment, and public release are distinct events. A merged PR may still be behind a feature flag or awaiting deployment.
+
+Before release, name the target environment, smoke checks, responsible person, and recovery route. After release, verify the user behavior and relevant operational signals. Failures and observations become inputs to the next task or design.
+
+The first Machinist delivery workflow stops with a PR ready for human acceptance. Automated merging or deployment requires its own explicit workflow and authority.
+
+## Scale builds systems that build software
+
+Scale means encoding repeatable engineering work into an automated system. It is the move from personally driving each step in a terminal to operating workflows that can take work, execute it, check results, and request help when needed. It does not mean scaling the application's traffic or adding agents without a verification plan.
+
+Start with a workflow you understand and have exercised. Put sequencing, waiting, retry budgets, and recovery in code. Give the maker and checker clear assignments. Add a queue or event trigger only after one task can finish or stop predictably. Keep the human's decisions and permissions explicit.
+
+The automated system must make its work visible: what it is doing, what revision it checked, why it stopped, and what someone needs to decide. Test repeated delivery, interruption, missing credentials, stale feedback, and concurrent attempts at the same ticket before increasing throughput.
+
+Scale is a stage in developing your engineering capability, rather than another step to perform after every small release. The system can automate an earlier loop, such as ticket to reviewed PR, while acceptance and release remain human-controlled. Learn the complete path first, then choose which parts deserve automation.
+
+## Worked example: archive a project
+
+This is a fictional teaching example, not evidence from a shipped Blueprint application.
+
+A user says, "Old projects clutter the workspace. Let me archive them."
+
+**Design.** The human and agent agree that workspace editors may archive a project, archived projects disappear from the default list, direct reads remain available to authorized members, and restoration is outside this change. Cross-workspace access must remain forbidden. The Markdown specification records these decisions and the required checks.
+
+**Plan.** One ticket adds the archive operation and default-list behavior, with authorization and persistence tests. A second dependent ticket adds the archive action to the interface and verifies the browser flow. The first delivers useful API behavior; the second builds on its established contract.
+
+**Build and test.** The maker implements the first ticket. It checks authorized archiving, default-list exclusion, retained direct access, and rejection of a caller from another workspace. Test fixtures use at least two workspaces so the authorization check can fail meaningfully.
+
+**Review.** The checker traces the operation against those criteria. If tests only use an administrator, the checker requests evidence for the actual editor role. If the code lacks the workspace boundary check, the maker fixes it and reruns verification. If the checker asks for restoration, the maker points to the agreed exclusion instead of expanding scope.
+
+**Ship.** After both tickets pass their checks, a human accepts the interface behavior, authorizes release, and verifies archiving in the target environment. A release check failing returns the change to diagnosis; a green PR alone does not settle that failure.
+
+**Scale.** After practicing this delivery loop, the team encodes it in a script. Approved tickets can enter a queue, makers implement them in separate workspaces, and checkers return evidence. A deliberately interrupted run must resume the existing PR before the team increases concurrency. People still decide what to build and what to release.
+
+## How Blueprint and Machinist use this lifecycle
+
+Blueprint provides the mental model, teaching material, and reusable engineering skills. People can use the process directly with a coding agent. Skills support the work without replacing the human's responsibility for decisions and acceptance.
+
+Machinist implements the Scale stage by automating selected parts of the same process through executable workflows. Scripts own ordering, waiting, budgets, and recovery. Agents receive explicit phase assignments. A Machinist workflow does not need a skill to decide what stage runs next.
+
+The shared foundation is the lifecycle and evidence standard. Blueprint and Machinist can implement it differently without requiring a runtime dependency between the projects.
+
+## Practice the handoff and choose what to automate
+
+Take a real request and write its outcome, exclusions, acceptance criteria, and verification approach. Decide whether it needs a separate design or fits in one ticket. Ask a fresh agent to identify consequential decisions it would have to invent before implementation.
+
+You have completed the exercise when another person can explain the intended behavior, a maker can start within the agreed scope, and a checker can tell what evidence would disprove completion. If a question changes the product or its risk, return it to Design. Do not solve it by silently making the ticket longer.
+
+After delivering the task, identify one repeated step you could encode in a script. Name its input, success evidence, retry limit, and human stopping point. Describe how you would prove the script can recover from an interruption without creating a second PR.
+
+## Related material
+
+- [Blueprint workflows](workflows.md) and [skill selection](choosing-a-skill.md).
+- [Design](../skills/design/SKILL.md), [planning](../skills/plan/SKILL.md), [testing](../skills/test/SKILL.md), and [review](../skills/review/SKILL.md).
+- Addy Osmani's [lifecycle](https://skills.addy.ie/lifecycle/) and [loop engineering](https://skills.addy.ie/loops/) are useful reference material. This guide uses Blueprint's stage names, authority boundaries, and delivery outcomes.


### PR DESCRIPTION
## Plain English summary

Blueprint needs a shared framework for teaching and improving how people build software with AI. This adds a lifecycle guide covering Design, Plan, Build, Test, Review, Ship, and Scale, plus a proposed roadmap for improving skills, measuring their quality, and publishing teaching material and a website.

## Details

The guide separates a feature specification from a ready task, gives implementation and independent review to different agents, and defines Scale as encoding a repeatable engineering process into automated systems. The roadmap ties skill and website work to learner outcomes and measured behavior before making quality claims.

## Reviewer notes

Start with `guides/lifecycle.md`, then `guides/blueprint-plan.md`. The roadmap proposes future work and marks decisions needing technical design; it does not claim those features or evaluation results exist. The companion Machinist roadmap describes code-driven execution of the same process.

## Checklist

- **Is this one focused, self-contained change?** Yes. The guide, roadmap, and navigation establish Blueprint's engineering foundation.
- **Did you write or update tests?** Not applicable. Documentation only; existing checks cover repository links and structure.
- **Did you run the relevant tests and checks?** Yes. `./scripts/check` and `git diff --check` passed. Read the rendered guides on GitHub, verified the lifecycle diagram, and checked the README at 1440px and 390px with no horizontal overflow.
- **Did you independently review the final diff and address valid findings?** Yes. A separate agent reviewed all three related documents against both repositories. No blocking or important findings remain; all 53 local links resolve.
- **Did you update documentation when behavior changed?** Not applicable. This change adds documentation without changing runtime or skill behavior.
- **Did required CI checks pass?** Yes. Repository and Greptile Review passed on `2037d69`. Automated review reported no actionable findings.
