### PR TITLE
docs(examples): align designs with the compact skill format

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,12 @@
+# Blueprint examples
+
+These examples show the current design format: requirements, user experience, technical design and choices, acceptance and proof, and open questions.
+
+- [RAG chatbot design](rag-chatbot/design.md) develops the [project notes](input.md) into a local API proposal. The [paired plan](rag-chatbot/plan.md) divides it into two useful delivery tasks.
+- [Dispatch design](dispatch-control-plane/design.md) shows a local agent control plane with task execution, history, and recovery.
+
+Both describe whole systems, so their technical sections need more detail than a routine feature. Keep smaller designs shorter. Commands and test scenarios describe the applications to be built; those applications are not implemented in this repository.
+
+The examples are curated teaching material. Judge a generated design by its decisions, user experience, scope, and proof. Different wording or a different valid implementation can satisfy the same brief.
+
+Run `./examples/regenerate.sh` from the repository root to print prompts for making a new RAG design and plan. Review the results before replacing an example. When changing a design's scope or acceptance criteria, update its paired plan too. Published implementation tickets should link to an immutable reviewed design revision.

--- a/examples/dispatch-control-plane/design.md
+++ b/examples/dispatch-control-plane/design.md
@@ -2,265 +2,74 @@
 
 > **Status:** Proposed for review
 >
-> **Scope:** Local-first v1
->
-> **Example:** Reviewed golden output
+> **Scope:** Local V1
 
-## 1. Executive summary
+## 1. Requirements: what and why
 
-Dispatch gives a developer a local web page for giving work to coding agents and checking the results. This web app is the control plane: it stores tasks and decides what runs next. A separate worker runs shell commands and agent prompts, then sends output back to the page.
+A developer wants to give work to coding agents and inspect results without watching several terminals. Build a local web application for creating tasks, seeing progress, reading output, and sending follow-up instructions.
 
-The first version uses Next.js for the web app, a Go worker, and one JSON file for data. This makes the system easy to run and inspect, but it is not safe or reliable enough for a shared production service.
+A task can contain ordered shell commands and agent prompts. Repository setup, tests, and Git operations remain explicit steps. Support one control-plane process and developer-controlled workers. Production durability, multi-user access, machine provisioning, automatic recovery, and agent-created task trees are out of scope.
 
-## 2. Context and scope
+## 2. User experience
 
-Today, a developer must start and watch each agent in a terminal. Dispatch adds a local task queue, run history, and web page. Checkout, setup, test, and push commands stay visible in each task.
+The developer enters a title, prompt, optional working directory, and steps. Omitting steps creates one agent step. The task appears pending, then running when a worker picks it up. Its page shows each step, ordered output, and the final result.
 
-V1 covers one local control-plane process and developer-controlled workers. It does not promise production durability, multi-user isolation, remote-machine provisioning, or automatic recovery of abandoned tasks.
+If a step fails, the page shows its failure and later steps are skipped. A follow-up on a finished task queues a new attempt while keeping previous results. Only the first comment queues that attempt; further comments remain in history. With a prior Claude session, the follow-up can continue that conversation.
 
-## 3. System context
+A worker appears disconnected once its last heartbeat is at least 15 seconds old. Its task remains open until the developer marks the abandoned attempt failed and submits a follow-up. Recovery closes the recorded attempt; it cannot stop a process on an unreachable worker. The developer checks that process before retrying commands with side effects.
 
-```mermaid
-flowchart TB
-    Developer([Developer]) --> UI["Next.js UI"]
-    UI --> API["Control-plane API"]
-    API <--> Store[("Local JSON store")]
-    Worker["Go worker"] <-->|tasks, status, events| API
-    Worker -->|execute| Shell["Local shell"]
-    Worker -->|delegate| Agent["Claude Code or compatible command"]
-```
+Store corruption or a failed write produces an operator-visible error and preserves the last complete state. V1 requires manual history cleanup as data grows.
 
-The web app decides which task runs next and stores task status and history. Workers run local processes, but they do not choose task order or own stored data.
+## 3. Technical design and choices
 
-## 4. Proposed design
-
-### How it works
-
-A developer creates a task with a title and prompt. The task may also name a working directory and an ordered set of steps. If it has no usable steps, the web app creates one agent step from the prompt.
-
-A worker registers and sends a heartbeat every 5 seconds. While idle, it asks for work every 2 seconds. The web app changes one pending task to running and creates its run in a single write before returning the steps.
-
-The worker runs each step in order. It marks the step as running, then sends four kinds of event: system messages, standard output (`stdout`), standard error (`stderr`), and agent events. Each event has a stable sequence number. The worker then records the result. A failed step marks every later step as skipped. If every step succeeds, the worker marks the run and task as succeeded.
-
-A user can follow up after a task has `succeeded` or `failed`. In one write, the web app changes the task back to `pending` and stores the new comment as its trigger. The next worker claim consumes that trigger and creates exactly one linked run.
-
-The first run uses the task prompt. A follow-up run uses the original prompt followed by the triggering comment under a `Follow-up:` label. More comments are saved while the task is pending or running, but they do not queue more runs.
-
-When the previous run has a Claude session ID, the first Claude step resumes that session with the follow-up prompt and keeps the earlier history. Later Claude steps start new sessions with the same prompt. The run stores the latest session ID it receives.
+### Components and storage
 
 ```mermaid
-sequenceDiagram
-    participant W as Worker
-    participant API as Control-plane API
-    participant R as Step runtime
-
-    W->>API: Claim next task
-    API-->>W: Task, run, and ordered steps
-    loop Each step until one fails
-        W->>API: Mark step running
-        W->>R: Execute shell command or agent prompt
-        R-->>W: Output, events, and exit code
-        W->>API: Append events
-        alt Step succeeds
-            W->>API: Complete run step as succeeded
-        else Step fails
-            W->>API: Complete run step as failed
-            API->>API: Skip later steps and fail run and task
-        end
-    end
-    opt Every step succeeds
-        W->>API: Complete run as succeeded
-    end
+flowchart LR
+    Developer[Developer] --> UI[Next.js UI]
+    UI --> API[Control-plane API]
+    API --> Store[JSON store]
+    Worker[Go worker] <-->|claims, status, output| API
+    Worker --> Runtime[Shell or agent process]
 ```
 
-### Components and responsibilities
+Use Next.js for the UI and API, with a separate Go worker for process execution. This keeps task lifetimes independent of the web server, at the cost of running two processes. Start the control plane with `just dev`.
 
-| Component | Owns | Depends on | Does not own |
-| --- | --- | --- | --- |
-| Next.js UI | Task creation and review experience | Control-plane API | Task state or process execution |
-| Control-plane API | Validation, assignment, status transitions, and event ordering | Store | Local command execution |
-| JSON store | Durable local task, run, step, comment, and event records | Local filesystem | Concurrency across control-plane processes |
-| Go worker | Host identity, polling, heartbeats, and sequential step execution | Control-plane API and local runtimes | Scheduling or durable history |
-| Agent adapter | Structured Claude invocation and session continuation | Agent runtime | Task policy or Git behavior |
+Use one JSON store for tasks, runs, steps, comments, and events. Serialize every mutation through `withStore` and atomically replace the file. This avoids a database setup step but limits the service to one control-plane process. Refuse to mutate corrupt data; a failed replacement leaves the previous file intact. Keep worker API contracts in shared fixtures so TypeScript and Go stay consistent.
 
-### Decisions
+A task owns its reusable step definitions and comments. Each claim creates a new run with separate step results, an immutable worker owner, and the effective prompt. The control plane generates opaque IDs and allocates increasing event sequence numbers. Workers execute commands and report results; the API owns scheduling and stored status.
 
-**Keep execution outside Next.js.** Running workers inside the web server would simplify startup, but task lifetimes would share the web process and make separate or remote workers harder later.
+### Claims, execution, and follow-up
 
-**Start with serialized JSON storage.** Postgres would improve concurrency and durability, but adds setup before the local delegation loop is validated. All mutations therefore pass through one `withStore` path that reads, changes, and atomically replaces the file.
+Task creation accepts `{title, prompt, working_directory?, steps?}`. Workers register, heartbeat every 5 seconds, and poll for work every 2 seconds while idle. Claiming atomically assigns one pending task and creates its run. A worker may own only one running run; another claim returns `409/worker_busy` without changing a task.
 
-**Represent work as ordered steps.** A single prompt is smaller, but it cannot make checkout, setup, test, and push behavior explicit. Defaults may create one agent step without hiding the step model.
+Steps execute in index order. Shell steps execute the supplied shell command. Agent prompts are passed as a single literal argument, with no shell interpolation. Every report includes worker ID and run ID. Reject non-owner reports, invalid transitions, and changes to finished runs.
 
-**Keep repository operations explicit.** Dispatch executes the supplied steps rather than embedding project-specific Git and workspace policy.
+The first follow-up on a terminal task stores its comment ID as a pending trigger. The next claim consumes it in the same write that creates the run. Build the prompt from the original task prompt plus the triggering text under `Follow-up:`. The first Claude step may resume the previous session; later Claude steps start new sessions. Keep the latest returned session ID with the run. This supports continuation while preserving each attempt's history.
 
-## 5. Invariants and requirements
+### Failure and operations
 
-### Invariants
+A failed or interrupted run keeps completed steps, fails the active step or first pending step, and skips remaining pending steps. Manual recovery uses that same threshold: the last heartbeat must be at least 15 seconds old. It records `worker_lost`. Late reports cannot reopen it. There is no automatic reassignment because the old process may still have side effects.
 
-- `INV-1`: Each running run has one owning worker, and each worker owns at most one running run.
-- `INV-2`: A worker executes a run's steps in ascending index order.
-- `INV-3`: A failed step marks every later step in that run skipped before the run becomes failed.
-- `INV-4`: Event sequence numbers increase monotonically within a run.
-- `INV-5`: A terminal-task follow-up stores at most one pending trigger, which a claim consumes into exactly one new run without rewriting earlier history.
-- `INV-6`: The control plane, not a worker, is authoritative for task and run status.
+Worker shutdown stops polling, sends `SIGTERM` to its child, and escalates to `SIGKILL` after 10 seconds. Report `worker_shutdown` when the API is reachable; otherwise use manual recovery. Web shutdown stops new claims and finishes the active store mutation. Restart reloads history; restarting a worker does not resume an old command automatically.
 
-### Requirements
+Commands use the worker user's permissions. There is no sandbox, authentication, or tenant isolation. Keep the service on developer-controlled machines and networks. Output grows without a capacity promise; document manual cleanup. Logs identify tasks and runs without duplicating command-output secrets into metadata.
 
-- Developers can create tasks from a web UI or API.
-- One or more local workers can register, heartbeat, claim tasks, and report completion.
-- Tasks contain ordered shell and agent steps.
-- Tasks retain comments. Runs retain status and ordered event streams for review.
-- Follow-up replies on terminal tasks can continue the previous Claude Code session.
-- A developer can recover an abandoned run after its worker has been disconnected for at least 15 seconds, then submit a follow-up to retry it.
-- The control plane starts with `just dev`; workers run as separate processes.
-- Checkout, setup, test, and push behavior remains explicit in task steps.
+## 4. Acceptance and proof
 
-## 6. Interfaces and data
+Use `scripts/fake-claude` for deterministic worker tests before exercising a real runtime. The application must provide `just test` for API/store contract tests and worker process tests. Check the actual UI in a browser.
 
-The shared TypeScript model is the contract used by the UI, API, store, and worker responses.
+| ID | Done when | How to check |
+|---|---|---|
+| AC-1 | A mixed shell/agent task shows ordered progress, output, and terminal status. | Start `just dev` and a worker with the fake runtime. Submit a task in the browser and inspect each step and event sequence. |
+| AC-2 | Claims assign a task once and a worker owns at most one running run. | Race two workers for one task; attempt a second claim from a busy worker and assert no other task changes. |
+| AC-3 | Failure stops later steps and only the owner can report progress. | Fail a middle step; submit non-owner and invalid-transition reports; verify preserved completed results and skipped pending work. |
+| AC-4 | Follow-up creates one new attempt with its own results and the correct prompt. | Race comments, restart before claiming, then inspect the trigger, prior history, literal prompt argument, and Claude session continuation. |
+| AC-5 | Recovery is guarded and terminal history cannot be rewritten. | Stop heartbeats; reject recovery while the last heartbeat is less than 15 seconds old and allow it at 15 seconds. Recover before, during, and after step execution; reject late output and completion. |
+| AC-6 | Shutdown follows the declared deadlines and preserves stored history. | Use a child that ignores `SIGTERM`; verify escalation and failure reporting. Interrupt a store mutation and confirm completion before web shutdown. |
+| AC-7 | Store failures preserve the last complete file. | Corrupt a copy, fail a replacement, and simulate disk exhaustion. Assert visible errors and unchanged prior data. |
+| AC-8 | The real adapter works beyond the fake runtime. | Repeat task creation and follow-up with Claude Code; verify output and session reuse in the browser. |
 
-| Type | Purpose |
-| --- | --- |
-| `Host` | Machine identity and labels |
-| `Worker` | Runtime process attached to a host |
-| `Task` | User-facing work item, current state, and optional pending trigger comment ID |
-| `TaskStep` | Reusable ordered shell or agent definition |
-| `TaskRun` | Execution attempt, immutable worker ID, effective prompt, status, failure reason, optional trigger comment ID, and optional Claude session ID |
-| `TaskRunStep` | Per-run step status, timing, exit result, and failure reason |
-| `TaskComment` | Task-owned user, agent, or system comment |
-| `TaskEvent` | Ordered output or lifecycle event |
+## 5. Open questions
 
-Task creation accepts a title, prompt, optional working directory, and optional step definitions. When no usable steps are supplied, the control plane creates one default agent step from the task prompt.
-
-Every comment belongs to one task and cannot change. The first follow-up on a finished task moves it to `pending` and stores that comment ID as the trigger.
-
-A successful claim makes these changes in one write:
-
-1. Copy the trigger ID and resolved prompt to the new run.
-2. Record the claiming worker ID as the run owner.
-3. Clear the trigger from the task.
-
-The first claim copies the task prompt because it has no follow-up. Every claim response includes the prompt to run. The JSON file keeps a pending trigger across web app restarts. Since writes run one at a time, only one of several comments can move a finished task to `pending`. The other comments stay in history but link to no run.
-
-The worker protocol uses these operations:
-
-```text
-POST /api/tasks                            -> created pending task
-POST /api/tasks/{task_id}/comments         -> recorded comment and queue result
-POST /api/workers/register                 -> host and worker record
-POST /api/workers/{worker_id}/heartbeat    -> refreshed heartbeat
-POST /api/workers/{worker_id}/claim        -> task, run, and run steps; no work; or worker_busy
-POST /api/runs/{run_id}/steps/{index}/start
-POST /api/runs/{run_id}/events
-POST /api/runs/{run_id}/steps/{index}/complete
-POST /api/runs/{run_id}/complete
-POST /api/runs/{run_id}/fail               -> worker-reported run failure
-POST /api/runs/{run_id}/recover            -> guarded manual recovery
-```
-
-Task status moves from `pending` to `running`, then to `succeeded` or `failed`. A follow-up can move a finished task back to `pending`.
-
-A run is created only after a worker claims a task. Its status is `running`, `succeeded`, or `failed`. Each step moves from `pending` to `running`, then to `succeeded` or `failed`. After a failure, unstarted steps move to `skipped`.
-
-A worker that already owns a running run receives `409` with `worker_busy` when it tries to claim more work. The claim changes no task. Every worker update includes its worker ID. The web app rejects the update unless that ID owns the run. It also rejects invalid status changes and all updates to finished runs.
-
-Claude Code has a structured adapter. Every agent step receives the run's effective prompt. Other agent commands receive that prompt as a direct argument without shell interpolation:
-
-```text
-argv[0] = <command>
-argv[1] = -p
-argv[2] = <run effective prompt>
-```
-
-### Naming and identity
-
-On first start, a worker creates an opaque host ID, which carries no user data, and stores it in its local configuration directory. Later worker processes reuse that ID. Startup fails if the identity file exists but cannot be read.
-
-Deleting the file creates a new host identity on the next start. Existing records keep the old ID. Each process registration receives a new opaque worker ID. A restart therefore keeps the host identity but creates a new worker session.
-
-The control plane generates opaque IDs for tasks, runs, comments, and events. A task step is identified by its task ID and stable zero-based index. Event sequence numbers are allocated by the control plane, not accepted from workers. A resumed Claude session ID is provider metadata attached to a run and never used as Dispatch identity.
-
-## 7. Failure behavior and lifecycle
-
-- A failed step records its output and exit status, marks later run steps skipped, marks the run and task failed, and stops execution.
-- A worker claims one task at a time. The UI marks it disconnected when no heartbeat arrives for 15 seconds, but V1 does not reassign its running task automatically.
-- A developer may recover an abandoned run only after its worker has been disconnected for at least 15 seconds. One store write marks the running step as failed with reason `worker_lost`. If no step is running, it fails the first pending step. It then skips later pending steps and fails the run and task. If all steps had succeeded, it keeps those results and fails only the run and task with reason `worker_lost`.
-- Worker event, step, completion, and failure reports with a missing or different worker ID are rejected.
-- After manual recovery, the control plane rejects late events and completion reports from the abandoned run because terminal history cannot be rewritten.
-- A corrupt store file stops mutations and reports an operator-visible error instead of replacing the file with empty state.
-- A failed store replacement leaves the previous complete file in place.
-- Restarting the control plane reloads the JSON store. Restarting a worker registers a new worker session and does not silently resume an in-flight command.
-- Control-plane shutdown stops new claims and lets the active serialized store mutation finish before exit.
-- Worker shutdown stops polling and sends `SIGTERM` to an active child process. It waits up to 10 seconds, then sends `SIGKILL`. It reports the run and task as failed with reason `worker_shutdown`. The running step, or next pending step, fails and later pending steps are skipped. Completed steps keep their results. If the worker cannot reach the web app, the run stays open until the developer recovers it.
-
-## 8. Security, privacy, and operations
-
-Shell commands and agent runtimes execute with the worker user's permissions. V1 has no sandbox, secret boundary, authentication, or tenant isolation and must stay on developer-controlled machines and networks.
-
-Each worker runs at most one task at a time. It sends a heartbeat every 5 seconds and asks for work every 2 seconds while idle. One web app process runs all file changes one at a time.
-
-Task events and output make the JSON file grow without a limit in V1. If a write fails, including when the disk is full, the API shows an error and keeps the previous complete file. The UI and docs must explain manual cleanup and that this version has no production capacity promise.
-
-The control plane exposes worker heartbeat age, task and run status, step exit codes, and ordered event history. Logs include task and run IDs but must not copy secrets from command output into separate metadata.
-
-## 9. Acceptance criteria
-
-- `AC-1`: A developer can create a task and see it move from `pending` to `running` to `succeeded` or `failed`.
-- `AC-2`: A worker claims at most one task at a time and executes its steps in order.
-- `AC-3`: Concurrent claim requests assign a pending task to at most one worker.
-- `AC-4`: A worker keeps one host ID across restarts, receives a new worker ID for each process, and appears disconnected after 15 seconds without a heartbeat.
-- `AC-5`: Shell and agent output appears in the task event stream with stable sequence numbers.
-- `AC-6`: A failed step stops the remaining steps and records the failure.
-- `AC-7`: Every run has separate step status and exit records; a follow-up never resets or reuses an earlier run's step records.
-- `AC-8`: A user follow-up on a succeeded or failed task persists its comment ID as the pending trigger. The next claim consumes that marker to create exactly one linked run, preserves previous history, and can reuse the prior Claude session ID. Extra or concurrent comments before that claim do not replace the marker or create extra runs.
-- `AC-9`: The initial run uses the task prompt. A follow-up run uses the original task prompt plus the labeled triggering comment body, and its first Claude agent step receives that resolved text when resuming the prior session.
-- `AC-10`: Agent prompts containing quotes or shell syntax arrive as one literal process argument.
-- `AC-11`: A corrupt store or failed file replacement does not reset existing state.
-- `AC-12`: Worker shutdown sends `SIGTERM`, escalates to `SIGKILL` after 10 seconds, and reports interrupted work as failed with reason `worker_shutdown` when the control plane is reachable.
-- `AC-13`: A developer can recover abandoned work only after its worker has been disconnected for at least 15 seconds. Recovery handles disconnection before the first step, during a step, between steps, and after the last step but before run completion according to the documented atomic transition.
-- `AC-14`: Late events or completion reports cannot change a manually failed run.
-- `AC-15`: A worker that does not own a run cannot append events or change its step, run, or task state.
-- `AC-16`: The full local flow works with `scripts/fake-claude` before a real agent runtime is required.
-
-## 10. Test approach
-
-- Start the control plane and a worker using `scripts/fake-claude`. (`AC-16`)
-- Create a task containing both shell and agent steps and verify ordered execution, event sequence numbers, and terminal status in the UI. (`AC-1`, `AC-2`, `AC-5`; `INV-2`, `INV-4`)
-- Race two workers against one pending task and verify only one claim succeeds. (`AC-3`; `INV-1`, `INV-6`)
-- Give one worker two pending tasks, claim once, then verify its second claim returns `409` with `worker_busy` and leaves the other task pending. (`AC-2`; `INV-1`)
-- Restart a worker and verify the host ID is stable, the worker ID changes, and the old worker becomes disconnected after 15 seconds. (`AC-4`)
-- Force a step failure and verify later run steps become skipped without starting. (`AC-6`; `INV-3`)
-- Run a follow-up and verify it receives new run-step records while the previous run's records remain unchanged. (`AC-7`; `INV-5`)
-- Add follow-ups to succeeded and failed tasks and verify each next claim creates exactly one linked run without rewriting history. Restart the control plane before the claim and verify the pending trigger survives. Race two follow-up comments and verify exactly one becomes the trigger while both remain in task history. (`AC-8`; `INV-5`, `INV-6`)
-- Inspect the claim and fake Claude invocation to verify an initial run receives the task prompt. Verify a follow-up run receives the original prompt plus one labeled copy of the triggering comment body in the resumed first Claude step. (`AC-9`; `INV-5`)
-- Submit event, step, completion, and failure reports with a different worker ID and verify every mutation is rejected. (`AC-15`; `INV-1`, `INV-6`)
-- Pass a prompt containing spaces, quotes, `$()`, and semicolons through the fallback adapter and verify it arrives as one literal argument without shell execution. (`AC-10`)
-- Corrupt a copied store and force a replacement failure to verify the original state is not replaced. (`AC-11`)
-- Interrupt the control plane during a store mutation and verify the mutation finishes before exit.
-- Interrupt a worker during active work and verify `SIGTERM`, 10-second escalation, and the `worker_shutdown` failure when the control plane is reachable. (`AC-12`; `INV-3`, `INV-6`)
-- Make the control plane unreachable during worker shutdown, then verify the disconnected-worker recovery action is unavailable before 15 seconds. After 15 seconds, exercise recovery after claim but before step start, during a step, between steps, and after the final step but before run completion. Verify `worker_lost`, failed and skipped step states where applicable, and failed run and task state. Submit a late event and completion report from the old worker and verify both are rejected. (`AC-13`, `AC-14`; `INV-3`, `INV-6`)
-- Repeat the happy path with a real Claude Code worker before declaring the adapter complete. (`AC-16`)
-
-## 11. Risks and tradeoffs
-
-| Risk | Consequence | Mitigation for V1 |
-| --- | --- | --- |
-| JSON storage | Lost updates or slow rewrites as history grows | Run one control-plane process, serialize mutations, and replace files atomically |
-| Abandoned tasks | A crashed worker can leave work running forever | Expose stale heartbeat and a guarded manual failure action; automatic leases are out of scope |
-| TypeScript and Go models drift | Runtime contract failures | Keep the worker API small and cover it with shared fixtures |
-| Local command execution | Host access and secret exposure | Limit V1 to developer-controlled machines and document the trust boundary |
-| Explicit task steps | More setup for users | Provide useful defaults without hiding the execution model |
-
-## 12. Open questions
-
-- What event retention or compaction policy should replace manual cleanup before production use? This does not block local V1.
-- What lease and idempotency model should reclaim abandoned tasks? This blocks distributed or unattended use, not local V1.
-
-## 13. Out of scope
-
-- Production durability or horizontally scaled control planes
-- Multi-user authentication and tenant isolation
-- Worker-machine provisioning
-- A distributed scheduler or automatic lease recovery
-- Budgets and agent-created task trees
-- Equal first-class support for every agent runtime
+What should replace manual history cleanup and recovery for unattended use? Recommended next step: design retention and leases before expanding beyond local V1. This does not block the scoped local version.

--- a/examples/dispatch-control-plane/design.md
+++ b/examples/dispatch-control-plane/design.md
@@ -43,13 +43,13 @@ A task owns its reusable step definitions and comments. Each claim creates a new
 
 Task creation accepts `{title, prompt, working_directory?, steps?}`. Workers register, heartbeat every 5 seconds, and poll for work every 2 seconds while idle. Claiming atomically assigns one pending task and creates its run. A worker may own only one running run; another claim returns `409/worker_busy` without changing a task.
 
-Steps execute in index order. Shell steps execute the supplied shell command. Agent prompts are passed as a single literal argument, with no shell interpolation. Every report includes worker ID and run ID. Reject non-owner reports, invalid transitions, and changes to finished runs.
+Steps execute in index order. Recording the last successful step marks the run and task succeeded in the same store write; there is no separate run-completion report. Shell steps execute the supplied shell command. Agent prompts are passed as a single literal argument, with no shell interpolation. Every report includes worker ID and run ID. Reject non-owner reports, invalid transitions, and changes to finished runs.
 
 The first follow-up on a terminal task stores its comment ID as a pending trigger. The next claim consumes it in the same write that creates the run. Build the prompt from the original task prompt plus the triggering text under `Follow-up:`. The first Claude step may resume the previous session; later Claude steps start new sessions. Keep the latest returned session ID with the run. This supports continuation while preserving each attempt's history.
 
 ### Failure and operations
 
-A failed or interrupted run keeps completed steps, fails the active step or first pending step, and skips remaining pending steps. Manual recovery uses that same threshold: the last heartbeat must be at least 15 seconds old. It records `worker_lost`. Late reports cannot reopen it. There is no automatic reassignment because the old process may still have side effects.
+A failure or interruption atomically fails the run and task, keeps completed steps, fails the active step or first pending step, and skips remaining pending steps. Manual recovery uses that same threshold: the last heartbeat must be at least 15 seconds old. It records `worker_lost`. Late reports cannot reopen it. There is no automatic reassignment because the old process may still have side effects.
 
 Worker shutdown stops polling, sends `SIGTERM` to its child, and escalates to `SIGKILL` after 10 seconds. Report `worker_shutdown` when the API is reachable; otherwise use manual recovery. Web shutdown stops new claims and finishes the active store mutation. Restart reloads history; restarting a worker does not resume an old command automatically.
 
@@ -63,9 +63,9 @@ Use `scripts/fake-claude` for deterministic worker tests before exercising a rea
 |---|---|---|
 | AC-1 | A mixed shell/agent task shows ordered progress, output, and terminal status. | Start `just dev` and a worker with the fake runtime. Submit a task in the browser and inspect each step and event sequence. |
 | AC-2 | Claims assign a task once and a worker owns at most one running run. | Race two workers for one task; attempt a second claim from a busy worker and assert no other task changes. |
-| AC-3 | Failure stops later steps and only the owner can report progress. | Fail a middle step; submit non-owner and invalid-transition reports; verify preserved completed results and skipped pending work. |
+| AC-3 | Failure stops later steps and only the owner can report progress. | Fail a middle step; submit non-owner and invalid-transition reports; verify preserved completed results and skipped pending work. Complete the last step and assert step, run, and task success commit together. |
 | AC-4 | Follow-up creates one new attempt with its own results and the correct prompt. | Race comments, restart before claiming, then inspect the trigger, prior history, literal prompt argument, and Claude session continuation. |
-| AC-5 | Recovery is guarded and terminal history cannot be rewritten. | Stop heartbeats; reject recovery while the last heartbeat is less than 15 seconds old and allow it at 15 seconds. Recover before, during, and after step execution; reject late output and completion. |
+| AC-5 | Recovery is guarded and terminal history cannot be rewritten. | Stop heartbeats; reject recovery while the last heartbeat is less than 15 seconds old and allow it at 15 seconds. Recover before a step, during a step, and between steps. After the last step succeeds, reject recovery because the run is already terminal. Reject late output and completion for recovered runs. |
 | AC-6 | Shutdown follows the declared deadlines and preserves stored history. | Use a child that ignores `SIGTERM`; verify escalation and failure reporting. Interrupt a store mutation and confirm completion before web shutdown. |
 | AC-7 | Store failures preserve the last complete file. | Corrupt a copy, fail a replacement, and simulate disk exhaustion. Assert visible errors and unchanged prior data. |
 | AC-8 | The real adapter works beyond the fake runtime. | Repeat task creation and follow-up with Claude Code; verify output and session reuse in the browser. |

--- a/examples/rag-chatbot/design.md
+++ b/examples/rag-chatbot/design.md
@@ -1,204 +1,65 @@
-# RAG Chatbot API
+# RAG chatbot API
 
 > **Status:** Proposed for review
 >
-> **Source:** [`examples/input.md`](../input.md)
->
-> **Example:** Reviewed golden output
+> **Source:** [Project notes](../input.md)
 
-## 1. Executive summary
+## 1. Requirements: what and why
 
-Build a small API where one person can upload PDFs and ask questions about them. Each answer must use the uploaded text and show which parts it used. If the documents do not contain the answer, the API says so.
+A person with a collection of PDFs wants answers without searching each document by hand. Build a local API that lets them upload, list, and delete documents, then ask questions with source text attached to each answer. When the collection contains no relevant information, say so.
 
-Use FastAPI, OpenAI, and PostgreSQL with its pgvector search extension. Keep uploads in the request instead of using a background job. This makes the first version easier to run and test, but large uploads take longer.
+V1 serves one trusted user through Docker Compose. Support text PDFs up to 25 MiB. Authentication, multiple users, OCR, conversation history, streaming, and background ingestion are out of scope.
 
-## 2. Context and scope
+## 2. User experience
 
-The project starts with no application. The first version must support the full local path from PDF upload to an answer based on that PDF. It must also list and delete documents. It runs with Docker Compose and assumes one trusted user, so login and separation between users are outside this design.
+1. Upload a PDF. A successful response contains its ID, filename, upload time, and chunk count. Chunks are searchable sections of the document. Processing finishes before the response; a failed upload creates no document.
+2. List uploaded documents or delete one by ID. Deletion removes its searchable content. Uploading the same filename twice creates separate documents.
+3. Submit a question. Receive an answer plus source entries containing document ID, filename, chunk position, and text. Sources are ordered by relevance.
+4. If nothing relevant is found, receive `{"answer":"No relevant information found in uploaded documents.","sources":[]}`.
 
-## 3. System context
+Invalid files and empty questions return a clear request error. Oversized files, missing documents, provider failures, and database failures have distinct error responses. Failures never appear as successful answers. The health endpoint reports database availability.
 
-```mermaid
-flowchart TB
-    subgraph API["FastAPI service"]
-        Upload["Document endpoints"]
-        Chat["Chat endpoint"]
-        Extract["PDF extraction and chunking"]
-        Provider["OpenAI adapter"]
-    end
+## 3. Technical design and choices
 
-    User([User]) --> Upload
-    User --> Chat
-    Upload --> Extract --> Provider
-    Chat --> Provider
-    Upload --> DB[("PostgreSQL + pgvector")]
-    Chat --> DB
-    Provider --> OpenAI["OpenAI API"]
-```
+### Stack and processing
 
-The API checks requests and runs each step in the right order. PostgreSQL stores the documents and text chunks. OpenAI turns text into vectors for search and writes answers, but it stores no application data.
+Use Python with FastAPI and `uv`, as requested in the brief. FastAPI provides the HTTP boundary; application services own ingestion and retrieval; a provider adapter keeps OpenAI calls replaceable in tests.
 
-## 4. Proposed design
+Use PostgreSQL with pgvector for both document data and embeddings, the numeric representations used for search. One store gives upload and deletion atomic behavior. It also couples search capacity to the database, which is acceptable for this local version.
 
-### How it works
+Extract text and divide it into approximately 500-token chunks with 50-token overlap. Fixed chunks are easy to test; they can split ideas across boundaries. Generate embeddings before committing the document and every chunk in one transaction. Synchronous ingestion avoids a queue but makes upload latency grow with document size.
 
-For upload, the API checks the file and extracts its text. It splits the text into overlapping chunks and asks OpenAI to turn them into search vectors, called embeddings. It writes the document and all chunks in one database transaction. It returns document details only after that transaction succeeds.
+Use one configured embedding model for both uploads and questions. Changing that model requires re-embedding existing documents. Give documents opaque UUIDs; filenames are display data. Each chunk stores its document ID, zero-based position, text, and embedding. Deletion cascades to chunks.
 
-For chat, the API turns the question into a vector and compares it with each text chunk. It calculates similarity as `1 - (embedding <=> query_embedding)` in pgvector. A chunk qualifies when its score is at least `RAG_RELEVANCE_THRESHOLD`. This value defaults to `0.75` and must be between `0` and `1`, including both limits.
+For chat, calculate pgvector cosine similarity as `1 - (embedding <=> query_embedding)`. Select at most five chunks scoring at least `RAG_RELEVANCE_THRESHOLD`, default `0.75`. Order equal scores by document ID and chunk position. Send only those chunks to the answer generator and return the same source text. The threshold reduces weak-context answers but needs tuning for different content.
 
-The API retrieves at most five matching chunks. If none match, it returns the fixed no-information response. Otherwise it sends only those chunks to OpenAI. It returns the answer and sources in score order. Equal scores are ordered by document ID and then chunk index.
+### Interfaces and failures
 
-Deleting a document removes its chunks through a database cascade. Later retrieval therefore cannot return deleted content.
+| Request | Successful response |
+|---|---|
+| `GET /health` | `{status: "ok"}` |
+| `POST /api/v1/documents`, multipart `file` | `{id, filename, uploaded_at, chunk_count}` |
+| `GET /api/v1/documents` | Array of document objects |
+| `DELETE /api/v1/documents/{id}` | `{deleted: true}` |
+| `POST /api/v1/chat`, `{message}` | `{answer, sources: [{document_id, filename, chunk_index, content}]}` |
 
-### Components and responsibilities
+Errors use `{error: {code, message}}`: invalid or textless PDFs and empty questions return `400/bad_request`; oversized PDFs `413/payload_too_large`; missing deletion `404/not_found`; OpenAI failures `502/upstream_error`; database operations `500/internal_error`. Health returns `503/service_unavailable` when PostgreSQL is unavailable and does not call OpenAI. No qualifying chunks is a successful chat response, not a provider error.
 
-| Component | Owns | Depends on | Does not own |
-| --- | --- | --- | --- |
-| FastAPI routes | HTTP validation and response shapes | Application services | Persistence or provider-specific calls |
-| Ingestion and chat services | Use-case ordering and failure mapping | Repository and OpenAI adapter | HTTP details |
-| PostgreSQL repository | Documents, chunks, embeddings, and vector queries | PostgreSQL with pgvector | Answer generation |
-| OpenAI adapter | Provider request and response translation | OpenAI API | Retrieval policy or durable state |
+Require `DATABASE_URL` and `OPENAI_API_KEY` before startup. Reject a nonnumeric relevance threshold or a value outside `[0, 1]`. Roll back failed uploads. Docker Compose owns persistent database storage. This service has no authentication and stays local. Document text is sent to OpenAI; disclose that in the README.
 
-### Decisions
+## 4. Acceptance and proof
 
-**Use PostgreSQL with pgvector.** This keeps metadata and vectors in one transactional store. A separate vector database could scale independently, but it would add another service and consistency boundary before V1 needs either.
+Use `pytest` and `httpx` against PostgreSQL with pgvector. Mock OpenAI with deterministic embeddings and answers. Run `uv sync --frozen` and `uv run pytest` in the application built from this design.
 
-**Use fixed-size chunks.** Chunks are about 500 tokens with about 50 tokens of overlap. Semantic chunking may improve retrieval, but fixed chunking is easier to reason about and test for the initial product.
+| ID | Done when | How to check |
+|---|---|---|
+| AC-1 | The application starts locally and health reflects database availability. | Run `docker compose up -d`; check health with PostgreSQL available and unavailable. Test missing required configuration and invalid threshold values. |
+| AC-2 | PDF upload is atomic and returns the documented fields. | Upload a known PDF and two files sharing a name. Reject invalid, textless, and oversized files; force persistence failure and assert no partial rows. |
+| AC-3 | Listing and deletion reflect stored documents. | List, delete by ID, verify chunks are gone, and repeat deletion to check `404`. |
+| AC-4 | Answers use exactly the returned sources, with at most five matches in the defined order. | Use known PDF text and deterministic scores above, below, and equal to the threshold. Check ties and inspect generator input. |
+| AC-5 | Empty questions fail clearly; absent or deleted evidence produces the fixed no-information response. | Exercise empty messages, no matches, and a question after deleting its only supporting document. |
+| AC-6 | Provider and database failures return the documented errors without partial uploads or success-shaped answers. | Inject failures during upload, list, delete, retrieval, and generation. Check response codes and stored rows. |
 
-**Use a relevance threshold before generation.** Returning a fixed no-information response is safer than asking the model to answer from weak context. The threshold is configurable because useful values vary by embedding model and content.
+## 5. Open questions
 
-## 5. Invariants and requirements
-
-### Invariants
-
-- `INV-1`: The answer generator receives no document context except the chunks returned in that response's source list.
-- `INV-2`: A deleted document has no chunks available to retrieval.
-- `INV-3`: A failed upload leaves no document or chunk rows behind.
-- `INV-4`: Provider failures never appear as successful grounded answers.
-
-### Requirements
-
-- Upload a PDF, extract text, chunk it, embed it, and store the document and chunks.
-- List uploaded documents with basic metadata.
-- Delete a document and all related chunks and embeddings.
-- Answer a question with an answer and ordered source references from relevant chunks.
-- Return a fixed no-information response when no relevant chunk exists.
-- Run locally with Docker Compose using FastAPI and PostgreSQL with pgvector.
-- Use `uv` for Python package and environment management.
-- Keep configuration in environment variables and OpenAI calls replaceable in tests.
-- Expose a health endpoint that reports whether the API can reach PostgreSQL.
-
-## 6. Interfaces and data
-
-```text
-GET    /health                -> {status: "ok"}
-POST   /api/v1/documents      <- multipart/form-data with one file field
-                              -> {id, filename, uploaded_at, chunk_count}
-GET    /api/v1/documents      -> [{id, filename, uploaded_at, chunk_count}]
-DELETE /api/v1/documents/{id} -> {deleted: true}
-POST   /api/v1/chat           <- {message}
-                              -> {answer, sources: [{document_id, filename, chunk_index, content}]}
-Errors                        -> {error: {code, message}}
-```
-
-Error codes are `bad_request`, `payload_too_large`, `not_found`, `internal_error`, `service_unavailable`, and `upstream_error`.
-
-Store one row per document and many related chunk rows. Each chunk holds its text, zero-based position, embedding, and document ID. The document foreign key cascades on delete.
-
-`RAG_RELEVANCE_THRESHOLD` configures the minimum inclusive cosine similarity and defaults to `0.75`. Startup accepts both `0` and `1` and fails unless the value is numeric and satisfies `0 <= value <= 1`.
-
-`SERVER_GRACEFUL_SHUTDOWN_SECONDS` configures the shutdown deadline and defaults to `10`. Startup fails unless it is an integer from `1` through `60`.
-
-`DATABASE_URL` and `OPENAI_API_KEY` are required. Startup fails before serving traffic when either setting is missing.
-
-### Naming and identity
-
-The service generates an opaque UUID for each uploaded document. The original filename is display metadata and never forms identity. Chunk identity is the document UUID plus its zero-based position, which remains stable for the lifetime of that document.
-
-## 7. Failure behavior and lifecycle
-
-- Reject a non-PDF or a PDF with no extractable text using `400` and `bad_request`.
-- Reject a PDF over 25 MiB using `413` and `payload_too_large`.
-- Return `404` and `not_found` when deleting a missing document.
-- Return `502` and `upstream_error` when embedding or answer generation fails.
-- Return `503` and `service_unavailable` when `/health` cannot reach PostgreSQL. The health check does not call OpenAI.
-- Return `500` and `internal_error` when a document or chat database operation fails. A failed upload transaction rolls back before this response is returned.
-- Return the fixed no-information response with status `200` when retrieval has no qualifying chunks.
-- Return `400` and `bad_request` when the chat message is missing or empty.
-- Fail startup before serving traffic when required database or OpenAI configuration is missing.
-- On shutdown, stop accepting new requests and wait up to `SERVER_GRACEFUL_SHUTDOWN_SECONDS` for in-flight requests. After the deadline, cancel remaining requests and let open database transactions roll back.
-
-## 8. Security, privacy, and operations
-
-V1 is for one trusted local user. It has no authentication, authorization, or tenant isolation and must not be exposed as a shared public service. Document text is sent to OpenAI for embeddings and relevant chunks are sent again for answer generation.
-
-Uploads are limited to 25 MiB and rejected before extraction when larger. Chat retrieves at most five chunks. Docker Compose owns local service startup and persistent database storage.
-
-## 9. Acceptance criteria
-
-- `AC-1`: `POST /api/v1/documents` accepts a PDF up to 25 MiB and returns its ID, filename, upload time, and chunk count.
-- `AC-2`: `GET /health` returns `200` with `{"status":"ok"}` when the API can reach PostgreSQL and `503` with `service_unavailable` when it cannot.
-- `AC-3`: Uploading a non-PDF, an empty-text PDF, or a file over 25 MiB returns `400` with `bad_request`, `400` with `bad_request`, or `413` with `payload_too_large` respectively and creates no rows.
-- `AC-4`: `GET /api/v1/documents` lists uploaded documents.
-- `AC-5`: `DELETE /api/v1/documents/{id}` removes the document and makes its chunks unavailable to retrieval.
-- `AC-6`: `POST /api/v1/chat` returns a grounded answer and ordered source references for known fixture content.
-- `AC-7`: Chat retrieves at most five qualifying chunks, and the mocked answer generator receives exactly the same ordered chunk content returned in `sources`.
-- `AC-8`: A chunk with cosine similarity exactly equal to `RAG_RELEVANCE_THRESHOLD` qualifies; a lower score does not.
-- `AC-9`: Chunks with equal similarity are ordered by document ID and then chunk index.
-- `AC-10`: Threshold configuration accepts `0` and `1` and rejects non-numeric values, values below `0`, and values above `1` before startup.
-- `AC-11`: Chat with no relevant content returns `{"answer":"No relevant information found in uploaded documents.","sources":[]}`.
-- `AC-12`: After a failed upload or document deletion, chat for that document's fixture content returns the fixed no-information response with no sources.
-- `AC-13`: A missing or empty chat message returns `400` with `bad_request`.
-- `AC-14`: Missing deletion returns `404` with the documented error shape.
-- `AC-15`: A forced upload persistence failure returns `500` with `internal_error` and leaves no document or chunk rows.
-- `AC-16`: Database failures while listing or deleting return `500` with `internal_error`.
-- `AC-17`: Startup fails before serving traffic when `DATABASE_URL` or `OPENAI_API_KEY` is missing.
-- `AC-18`: Shutdown stops new requests, gives in-flight requests 10 seconds by default, then cancels remaining work without committing a partial upload.
-- `AC-19`: The full test suite passes against PostgreSQL with pgvector while OpenAI calls are mocked.
-- `AC-20`: `uv sync --frozen` and `uv run pytest` are the supported local dependency and test commands.
-- `AC-21`: An OpenAI embedding failure during upload returns `502` with the documented error shape.
-- `AC-22`: A database failure while retrieving for chat returns `500` with `internal_error`.
-- `AC-23`: Startup fails before serving traffic when `SERVER_GRACEFUL_SHUTDOWN_SECONDS` is outside `1` through `60` or is not an integer.
-- `AC-24`: An OpenAI embedding or answer-generation failure during chat returns `502` with the documented error shape.
-
-## 10. Test approach
-
-- Use `pytest` and `httpx` for endpoint tests.
-- Test persistence and vector behavior against PostgreSQL with pgvector. (`AC-1`, `AC-3`, `AC-4`, `AC-5`, `AC-6`, `AC-7`, `AC-8`, `AC-9`, `AC-11`, `AC-12`, `AC-15`, `AC-19`; `INV-1`, `INV-2`, `INV-3`)
-- Mock OpenAI calls with deterministic embeddings and answers. (`AC-1`, `AC-6`, `AC-7`, `AC-8`, `AC-9`, `AC-11`, `AC-12`, `AC-19`, `AC-21`, `AC-24`; `INV-1`, `INV-4`)
-- Use a small PDF fixture containing the sentence "PostgreSQL with pgvector stores the embeddings." to prove grounded chat and source references. (`AC-6`, `AC-12`)
-- Use deterministic embeddings that produce scores equal to, immediately below, and immediately above `RAG_RELEVANCE_THRESHOLD`. (`AC-8`)
-- Create more than five qualifying chunks, then assert that retrieval, generator context, and returned sources use the same ordered first five chunks. (`AC-7`, `AC-9`; `INV-1`)
-- Cover threshold configuration at `0`, at `1`, below `0`, above `1`, and with a non-numeric value. (`AC-10`)
-- Cover `SERVER_GRACEFUL_SHUTDOWN_SECONDS` at `1`, at `60`, below `1`, above `60`, and with a non-integer value. (`AC-23`)
-- Start a deliberately slow upload, request shutdown, and cover completion before the configured deadline and cancellation with transaction rollback after it. (`AC-18`; `INV-3`)
-- Cover upload, list, delete, relevant chat, no-result chat, transaction rollback, and the `400`, `413`, and upload-persistence `500` paths. (`AC-1`, `AC-3`, `AC-4`, `AC-5`, `AC-6`, `AC-11`, `AC-15`; `INV-2`, `INV-3`)
-- Delete an unknown document ID and assert `404` with `not_found` in the documented error shape. (`AC-14`)
-- Force an upload embedding failure and assert `502` with `upstream_error` in the documented error shape. (`AC-21`; `INV-4`)
-- Force chat embedding and answer-generation failures and assert `502` with `upstream_error` in the documented error shape. (`AC-24`; `INV-4`)
-- Cover health with PostgreSQL available and unavailable and missing or empty chat messages. (`AC-2`, `AC-13`)
-- Force database failures while listing and deleting and assert `500` with `internal_error`. (`AC-16`)
-- Force a database failure while retrieving for chat and assert `500` with `internal_error`. (`AC-22`)
-- Cover startup with each required setting missing. (`AC-17`)
-- Assert through the public API that a deleted document and a failed upload leave no retrievable chunks. (`AC-5`, `AC-12`, `AC-15`; `INV-2`, `INV-3`)
-- Run `uv sync --frozen`, then run the full suite with `uv run pytest`. (`AC-19`, `AC-20`)
-
-## 11. Risks and tradeoffs
-
-- Text extraction quality varies across PDFs. V1 accepts text PDFs only and fails clearly when no text can be extracted.
-- A fixed relevance threshold may miss useful chunks or include weak ones. Make the threshold configurable and cover the boundary with deterministic tests.
-- Synchronous embedding makes upload latency proportional to document size. The 25 MiB limit bounds the initial risk; background ingestion remains outside V1.
-- Sending document text to OpenAI may not suit sensitive documents. The README must disclose that boundary.
-
-## 12. Open questions
-
-None block implementation. Authentication, provider selection, and asynchronous ingestion require new designs if the deployment scope expands beyond one trusted user.
-
-## 13. Out of scope
-
-- Authentication, multiple users, or tenant isolation
-- Conversation history, streaming, or reranking
-- Non-PDF formats or OCR
-- Retrieval tuning beyond the simple V1 defaults
-- Background ingestion
-- Cloud deployment beyond local Docker Compose
+None block this local version. Authentication and asynchronous ingestion need a separate design if the deployment scope grows.

--- a/examples/rag-chatbot/plan.md
+++ b/examples/rag-chatbot/plan.md
@@ -1,181 +1,85 @@
-# Plan: RAG Chatbot API
+# Plan: RAG chatbot API
 
-> Captured chat output from the `/plan` skill. A real run stays in chat or is published as tracker tickets when requested.
+> Example of `/plan` output. Real plans stay in chat or become tracker tickets when requested.
 
-Source design: [RAG chatbot design at the revision used for this example](https://github.com/owainlewis/blueprint/blob/9ec6081beeaff327a96fe60ef555ae52a504aa21/examples/rag-chatbot/design.md)
+Source: [Paired RAG design](design.md). These two examples describe the same scope. When publishing real tickets, link to the reviewed design revision.
 
-## Milestone 1: Run the service locally
+## 1. Upload and manage a local PDF collection
 
-### Task 1: Start the API and check its health
+### What are we building?
 
-#### What are we building?
+Let a person upload, list, and delete PDFs through a locally running API. Accepted documents become searchable text; failed uploads leave no partial records.
 
-Create the smallest version of the API that starts locally, connects to PostgreSQL, and reports whether the database is available.
+### Why?
 
-#### Why?
+Users need a reliable collection before the service can answer questions from it. This task delivers usable document management on its own.
 
-Developers need a repeatable starting point before they can add document upload or question answering.
+### Done when
 
-#### Done when
+- Docker Compose starts the service and database; health reports database availability and startup validates required configuration (`AC-1`).
+- Upload returns the documented metadata, preserves distinct IDs for duplicate filenames, and rejects invalid, textless, and oversized PDFs (`AC-2`).
+- Listing shows stored documents. Deletion removes their chunks and returns the missing-document error when repeated (`AC-3`).
+- Upload, list, and delete follow the shared provider/database failure contract, with no partial upload rows (`AC-6`, document operations).
+- README explains local startup, supported files, API usage, and that document text is sent to OpenAI.
 
-- Docker Compose starts the API and PostgreSQL with pgvector.
-- `GET /health` returns `200` when PostgreSQL is available and `503` when it is not. (`AC-2`)
-- The health check does not call OpenAI. (`AC-2`)
-- The app refuses to start when required settings are missing. (`AC-17`)
-- The README explains local startup and that document text will be sent to OpenAI.
-- The baseline test suite passes. (`AC-20`)
+### How to check
 
-#### How to check
-
-```bash
+```sh
 docker compose up -d
-curl http://localhost:8000/health
 uv sync --frozen
 uv run pytest
 ```
 
-Also make PostgreSQL unavailable and verify the documented `503` response. Make the OpenAI test adapter fail and verify that `/health` still returns `200` while PostgreSQL is available.
+Use a small PDF with known text. Test duplicate filenames, extraction failure, size limits, provider failure, and database rollback. Check stored rows after failures. Make PostgreSQL unavailable and verify health changes without calling OpenAI.
 
-#### Agent notes
+### Agent notes
 
 - Depends on: None.
-- Source: [RAG chatbot design at the revision used for this example](https://github.com/owainlewis/blueprint/blob/9ec6081beeaff327a96fe60ef555ae52a504aa21/examples/rag-chatbot/design.md).
-- Use FastAPI, PostgreSQL with pgvector, Docker Compose, and `uv`.
-- Require `DATABASE_URL` and `OPENAI_API_KEY`.
-- Return errors as `{error: {code, message}}`.
-- Keep the health check limited to PostgreSQL.
+- Source: [Design](design.md), sections 1 through 4.
+- Own the shared FastAPI, PostgreSQL/pgvector, OpenAI adapter, environment configuration, and error-response contracts.
+- Ingest synchronously, using approximately 500-token chunks with 50-token overlap and one configured embedding model. Commit document and chunks together after embedding succeeds.
+- Use document UUIDs, zero-based chunk positions, and cascading deletion. Keep HTTP handling, use-case behavior, persistence, and provider translation separate.
+- Lock dependencies with `uv`; use pytest/httpx with a real PostgreSQL test database and mocked OpenAI. Validate the shared relevance-threshold configuration now; retrieval uses it in task 2.
 
-#### Out of scope
+### Out of scope
 
-- Document upload, search, chat, authentication, and cloud deployment.
+- Question answering, authentication, OCR, background ingestion, and cloud deployment.
 
-## Milestone 2: Store uploaded documents
+## 2. Answer questions with matching source text
 
-### Task 2: Upload PDFs and make them searchable
+### What are we building?
 
-#### What are we building?
+Let a person ask a question about the uploaded collection and receive an answer with its supporting text. Return the fixed no-information response when the collection has no relevant evidence.
 
-Add an endpoint that accepts a PDF, extracts its text, and stores a document record with all extracted searchable sections in PostgreSQL.
+### Why?
 
-#### Why?
+This turns stored documents into a useful question-answering tool and lets users inspect where an answer came from.
 
-The service cannot answer questions until it has safely stored material to search.
+### Done when
 
-#### Done when
+- Chat accepts a nonempty question and returns the documented answer/source shape, using exactly the source chunks given to the generator (`AC-4`).
+- Retrieval applies the inclusive threshold, five-chunk limit, and deterministic ordering from the design (`AC-4`).
+- Empty questions fail clearly; absent or deleted evidence returns the fixed no-information response (`AC-5`).
+- Retrieval and generation failures use the shared error contract and never appear as successful answers (`AC-6`, chat operations).
+- The full collection-to-answer flow works with the known PDF fixture, and README includes question and response examples.
 
-- `POST /api/v1/documents` accepts a PDF up to 25 MiB and returns its ID, filename, upload time, and section count. (`AC-1`)
-- Two files with the same name are stored as separate documents.
-- Invalid, empty, and oversized files return the documented errors and create no records. (`AC-3`; `INV-3`)
-- Each document and all its searchable sections are committed together or not at all. (`AC-15`; `INV-3`)
-- OpenAI and database failures return the documented errors without leaving partial data. (`AC-15`; `AC-21`; `INV-3`; `INV-4`)
-- Graceful shutdown lets short uploads finish, rejects new uploads, and rolls back work that exceeds the deadline. (`AC-18`)
-- Startup accepts shutdown deadlines from `1` through `60` seconds and rejects zero, negative, larger, and non-integer values. (`AC-23`)
+### How to check
 
-#### How to check
-
-```bash
-uv run pytest
-curl -F "file=@tests/fixtures/test.pdf" http://localhost:8000/api/v1/documents
-```
-
-Use focused tests to force extraction, OpenAI, persistence, and shutdown failures. Query PostgreSQL after each failure to prove that no partial document remains.
-
-#### Agent notes
-
-- Depends on: Task 1.
-- Source: [RAG chatbot design at the revision used for this example](https://github.com/owainlewis/blueprint/blob/9ec6081beeaff327a96fe60ef555ae52a504aa21/examples/rag-chatbot/design.md).
-- Accept PDF files only. Reject files over 25 MiB before extraction.
-- Use opaque UUIDs for document identity. The filename is display data only.
-- Divide text into sections of about 500 tokens with about 50 tokens of overlap.
-- Store sections and OpenAI embeddings in PostgreSQL with pgvector.
-- Identify each section by its document UUID and stable zero-based position.
-- Delete sections through a cascading foreign key when their document is deleted. (`INV-2`)
-- Read the shutdown deadline from `SERVER_GRACEFUL_SHUTDOWN_SECONDS`. Default to `10`; accept integers from `1` through `60`.
-- Mock OpenAI in tests.
-
-#### Out of scope
-
-- Listing, deletion, search, chat, and non-PDF formats.
-
-### Task 3: List and delete documents
-
-#### What are we building?
-
-Add endpoints to show stored documents and remove a selected document with all of its searchable text.
-
-#### Why?
-
-Users need to know what the service can search and remove information they no longer want included in answers.
-
-#### Done when
-
-- `GET /api/v1/documents` returns each document's ID, filename, upload time, and section count. (`AC-4`)
-- `DELETE /api/v1/documents/{id}` removes the document and its searchable sections. (`AC-5`; `INV-2`)
-- Deleting an unknown ID returns the documented `404` response. (`AC-14`)
-- Database failures return the documented error and leave existing data unchanged. (`AC-16`)
-- Deleted text can no longer be found by later searches. (`AC-5`; `INV-2`)
-
-#### How to check
-
-```bash
+```sh
 uv run pytest
 ```
 
-Upload the PDF fixture, list documents, delete its returned ID, and verify that the ID and its sections are gone. Force listing and deletion failures and verify their responses and stored data.
+Use deterministic embeddings to test scores below, equal to, and above the threshold, ties, and more than five matches. Inspect the mocked generator input and returned sources. Ask about the fixture before and after deleting its document. Force retrieval and provider failures and assert exact error codes.
 
-#### Agent notes
+### Agent notes
 
-- Depends on: Task 2.
-- Source: [RAG chatbot design at the revision used for this example](https://github.com/owainlewis/blueprint/blob/9ec6081beeaff327a96fe60ef555ae52a504aa21/examples/rag-chatbot/design.md).
-- Use the document UUID in API paths. Never use the filename as identity.
-- Keep HTTP formatting in FastAPI routes and PostgreSQL access in a repository.
-- Rely on the database foreign-key cascade to remove stored sections.
-- Return errors as `{error: {code, message}}`.
+- Depends on: Upload and manage a local PDF collection.
+- Source: [Design](design.md), sections 2 through 4.
+- Reuse task 1's provider adapter, database schema, configuration, and error mapping.
+- Use the same embedding model as ingestion. Search with pgvector cosine similarity; order equal scores by document ID and chunk position.
+- Pass only selected source text to generation. Return the fixed no-information response without generation when no chunks qualify.
+- Keep OpenAI mocked in automated tests; verify retrieval against PostgreSQL with pgvector.
 
-#### Out of scope
+### Out of scope
 
-- Search, chat, permissions, and soft deletion.
-
-## Milestone 3: Answer questions from documents
-
-### Task 4: Answer questions using uploaded PDFs
-
-#### What are we building?
-
-Add an endpoint that finds relevant text in uploaded PDFs and uses that text to answer a question. Return the source text with the answer, or say clearly when the documents do not contain enough information.
-
-#### Why?
-
-This is the useful result of the application: people can ask questions without searching every uploaded PDF by hand.
-
-#### Done when
-
-- `POST /api/v1/chat` accepts `{"message":"..."}` and returns an answer with its sources. Missing and empty questions return the documented validation error. (`AC-6`; `AC-13`)
-- The answer generator receives exactly the source sections returned to the caller, with at most five sections. (`AC-7`; `INV-1`)
-- Equal scores are ordered by document ID and section position. (`AC-9`) A score exactly on the relevance threshold qualifies and a lower score does not. (`AC-8`) Threshold settings accept numeric values from `0` through `1` and reject invalid values before startup. (`AC-10`)
-- When no useful text exists, the endpoint returns the fixed no-information answer with no sources. (`AC-11`) Failed uploads and deleted documents cannot affect later answers. (`AC-12`; `INV-2`; `INV-3`)
-- OpenAI and database failures return the documented errors. (`AC-22`; `AC-24`; `INV-4`)
-- The full test suite passes against PostgreSQL with pgvector while OpenAI calls are mocked. (`AC-19`)
-
-#### How to check
-
-```bash
-uv run pytest
-```
-
-Upload `tests/fixtures/test.pdf`, ask `What database is used for embeddings?`, and verify that the answer mentions PostgreSQL with pgvector and includes a source. Test empty questions, threshold boundaries, stable ordering, deleted documents, and forced OpenAI and database failures.
-
-#### Agent notes
-
-- Depends on: Tasks 2 and 3.
-- Source: [RAG chatbot design at the revision used for this example](https://github.com/owainlewis/blueprint/blob/9ec6081beeaff327a96fe60ef555ae52a504aa21/examples/rag-chatbot/design.md).
-- Search PostgreSQL with pgvector cosine similarity and return at most five sections.
-- Read the inclusive threshold from `RAG_RELEVANCE_THRESHOLD`. Default to `0.75`; accept numeric values from `0` through `1`.
-- Order equal scores by document ID and section position.
-- Send only returned source sections to OpenAI.
-- Return source document ID, filename, section position, and content.
-- Mock OpenAI in tests.
-
-#### Out of scope
-
-- Conversation history, streaming, reranking, and retrieval tuning beyond the V1 defaults.
+- Conversation history, streaming, reranking, model switching, and retrieval tuning beyond the specified defaults.

--- a/examples/regenerate.sh
+++ b/examples/regenerate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Regenerate the golden design and plan examples.
+# Print prompts for creating reviewed design and plan examples.
 # Run from the repo root: ./examples/regenerate.sh
 
 set -e
@@ -21,4 +21,5 @@ echo "  architecture review findings and a verdict in chat"
 echo "  a plan in chat, or tracker tickets when requested"
 echo ""
 echo "Then copy the reviewed design and example plan into examples/$FEATURE/ and review the diff."
+echo "Keep the paired design and plan aligned when changing scope or acceptance criteria."
 echo "Input: $INPUT"


### PR DESCRIPTION
## Plain English summary

The examples still used the old thirteen-section design format after the design skill was simplified. Rewrite the RAG and Dispatch examples around requirements, user experience, technical design and choices, acceptance and proof, and open questions. The paired RAG plan now describes two useful delivery tasks against the current design.

## Details

Remove repeated material and unnecessary legacy detail. Add an examples index explaining how to read and refresh the samples, and clarify that their application commands and checks describe systems to build. Update the prompt-printing helper to keep paired designs and plans aligned.

## Reviewer notes

These are revised teaching proposals. Their scopes and acceptance IDs were intentionally refreshed. The RAG plan links to its paired design, with guidance to pin reviewed revisions when publishing real tickets.

Dispatch records the final successful step and run/task success atomically. Its manual recovery rule and acceptance checks use one threshold: the last heartbeat is at least 15 seconds old. Completed runs reject recovery and late reports.

## Checklist

- **Is this one focused, self-contained change?** Yes. Aligns the examples and their usage guidance with the merged design skill.
- **Did you write or update tests?** Not applicable. These are documentation and prompt-help changes. Checked the five headings, unique acceptance IDs, current plan references, and complete RAG criterion coverage.
- **Did you run the relevant tests and checks?** Yes. `./scripts/check` passed all 27 tests, metadata, Markdown links, shell syntax, and diff checks. Ran `./examples/regenerate.sh`. Rechecked links and whitespace after the final documentation correction. The proposed applications were not implemented or exercised.
- **Did you independently review the final diff and address valid findings?** Yes. Fresh subagent review approved the final changes. The automated review finding was fixed, replied to, and resolved. Greptile reviewed commit `1a9919c` with no outstanding findings.
- **Did you update documentation when behavior changed?** Yes. Rewrote both designs, updated the paired plan, and added examples guidance.
- **Did required CI checks pass?** Yes. Repository and Greptile Review passed on the final commit `1a9919c`.
